### PR TITLE
fix: tests and sqlite migrations

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -6,26 +6,27 @@ on:
 
 jobs:
   test-app:
+    runs-on: ubuntu-latest
 
-    runs-on: ubuntu-18.04
-    
     steps:
-      # Test app
     - uses: actions/checkout@v2
+
     - name: Copy .env
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+
     - name: Install Dependencies
       run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist && npm install
+
     - name: Generate key
       run: php artisan key:generate
+
     - name: Directory Permissions
       run: chmod -R 777 storage bootstrap/cache
+
     - name: Create Database
       run: |
         mkdir -p database
-        touch database/database.sqlite
-    - name: Execute tests (Unit and Feature tests) via PHPUnit
-      env:
-        DB_CONNECTION: sqlite
-        DB_DATABASE: database/database.sqlite
-      run: vendor/bin/phpunit
+        touch database/testing.sqlite
+
+    - name: Execute unit and feature tests via PHPUnit
+      run: ./vendor/bin/phpunit

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -1,4 +1,4 @@
-name: Test App
+name: Run Tests
 
 on:
   pull_request:
@@ -29,4 +29,11 @@ jobs:
         touch database/testing.sqlite
 
     - name: Execute unit and feature tests via PHPUnit
-      run: ./vendor/bin/phpunit
+      run: ./vendor/bin/phpunit --log-junit=report.junit.xml
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v2
+      if: success() || failure()
+      with:
+        name: test-results
+        path: report.junit.xml

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,17 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows:
+      - "Run Tests"
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dorny/test-reporter@v1
+      with:
+        artifact: test-results
+        name: Laravel/PHPUnit Tests
+        path: '*.xml'
+        reporter: jest-junit

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -3,21 +3,55 @@ Contributions are much appreciated to help everyone move this service forward wi
 
 In order to keep a collaborative project in the same style and understandable, it's important to follow some conventions:
 
-##### GitHub Branches
+### GitHub Branches
 We name branches with `topic/name-here` including fixes and features, for instance `topic/new-api` or `topic/mentor-mail-fix`
 
-##### Models/SQL
+### Testing
+
+We strive to create tests for the features we do. This helps reduce the risk of us breaking the feature in the future.
+It also helps us to keep the code cleaner. Imagine how you'd like to use your own feature if it were provided as a library to yourself. From that, try to create some accompanying tests, whether they're unit or feature tests.
+
+#### Getting started
+
+To get you started these instructions overlap a little with typical Laravel project setup.
+For additional details, see Laravel documentation on setting up a new project.
+
+```shell
+# 0. Install the dependencies
+composer install
+
+# 1. Setup a local environment variables file
+cp -n .env.example .env
+
+# 2. Generate and set a Laravel application key in your environment variables
+php artisan key:generate
+
+# 3. Create a local database
+php artisan migrate --database sqlite-testing
+```
+
+You should now be able to run the tests locally. To the next section.
+
+#### Running the tests
+
+Once you've got your setup locally, running the tests is a brief affair.
+
+```shell
+php artisan test
+```
+
+### Models/SQL
 * MySQL tables are named in plural e.g `training_reports`, not `training_report`
 * Models are named in singular e.g. `Training`, not `Trainings`
 * Models names don't have any specific suffix or prefix
 * Models are per Laravel 8 located in root of `App/Models` folder.
 
