### PR TITLE
fix: support configuring trusted proxies

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -42,6 +42,7 @@ Table with all the variables, default value and explanation. Override the enviro
 | MAIL_ENCRYPTION | null | Mail encryption |
 | MAIL_FROM_NAME | Control Center | Mail from name |
 | MAIL_FROM_ADDRESS | noreply@yourvacc.com | Mail from address |
+| TRUSTED_PROXIES | null | Comma-separated list of trusted proxy addresses or '*' for all |
 
 #### OAuth
 

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,15 @@ class TrustProxies extends Middleware
      *
      * @var array
      */
-    protected $proxies;
+    public function proxies(): null|string|array
+    {
+        $trusted = config('app.proxies.trusted');
+        if ($trusted != null && str_contains($trusted, ',')) {
+            return explode(',', $trusted);
+        }
+
+        return $trusted;
+    }
 
     /**
      * The headers that should be used to detect proxies.

--- a/config/app.php
+++ b/config/app.php
@@ -242,6 +242,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Network & Requests
+    |--------------------------------------------------------------------------
+    | Configure the list of proxies that you trust if you are running Control
+    | Center behind a proxy such as nginx, traefik or similarly.
+    | Separate allowed proxies with a comma (no space!).
+    | If you're running Control Center in a container, you may set it to '*'.
+    */
+    'proxies' => [
+        'trusted' => env('TRUSTED_PROXIES'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Class Aliases
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Fixes #569.

Allows users to configure TRUSTED_PROXIES to get the correct IP
addresses reported based on the proxy forwarding headers.