### PR TITLE
Fixed getOAuthProperty nulling the number 0

### DIFF
--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -86,7 +86,7 @@ class OAuthController extends GenericProvider
         };
 
         $resolved = $getfunc($data, $property);
-        if (isset($resolved)) {
+        if (isset($resolved) && $resolved != '') {
             return $resolved;
         }
 

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -73,7 +73,7 @@ class OAuthController extends GenericProvider
     {
         $getfunc = function ($obj, $prop) use (&$getfunc) {
             $proplist = explode('-', $prop, 2);
-            if (empty($proplist[0]) || empty($obj->{$proplist[0]})) {
+            if (! isset($proplist[0]) || ! isset($obj->{$proplist[0]})) {
                 return null;
             }
             $obj = $obj->{$proplist[0]};
@@ -86,7 +86,7 @@ class OAuthController extends GenericProvider
         };
 
         $resolved = $getfunc($data, $property);
-        if (! empty($resolved)) {
+        if (isset($resolved)) {
             return $resolved;
         }
 


### PR DESCRIPTION
This caused the nightly member update to fail if a member's rating is set to 0 (SUSPENDED). Prior to this, the function would return null and then you get SQL constraint failing as null is not allowed as rating in user table.