### PR TITLE
docs: fix contributors and update plugins

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - docs/*
     tags:
       - '**'
 
@@ -78,11 +79,11 @@ jobs:
           [ "$MINOR" != "" ] || { echo "Couldn't parse tag to get major-minor version"; exit 1; }
           echo "minor=$MINOR" >> $GITHUB_OUTPUT
 
-      - name: deploy latest development documentation
+      - name: deploy development documentation
         run: >-
           pdm run mike deploy -b "${{ env.DOCS_BRANCH }}"
           "${{ env.DOCS_DEVELOPMENT_ALIAS }}" --push
-        if: "github.ref == 'refs/heads/main'"
+        if: "!startsWith(github.ref, 'refs/tags/')"
 
       - name: deploy latest documentation for v${{ steps.version.outputs.tag }}
         run: >-

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -158,43 +158,26 @@ markdown_extensions:
       alternate_style: true
 
 plugins:
+  # Generate multiple versions of docs
   - mike:
       alias_type: symlink
       canonical_version: latest
   - search
+  # Exclude files that aren't part of the site
   - exclude:
       glob:
         - _includes/*
         - _theme/*
         - __pycache__/*
+  # Show creation and revision date on each page
   - git-revision-date-localized:
       enabled: !ENV ["CI", false]
       enable_creation_date: true
       exclude:
         - index.md
-  # Show people who've contributed to the documentation page
-  # FIXME: disabled until PR is merged
+  # Show people who've contributed on each page
   - git-committers:
-      enabled: false
-      # enabled: !ENV ["CI", false]
+      enabled: !ENV ["CI", false]
       repository: Vatsim-Scandinavia/controlcenter
-      branch: feat/initial-documentation
+      branch: main
       token: !ENV ["CONTRIBUTORS_TOKEN"]
-#  - mkdocstrings:
-#      handlers:
-#        python:
-#          paths: [.]
-#          options:
-#            members_order: source
-#            separate_signature: true
-#            filters: ["!^_"]
-#            docstring_options:
-#              ignore_init_summary: true
-#            merge_init_into_class: true
-#            extensions:
-#              - docs/plugins/griffe_doclinks.py
-#  - mkdocs-simple-hooks:
-#      hooks:
-#        on_pre_build: 'docs.plugins.main:on_pre_build'
-#        on_files: 'docs.plugins.main:on_files'
-#        on_page_markdown: 'docs.plugins.main:on_page_markdown'

--- a/docs/pdm.lock
+++ b/docs/pdm.lock
@@ -272,7 +272,7 @@ files = [
 
 [[package]]
 name = "mkdocs-git-committers-plugin-2"
-version = "2.2.2"
+version = "2.2.3"
 requires_python = ">=3.8,<4"
 summary = "An MkDocs plugin to create a list of contributors on the page. The git-committers plugin will seed the template context with a list of GitHub or GitLab committers and other useful GIT info such as last modified date"
 groups = ["default"]
@@ -282,8 +282,8 @@ dependencies = [
     "requests",
 ]
 files = [
-    {file = "mkdocs-git-committers-plugin-2-2.2.2.tar.gz", hash = "sha256:87a241624116e1c6245034ca2ee3f247e4500589e75f19f71d352b052a8630d8"},
-    {file = "mkdocs_git_committers_plugin_2-2.2.2-py3-none-any.whl", hash = "sha256:73545bdc813ecad609681f876e4f9305f8878c1aeb01a5e92d0e21d7d02ad87e"},
+    {file = "mkdocs-git-committers-plugin-2-2.2.3.tar.gz", hash = "sha256:e0dddef4e3e321d97bcb83123fd963a839d9f9fa801c3125efeb6544bd8b247c"},
+    {file = "mkdocs_git_committers_plugin_2-2.2.3-py3-none-any.whl", hash = "sha256:0f20d61a9315174f30d5a0266d4a457d3d88909ca5c5bd7d0e0dd2e1841f2af0"},
 ]
 
 [[package]]
@@ -305,7 +305,7 @@ files = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.2"
+version = "9.5.3"
 requires_python = ">=3.8"
 summary = "Documentation that simply works"
 groups = ["default"]
@@ -315,7 +315,7 @@ dependencies = [
     "jinja2~=3.0",
     "markdown~=3.2",
     "mkdocs-material-extensions~=1.3",
-    "mkdocs>=1.5.3,~=1.5",
+    "mkdocs~=1.5.3",
     "paginate~=0.5",
     "pygments~=2.16",
     "pymdown-extensions~=10.2",
@@ -323,8 +323,8 @@ dependencies = [
     "requests~=2.26",
 ]
 files = [
-    {file = "mkdocs_material-9.5.2-py3-none-any.whl", hash = "sha256:6ed0fbf4682491766f0ec1acc955db6901c2fd424c7ab343964ef51b819741f5"},
-    {file = "mkdocs_material-9.5.2.tar.gz", hash = "sha256:ca8b9cd2b3be53e858e5a1a45ac9668bd78d95d77a30288bb5ebc1a31db6184c"},
+    {file = "mkdocs_material-9.5.3-py3-none-any.whl", hash = "sha256:76c93a8525cceb0b395b9cedab3428bf518cf6439adef2b940f1c1574b775d89"},
+    {file = "mkdocs_material-9.5.3.tar.gz", hash = "sha256:5899219f422f0a6de784232d9d40374416302ffae3c160cacc72969fcc1ee372"},
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes the contributors plugin by updating to v2.2.3 after submitting my
own PR to fix a repo path issue. Adjusts the branch to point to main.

Removes the old configuration that we haven't gotten around to yet and
adds a few comments to help explain the plugins.
