### PR TITLE
removed auth check for styleing of navbar

### DIFF
--- a/resources/views/layouts/topbar.blade.php
+++ b/resources/views/layouts/topbar.blade.php
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand bg-white topbar {{ (\Auth::user()->isModeratorOrAbove()) ? 'justify-content-between' : 'justify-content-end' }} mb-4 ps-4 pe-4 static-top shadow">
+<nav class="navbar navbar-expand bg-white topbar justify-content-between mb-4 ps-4 pe-4 static-top shadow">
 
     <a class="sidebar-brand sidebar-brand-topbar align-items-center" href="{{ route('dashboard') }}">
         <div class="sidebar-brand-icon">


### PR DESCRIPTION
Hi WebDev team.

When using control center on mobile, I noticed the logo is not left-aligned like most websites.
I think this looks out of place and would like to see it looked upon.

When looking at the code, there is an auth check that decides whether or not this is implemented and I have no idea why. 
Maybe enlightening me :)

![image](https://github.com/Vatsim-Scandinavia/controlcenter/assets/32055984/62b12186-29eb-4a50-9df2-bdd03924b4e8)