-##### Controllers
+### Controllers
 * Controllers are suffixed with `Controller`, for instance `TrainingController`
 * Controllers are named in singular e.g. `TrainingController`, not `TrainingsController`
 * The controllers should mainly consist of the methods of "7 restful controller actions" [Check out this video](https://laracasts.com/series/laravel-6-from-scratch/episodes/21?autoplay=true)
 
-##### Other
+### Other
 * We name our views with blade suffix for clarity, like `header.blade.php`
 * For more in-depth conventions which we try to follow, check out [Laravel best practices](https://github.com/alexeymezenin/laravel-best-practices/blob/master/README.md#contents)
 * We tab with 4 spaces for increased readability

--- a/README.md
+++ b/README.md
@@ -50,5 +50,8 @@ There's quite a few automations in Control Center that are running through the c
 - Daily member cleanup, if a member leaves the division, their training will be automatically closed. Same for mentors. Does not apply to visitors.
 - Other misc cleanups
 
-## Contribution, conventions and intro to Laravel
-Read the [CONTRIBUTE.md](CONTRIBUTE.md) for details.
+## Contributing, conventions and intro to Laravel
+
+Do you want to help us with improving Control Center? Curious about whether we use testing? Stylistic choices?
+
+[Read the `CONTRIBUTE.md`](CONTRIBUTE.md) for details.

--- a/config/database.php
+++ b/config/database.php
@@ -43,6 +43,12 @@ return [
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
         ],
 
+        'sqlite-testing' => [
+            'driver' => 'sqlite',
+            'database' => database_path('testing.sqlite'),
+            'foreign_key_constraints' => true,
+        ],
+
         'mysql' => [
             'driver' => 'mysql',
             'url' => env('DATABASE_URL'),

--- a/database/factories/TrainingReportFactory.php
+++ b/database/factories/TrainingReportFactory.php
@@ -26,7 +26,7 @@ class TrainingReportFactory extends Factory
         $date = $this->faker->dateTimeBetween($startDate = '-1 years', $endDate = 'now');
 
         return [
-            'report_date' => $date,
+            'report_date' => $date->format("Y-M-d"),
             'content' => $this->faker->paragraph(),
             'contentimprove' => $this->faker->paragraph(),
             'position' => Position::inRandomOrder()->first()->callsign,

--- a/database/migrations/2021_02_27_154220_delete_old_permission_system.php
+++ b/database/migrations/2021_02_27_154220_delete_old_permission_system.php
@@ -20,7 +20,7 @@ class DeleteOldPermissionSystem extends Migration
                         ? config('database.connections.' . $connection . '.prefix')
                         : '';
 
-			if (env('DB_CONNECTION') != 'sqlite') {
+            if (Schema::getConnection()->getDriverName() != 'sqlite') {
                 $table->dropForeign($prefix . 'users_country_foreign');
             	$table->dropForeign($prefix . 'users_group_foreign');
 			}

--- a/database/migrations/2022_11_19_142147_remove_vatbook_add_booking.php
+++ b/database/migrations/2022_11_19_142147_remove_vatbook_add_booking.php
@@ -15,9 +15,7 @@ return new class extends Migration
     {
         Schema::rename('vatbooks', 'bookings');
         Schema::table('bookings', function (Blueprint $table) {
-            $table->dropColumn('eu_id');
-            $table->dropColumn('local_id');
-            $table->dropColumn('cid');
+            $table->dropColumn(['eu_id', 'local_id', 'cid']);
         });
     }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,8 +20,7 @@
     <server name="MAIL_DRIVER" value="array"/>
     <server name="QUEUE_CONNECTION" value="sync"/>
     <server name="SESSION_DRIVER" value="array"/>
-    <server name="DB_CONNECTION" value="sqlite"/>
-    <server name="DB_DATABASE" value=":memory:"/>
+    <server name="DB_CONNECTION" value="sqlite-testing"/>
     <server name="FILESYSTEM_DISK" value="test"/>
   </php>
 </phpunit>

--- a/tests/Feature/FilesTest.php
+++ b/tests/Feature/FilesTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\File;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\UploadedFile;
@@ -29,7 +30,7 @@ class FilesTest extends TestCase
     /** @test */
     public function mentor_can_upload_a_pdf_file()
     {
-        $user = \App\Models\User::factory()->create(['id' => 10000001]);
+        $user = User::factory()->create(['id' => 10000001]);
         $user->groups()->attach(3, ['area_id' => 1]);
         $file = UploadedFile::fake()->create($this->faker->word . '.pdf', 2048, 'application/pdf');
 
@@ -42,7 +43,7 @@ class FilesTest extends TestCase
     /** @test */
     public function mentor_can_upload_an_image_file()
     {
-        $user = \App\Models\User::factory()->create(['id' => 10000001]);
+        $user = User::factory()->create(['id' => 10000001]);
         $user->groups()->attach(3, ['area_id' => 1]);
         $file = UploadedFile::fake()->image($this->faker->word . '.jpg');
 
@@ -55,7 +56,7 @@ class FilesTest extends TestCase
     /** @test */
     public function user_can_see_a_file_they_uploaded()
     {
-        $user = \App\Models\User::factory()->create(['id' => 10000001]);
+        $user = User::factory()->create(['id' => 10000001]);
         $user->groups()->attach(3, ['area_id' => 1]);
         $file = UploadedFile::fake()->image($this->faker->word . '.jpg');
 
@@ -71,7 +72,7 @@ class FilesTest extends TestCase
     /** @test */
     public function regular_user_cant_upload_a_file()
     {
-        $user = \App\Models\User::factory()->create(['id' => 10000001]);
+        $user = User::factory()->create(['id' => 10000001]);
         $file = UploadedFile::fake()->image($this->faker->word);
 
         $this->actingAs($user)->postJson(route('file.store'), ['file' => $file])
@@ -81,7 +82,7 @@ class FilesTest extends TestCase
     /** @test */
     public function owner_can_delete_their_own_files()
     {
-        $user = \App\Models\User::factory()->create(['id' => 10000001]);
+        $user = User::factory()->create(['id' => 10000001]);
         $user->groups()->attach(3, ['area_id' => 1]);
         $file = UploadedFile::fake()->image($this->faker->word . '.jpg');
         $response = $this->actingAs($user)->postJson(route('file.store'), ['file' => $file]);
@@ -96,14 +97,14 @@ class FilesTest extends TestCase
     /** @test */
     public function moderator_can_delete_another_users_file()
     {
-        $user = \App\Models\User::factory()->create(['id' => 10000001]);
+        $user = User::factory()->create(['id' => 10000001]);
         $user->groups()->attach(3, ['area_id' => 1]);
         $file = UploadedFile::fake()->image($this->faker->word . '.jpg');
         $response = $this->actingAs($user)->postJson(route('file.store'), ['file' => $file]);
         $file_id = $response->json('file_id');
         $response->assertStatus(200)->assertJsonFragment(['message' => 'File successfully uploaded']);
 
-        $moderator = \App\Models\User::factory()->create();
+        $moderator = User::factory()->create();
         $moderator->groups()->attach(2, ['area_id' => 1]);
 
         $this->actingAs($moderator)->delete(route('file.delete', ['file' => $file_id]))->assertRedirect()->assertSessionHas('success', 'File successfully deleted');

--- a/tests/Feature/FrontpageTest.php
+++ b/tests/Feature/FrontpageTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
-use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Facades\Auth;
 use Tests\TestCase;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class FrontpageTest extends TestCase
 {

--- a/tests/Feature/TrainingExaminationsTest.php
+++ b/tests/Feature/TrainingExaminationsTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Feature;
 
+use Carbon\Carbon;
+use Tests\TestCase;
+use App\Models\User;
 use App\Models\Training;
 use App\Models\TrainingExamination;
-use App\Models\User;
-use Carbon\Carbon;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class TrainingExaminationsTest extends TestCase
 {

--- a/tests/Feature/TrainingExaminationsTest.php
+++ b/tests/Feature/TrainingExaminationsTest.php
@@ -29,7 +29,7 @@ class TrainingExaminationsTest extends TestCase
             ]),
         ]);
 
-        $this->examination->examiner->groups()->attach(3, ['area_id' => $this->examination->training->area]);
+        $this->examination->examiner->groups()->attach(3, ['area_id' => $this->examination->training->area->id]);
 
         $this->training = $this->examination->training;
         $this->training->mentors()->attach($this->examination->examiner, ['expire_at' => now()->addMonths(12)]);

--- a/tests/Feature/TrainingObjectAttachmentTest.php
+++ b/tests/Feature/TrainingObjectAttachmentTest.php
@@ -2,16 +2,16 @@
 
 namespace Tests\Feature;
 
+use Tests\TestCase;
 use App\Models\File;
-use App\Models\Training;
-use App\Models\TrainingObjectAttachment;
-use App\Models\TrainingReport;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
+use App\Models\Training;
+use App\Models\TrainingReport;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use Tests\TestCase;
+use App\Models\TrainingObjectAttachment;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class TrainingObjectAttachmentTest extends TestCase
 {

--- a/tests/Feature/TrainingReportsTest.php
+++ b/tests/Feature/TrainingReportsTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Feature;
 
-use App\Models\User;
-use App\Models\TrainingReport;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Facades\Gate;
 use Tests\TestCase;
+use App\Models\User;
+use App\Models\Training;
+use App\Models\TrainingReport;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class TrainingReportsTest extends TestCase
 {
@@ -16,10 +17,10 @@ class TrainingReportsTest extends TestCase
     /** @test */
     public function mentor_can_access_training_reports()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000005])->id,
         ]);
-        $mentor = \App\Models\User::factory()->create(['id' => 10000400]);
+        $mentor = User::factory()->create(['id' => 10000400]);
         $mentor->groups()->attach(3, ['area_id' => $training->area->id]);
         $training->mentors()->attach($mentor, ['expire_at' => now()->addYears(10)]);
 
@@ -29,7 +30,7 @@ class TrainingReportsTest extends TestCase
     /** @test */
     public function trainee_can_access_training_reports()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000005])->id,
         ]);
         $this->actingAs($training->user)->assertTrue(Gate::inspect('viewReports', $training)->allowed());
@@ -38,24 +39,24 @@ class TrainingReportsTest extends TestCase
     /** @test */
     public function a_regular_user_cant_access_training_reports()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000005])->id,
         ]);
