### PR TITLE
Include arm64 in docker build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
 
 env:
   IMAGE_NAME: vatsim-scandinavia/control-center
+  TARGET_PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   build-container:
@@ -44,6 +45,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ env.TARGET_PLATFORMS }}
 
   test-app:
     name: Control Center Test Suite


### PR DESCRIPTION
Today it's not possible to run the docker container successfully on Mac (🍎 Silicon ARM) or generally ARM-based systems. You can force x86 but it seems to be quite buggy when attempting to emulate.

After fighting some issues with VAT-CZ we figured out that supplying an ARM image solved most of the issues for them testing this locally on a Mac-computer.