### PR TITLE
ci: add container building with major and full

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
       - "*/*.md"
 
 env:
-  IMAGE_NAME: vatsim-scandinavia/controlcenter
+  IMAGE_NAME: vatsim-scandinavia/control-center
 
 jobs:
   build-container:
@@ -40,7 +40,7 @@ jobs:
       - name: build & push container image
         uses: docker/build-push-action@v4
         with:
-          context: "{{defaultContext}}:controlcenter"
+          context: "{{defaultContext}}:."
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,50 @@
-name: Run Tests
+---
+name: "[ci] Continuous Integration"
 
 on:
   push:
+    paths-ignore:
+      - "*/*.md"
+
+env:
+  IMAGE_NAME: vatsim-scandinavia/controlcenter
 
 jobs:
+  build-container:
+    name: Build Control Center Container
+    runs-on: ubuntu-latest
+    steps:
+      - name: configure docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: login to github container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: setup container metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr
+            type=sha,event=branch,prefix=
+            type=semver,pattern=v{{version}},enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=semver,pattern=v{{major}},enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+      - name: build & push container image
+        uses: docker/build-push-action@v4
+        with:
+          context: "{{defaultContext}}:controlcenter"
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   test-app:
     name: Control Center Test Suite
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #542.

I'm honestly unsure if it'll work on `main` when we push a release. It's a bit trickier to try in a branch, I suppose.
A tag event should result in a push, resulting in a new container image being built. Hopefully.