-        $otherUser = \App\Models\User::factory()->create(['id' => 10000134]);
+        $otherUser = User::factory()->create(['id' => 10000134]);
         $this->actingAs($otherUser)->assertTrue(Gate::inspect('viewReports', $training)->denied());
     }
 
     /** @test */
     public function trainee_cant_access_draft_training_report()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000067])->id,
         ]);
 
         $mentor = User::factory()->create(['id' => 10000159]);
         $mentor->groups()->attach(3, ['area_id' => $training->area->id]);
 
-        $report = \App\Models\TrainingReport::factory()->create([
+        $report = TrainingReport::factory()->create([
             'training_id' => $training->id,
             'written_by_id' => $mentor->id,
             'report_date' => now()->addYear(),
@@ -70,14 +71,14 @@ class TrainingReportsTest extends TestCase
     /** @test */
     public function mentor_can_access_draft_training_report()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000042])->id,
         ]);
 
         $mentor = User::factory()->create(['id' => 10000080]);
         $mentor->groups()->attach(3, ['area_id' => $training->area->id]);
 
-        $report = \App\Models\TrainingReport::factory()->create([
+        $report = TrainingReport::factory()->create([
             'training_id' => $training->id,
             'written_by_id' => $mentor->id,
             'report_date' => now()->addYear(),
@@ -106,14 +107,14 @@ class TrainingReportsTest extends TestCase
     /** @test */
     public function a_regular_user_cant_create_training_report()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000090])->id,
         ]);
-        $report = \App\Models\TrainingReport::factory()->make([
+        $report = TrainingReport::factory()->make([
             'training_id' => $training->id,
         ]);
 
-        $this->actingAs(\App\Models\User::factory()->create())
+        $this->actingAs(User::factory()->create())
             ->post(route('training.report.store', ['training' => $report->training->id]), $report->getAttributes())
             ->assertStatus(403);
 
@@ -123,10 +124,10 @@ class TrainingReportsTest extends TestCase
     /** @test */
     public function mentor_can_update_a_training_report()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000091])->id,
         ]);
-        $report = \App\Models\TrainingReport::factory()->create([
+        $report = TrainingReport::factory()->create([
             'training_id' => $training->id,
         ]);
         $mentor = User::factory()->create(['id' => 10000015]);
@@ -146,10 +147,10 @@ class TrainingReportsTest extends TestCase
     /** @test */
     public function a_regular_user_cant_update_a_training_report()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000092])->id,
         ]);
-        $report = \App\Models\TrainingReport::factory()->create([
+        $report = TrainingReport::factory()->create([
             'training_id' => $training->id,
             'written_by_id' => null,
             'report_date' => now()->addYear(),
@@ -170,7 +171,7 @@ class TrainingReportsTest extends TestCase
     /** @test */
     public function mentor_can_delete_a_training_report()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000093])->id,
             'id' => 2,
         ]);
@@ -178,7 +179,7 @@ class TrainingReportsTest extends TestCase
         $mentor = User::factory()->create(['id' => 10000500]);
         $mentor->groups()->attach(3, ['area_id' => $training->area->id]);
 
-        $report = \App\Models\TrainingReport::factory()->create([
+        $report = TrainingReport::factory()->create([
             'training_id' => $training->id,
             'written_by_id' => $mentor->id,
             'report_date' => now()->addYear(),
@@ -199,13 +200,13 @@ class TrainingReportsTest extends TestCase
     /** @test */
     public function another_mentor_cant_delete_training_report()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000094])->id,
         ]);
-        $report = \App\Models\TrainingReport::factory()->create([
+        $report = TrainingReport::factory()->create([
             'training_id' => $training->id,
         ]);
-        $otherMentor = \App\Models\User::factory()->create(['id' => 10000100]);
+        $otherMentor = User::factory()->create(['id' => 10000100]);
         $otherMentor->groups()->attach(3, ['area_id' => $training->area->id]);
 
         $this->actingAs($otherMentor)
@@ -218,13 +219,13 @@ class TrainingReportsTest extends TestCase
     /** @test */
     public function regular_user_cant_delete_training_report()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000095])->id,
         ]);
-        $report = \App\Models\TrainingReport::factory()->create([
+        $report = TrainingReport::factory()->create([
             'training_id' => $training->id,
         ]);
-        $regularUser = \App\Models\User::factory()->create(['id' => 1000096]);
+        $regularUser = User::factory()->create(['id' => 1000096]);
 
         $this->actingAs($regularUser)
             ->get(route('training.report.delete', ['report' => $report->id]))
@@ -236,14 +237,14 @@ class TrainingReportsTest extends TestCase
     /** @test */
     public function another_moderator_can_delete_training_report()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000098])->id,
         ]);
 
         $mentor = User::factory()->create(['id' => 10000220]);
         $mentor->groups()->attach(3, ['area_id' => $training->area->id]);
 
-        $report = \App\Models\TrainingReport::factory()->create([
+        $report = TrainingReport::factory()->create([
             'training_id' => $training->id,
             'written_by_id' => $mentor->id,
             'report_date' => now()->addYear(),
@@ -252,7 +253,7 @@ class TrainingReportsTest extends TestCase
             'position' => null,
             'draft' => false,
         ]);
-        $otherModerator = \App\Models\User::factory()->create(['id' => 10000101]);
+        $otherModerator = User::factory()->create(['id' => 10000101]);
         $otherModerator->groups()->attach(1, ['area_id' => $training->area->id]);
 
         $this->actingAs($otherModerator)

--- a/tests/Feature/TrainingReportsTest.php
+++ b/tests/Feature/TrainingReportsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use App\Models\TrainingReport;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Gate;
@@ -20,7 +21,7 @@ class TrainingReportsTest extends TestCase
         ]);
         $mentor = \App\Models\User::factory()->create(['id' => 10000400]);
         $mentor->groups()->attach(3, ['area_id' => $training->area->id]);
-        $training->mentors()->attach($mentor, ['expire_at' => now()->addCentury()]);
+        $training->mentors()->attach($mentor, ['expire_at' => now()->addYears(10)]);
 
         $this->actingAs($mentor)->assertTrue(Gate::inspect('viewReports', $training)->allowed());
     }
@@ -229,7 +230,7 @@ class TrainingReportsTest extends TestCase
             ->get(route('training.report.delete', ['report' => $report->id]))
             ->assertStatus(403);
 
-        $this->assertDatabaseHas('training_reports', $report->getAttributes());
+        $this->assertDatabaseHas(TrainingReport::class, $report->getAttributes());
     }
 
     /** @test */

--- a/tests/Feature/TrainingsTest.php
+++ b/tests/Feature/TrainingsTest.php
@@ -2,10 +2,11 @@
 
 namespace Tests\Feature;
 
-use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
+use App\Models\User;
+use App\Models\Training;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class TrainingsTest extends TestCase
 {
@@ -52,9 +53,9 @@ class TrainingsTest extends TestCase
     public function moderator_can_update_training_request()
     {
 
-        $moderator = \App\Models\User::factory()->create();
+        $moderator = User::factory()->create();
 
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000005])->id,
         ]);
 
@@ -75,7 +76,7 @@ class TrainingsTest extends TestCase
     public function a_regular_user_cant_update_a_training()
     {
 
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000005])->id,
         ]);
         $user = $training->user;
@@ -93,10 +94,10 @@ class TrainingsTest extends TestCase
 //    /** @test */
     public function moderator_can_update_the_trainings_status()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000005])->id,
         ]);
-        $moderator = \App\Models\User::factory()->create();
+        $moderator = User::factory()->create();
         $moderator->groups()->attach(1, ['area_id' => $training->area->id]);
 
         $this->actingAs($moderator)->patch(route('training.update', ['training' => $training->id]), ['status' => 0]);
@@ -179,12 +180,12 @@ class TrainingsTest extends TestCase
     /** @test */
     public function a_mentor_cant_be_added_if_they_are_not_a_mentor_in_the_right_area()
     {
-        $training = \App\Models\Training::factory()->create([
+        $training = Training::factory()->create([
             'user_id' => User::factory()->create(['id' => 10000005])->id,
         ]);
-        $moderator = \App\Models\User::factory()->create();
+        $moderator = User::factory()->create();
         $moderator->groups()->attach(2, ['area_id' => $training->area->id]);
-        $mentor = \App\Models\User::factory()->create();
+        $mentor = User::factory()->create();
 
         // We hardcoded area id to 1 in the factory so anything other than 1 will work - let's pick 2 lol.
         $mentor->groups()->attach(3, ['area_id' => 2]);

--- a/tests/Unit/UserUnitTest.php
+++ b/tests/Unit/UserUnitTest.php
@@ -2,10 +2,13 @@
 
 namespace Tests\Unit;
 
-use App\Exceptions\PolicyMissingException;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
+use App\Models\User;
+use App\Models\Handover;
+use App\Models\Training;
+use App\Exceptions\PolicyMissingException;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class UserUnitTest extends TestCase
 {
@@ -17,8 +20,8 @@ class UserUnitTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = \App\Models\User::factory()->create(['id' => 10000000]);
-        $this->user->handover = \App\Models\Handover::factory()->make(['id' => 10000000]);
+        $this->user = User::factory()->create(['id' => 10000000]);
+        $this->user->handover = Handover::factory()->make(['id' => 10000000]);
     }
 
     /** @test */
@@ -56,7 +59,7 @@ class UserUnitTest extends TestCase
     /** @test */
     public function user_can_have_trainings_they_can_access()
     {
-        $training = \App\Models\Training::factory()->create(['user_id' => $this->user->id]);
+        $training = Training::factory()->create(['user_id' => $this->user->id]);
 
         $this->user->can('view', $training)
             ? $this->assertTrue($this->user->viewableModels('\App\Models\Training')->contains($training))
@@ -67,8 +70,8 @@ class UserUnitTest extends TestCase
     /** @test */
     public function trainings_can_exist_with_out_user_being_able_to_see_them()
     {
-        $otherUser = \App\Models\User::factory()->create(['id' => ($this->user->id + 1)]);
-        $training = \App\Models\Training::factory()->create(['user_id' => $otherUser->id]);
+        $otherUser = User::factory()->create(['id' => ($this->user->id + 1)]);
+        $training = Training::factory()->create(['user_id' => $otherUser->id]);
 
         $this->user->can('view', $training)
             ? $this->assertTrue($this->user->viewableModels('\App\Models\Training')->contains($training))


### PR DESCRIPTION
Primarily fixes the training test with some very minor tweaks.

Secondarily, tests are now possible to run locally again with the database connection setting `sqlite-testing` with:

```sh
php artisan migrate --database sqlite-testing
php artisan test
```

It performs a few changes to pass the tests, while also tweaking some migrations to get around limitations with SQLite in Eloquent.

---

All commits:

- fix(tests): pass training tests
- fix(tests): sqlite migrations and use file sqlite
- style(tests): sort imports and always Use modules
