### PR TITLE
fix: move activity and notification to area level

### DIFF
--- a/app/Console/Commands/CheckOnlineControllers.php
+++ b/app/Console/Commands/CheckOnlineControllers.php
@@ -76,7 +76,7 @@ class CheckOnlineControllers extends Command
                     $this->info('Checking user ' . $d['cid']);
                     $user = User::find($d['cid']);
                     if (isset($user) && ! $user->isVisiting()) {
-                        if (! $user->active && ! $user->hasActiveTrainings(false) && ! $user->hasRecentlyCompletedTraining()) {
+                        if (! $user->isActiveAtc() && ! $user->hasActiveTrainings(false) && ! $user->hasRecentlyCompletedTraining()) {
                             if (! isset($user->last_inactivity_warning) || (isset($user->last_inactivity_warning) && Carbon::now()->gt(Carbon::parse($user->last_inactivity_warning)->addHours(6)))) {
                                 // Send warning to user
                                 $user->notify(new InactiveOnlineNotification($user));

--- a/app/Console/Commands/UpdateAtcReactivate.php
+++ b/app/Console/Commands/UpdateAtcReactivate.php
@@ -38,10 +38,9 @@ class UpdateAtcReactivate extends Command
         $atcHourRecords = AtcActivity::where('hours', '>=', Setting::get('atcActivityRequirement'))->get();
         $count = 0;
         foreach ($atcHourRecords as $record) {
-            $user = $record->user;
-            if ($user->atc_active == false) {
-                $user->atc_active = true;
-                $user->save();
+            if ($record->atc_active == false) {
+                $record->atc_active = true;
+                $record->save();
                 $count++;
             }
         }

--- a/app/Console/Commands/UserDelete.php
+++ b/app/Console/Commands/UserDelete.php
@@ -91,7 +91,6 @@ class UserDelete extends Command
                     $user->region = 'XXX';
                     $user->division = null;
                     $user->subdivision = null;
-                    $user->atc_active = null;
                     $user->access_token = null;
                     $user->refresh_token = null;
                     $user->token_expires = null;

--- a/app/Http/Controllers/API/RatingController.php
+++ b/app/Http/Controllers/API/RatingController.php
@@ -23,7 +23,7 @@ class RatingController extends Controller
             if ($publishUser) {
                 $data->push([
                     'user_id' => $user->id,
-                    'user_atc_active' => boolval($user->atc_active),
+                    'user_atc_active' => $user->isActiveAtc(),
                     'ratings' => $ratings,
                 ]);
             }

--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -51,7 +51,9 @@ class UserController extends Controller
         if ($paramIncludeAllUsers) {
             $returnUsers = User::where('subdivision', config('app.owner_short'));
             if ($paramOnlyActive) {
-                $returnUsers = $returnUsers->where('atc_active', true);
+                $returnUsers = $returnUsers->whereHas('atcActivity', function ($query) {
+                    $query->where('atc_active', true);
+                });
             }
             $returnUsers = $returnUsers->with($queryInclude)->get();
         }
@@ -61,7 +63,9 @@ class UserController extends Controller
                 $q->where('expired', false)->where('revoked', false);
             })->whereNotIn('id', $returnUsers->pluck('id'));
             if ($paramOnlyActive) {
-                $endorsementUsers = $endorsementUsers->where('atc_active', true);
+                $endorsementUsers = $endorsementUsers->whereHas('atcActivity', function ($query) {
+                    $query->where('atc_active', true);
+                });
             }
             $endorsementUsers = $endorsementUsers->with($queryInclude)->get();
 
@@ -71,7 +75,9 @@ class UserController extends Controller
         if ($paramIncludeRoles) {
             $roleUsers = User::whereHas('groups')->whereNotIn('id', $returnUsers->pluck('id'));
             if ($paramOnlyActive) {
-                $roleUsers = $roleUsers->where('atc_active', true);
+                $roleUsers = $roleUsers->whereHas('atcActivity', function ($query) {
+                    $query->where('atc_active', true);
+                });
             }
             $roleUsers = $roleUsers->with($queryInclude)->get();
 
@@ -83,7 +89,9 @@ class UserController extends Controller
                 $q->where('status', '>=', 0);
             })->whereNotIn('id', $returnUsers->pluck('id'));
             if ($paramOnlyActive) {
-                $trainingUsers = $trainingUsers->where('atc_active', true);
+                $trainingUsers = $trainingUsers->whereHas('atcActivity', function ($query) {
+                    $query->where('atc_active', true);
+                });
             }
             $trainingUsers = $trainingUsers->with($queryInclude)->get();
 
@@ -153,7 +161,7 @@ class UserController extends Controller
             ($includeDivisions) ? $returnData['region'] = $user->region : null;
             ($includeDivisions) ? $returnData['division'] = $user->division : null;
             ($includeDivisions) ? $returnData['subdivision'] = $user->subdivision : null;
-            $returnData['atc_active'] = boolval($user->atc_active);
+            $returnData['atc_active'] = $user->isActiveAtc();
             ($includeEndorsements) ? $returnData['endorsements'] = $user->endorsements : null;
             ($includeRoles) ? $returnData['roles'] = $user->roles : null;
             ($includeTraining) ? $returnData['training'] = $user->training : null;

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -58,7 +58,7 @@ class DashboardController extends Controller
 
         // If the user belongs to our subdivision, doesn't have any training requests, has S2+ rating and is marked as inactive -> show notice
         $allowedSubDivisions = explode(',', Setting::get('trainingSubDivisions'));
-        $atcInactiveMessage = ((in_array($user->subdivision, $allowedSubDivisions) && $allowedSubDivisions != null) && (! $user->hasActiveTrainings(true) && $user->rating > 1 && ! $user->active) && ! $user->hasRecentlyCompletedTraining());
+        $atcInactiveMessage = ((in_array($user->subdivision, $allowedSubDivisions) && $allowedSubDivisions != null) && (! $user->hasActiveTrainings(true) && $user->rating > 1 && ! $user->isActiveAtc()) && ! $user->hasRecentlyCompletedTraining());
         $completedTrainingMessage = $user->hasRecentlyCompletedTraining();
 
         $workmailRenewal = (isset($user->setting_workmail_expire)) ? (Carbon::parse($user->setting_workmail_expire)->diffInDays(Carbon::now(), false) > -7) : false;

--- a/app/Http/Controllers/EndorsementController.php
+++ b/app/Http/Controllers/EndorsementController.php
@@ -311,15 +311,6 @@ class EndorsementController extends Controller
     }
 
     /**
-     * @param User user
-     */
-    public static function disableAtc($user)
-    {
-        $user->atc_active = false;
-        $user->save();
-    }
-
-    /**
      * Shorten the specified resource from storage.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/app/Http/Controllers/FeedbackController.php
+++ b/app/Http/Controllers/FeedbackController.php
@@ -24,7 +24,7 @@ class FeedbackController extends Controller
         }
 
         $positions = Position::all();
-        $controllers = User::where('atc_active', true)->get();
+        $controllers = User::getActiveAtcMembers();
 
         return view('feedback.create', compact('positions', 'controllers'));
     }

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -171,7 +171,7 @@ class TrainingController extends Controller
             // Inject the data into payload
             $payload[$area->id]['name'] = $area->name;
             $payload[$area->id]['data'] = $availableRatings;
-            $payload[$area->id]['atcActive'] = ($user->atcActivity->firstWhere('area_id', $area->id) && $user->atcActivity->firstWhere('area_id', $area->id)->isActive()) ? true : false;
+            $payload[$area->id]['atcActive'] = ($user->atcActivity->firstWhere('area_id', $area->id) && $user->atcActivity->firstWhere('area_id', $area->id)->atc_active) ? true : false;
         }
 
         // Fetch user's ATC hours
@@ -257,7 +257,7 @@ class TrainingController extends Controller
             // Check if user is active in the area if required by setting
             if (Setting::get('atcActivityAllowTotalHours') == false) {
                 $atcActivity = Auth::user()->atcActivity->firstWhere('area_id', $data['training_area']);
-                if (! $atcActivity || ! $atcActivity->isActive()) {
+                if (! $atcActivity || ! $atcActivity->atc_active) {
                     return redirect()->back()->withErrors('You need to be active in the area to apply for training.');
                 }
             }

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -584,11 +584,9 @@ class TrainingController extends Controller
                 if ((int) $training->status == TrainingStatus::COMPLETED->value) {
                     // If training is [Refresh, Transfer or Fast-track] or [Standard and exam is passed]
                     if ($training->type <= 4) {
-                        $training->user->atc_active = true;
-                        $training->user->save();
-
                         try {
                             $activity = AtcActivity::where('user_id', $training->user->id)->where('area_id', $training->area->id)->firstOrFail();
+                            $activity->atc_active = true;
                             $activity->start_of_grace_period = now();
                             $activity->save();
                         } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -41,7 +41,7 @@ class UserController extends Controller
         $apiUsers = [];
         $ccUsers = User::pluck('id');
         $ccUsersHours = AtcActivity::all();
-        $ccUsersActive = User::where('atc_active', true)->pluck('id');
+        $ccUsersActive = User::getActiveAtcMembers()->pluck('id');
 
         // Only include users from the division and index by key
         foreach ($response as $data) {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -130,7 +130,7 @@ class UserController extends Controller
                     $atcActivityHours[$area->id]['graced'] = false;
                 }
 
-                $atcActivityHours[$area->id]['active'] = $activity->isActive();
+                $atcActivityHours[$area->id]['active'] = ($activity->atc_active) ? true : false;
 
             } else {
                 $atcActivityHours[$area->id]['hours'] = 0;

--- a/app/Models/AtcActivity.php
+++ b/app/Models/AtcActivity.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use anlutro\LaravelSettings\Facade as Setting;
 use Illuminate\Database\Eloquent\Model;
 
 class AtcActivity extends Model
@@ -25,5 +24,4 @@ class AtcActivity extends Model
     {
         return $this->belongsTo(Area::class);
     }
-
 }

--- a/app/Models/AtcActivity.php
+++ b/app/Models/AtcActivity.php
@@ -12,6 +12,7 @@ class AtcActivity extends Model
     protected $casts = [
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
+        'atc_active' => 'boolean',
         'start_of_grace_period' => 'datetime',
     ];
 
@@ -25,8 +26,4 @@ class AtcActivity extends Model
         return $this->belongsTo(Area::class);
     }
 
-    public function isActive()
-    {
-        return $this->hours >= Setting::get('atcActivityRequirement') || ($this->start_of_grace_period != null && $this->start_of_grace_period->addMonths(Setting::get('atcActivityGracePeriod'))->isFuture());
-    }
 }

--- a/app/Models/AtcActivity.php
+++ b/app/Models/AtcActivity.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class AtcActivity extends Model
 {
-    protected $fillable = ['user_id', 'area_id', 'hours', 'start_of_grace_period'];
+    protected $fillable = ['user_id', 'area_id', 'hours', 'start_of_grace_period', 'atc_active'];
 
     protected $casts = [
         'created_at' => 'datetime',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -32,7 +32,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'id', 'email', 'first_name', 'last_name', 'rating', 'rating_short', 'rating_long', 'region', 'division', 'subdivision', 'last_login', 'access_token', 'refresh_token', 'token_expires',
+        'id', 'email', 'first_name', 'last_name', 'rating', 'rating_short', 'rating_long', 'region', 'division', 'subdivision', 'atc_active', 'last_login', 'access_token', 'refresh_token', 'token_expires',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -178,7 +178,6 @@ class User extends Authenticatable
         return $this->email;
     }
 
-
     /*
     * Check if the user is active as ATC
     *
@@ -204,8 +203,8 @@ class User extends Authenticatable
                 })->get();
         } else {
             return User::whereHas('atcActivity', function ($query) {
-                    $query->where('atc_active', true);
-                })->get();
+                $query->where('atc_active', true);
+            })->get();
         }
     }
 

--- a/app/Policies/BookingPolicy.php
+++ b/app/Policies/BookingPolicy.php
@@ -32,7 +32,7 @@ class BookingPolicy
     public function create(User $user)
     {
         return
-            $user->active && $user->rating >= VatsimRating::S1->value
+            $user->isActiveAtc() && $user->rating >= VatsimRating::S1->value
             || $user->hasActiveEndorsement('VISITING')
             || $user->getActiveTraining(TrainingStatus::PRE_TRAINING->value) != null
             || $user->isModeratorOrAbove();

--- a/app/Policies/TrainingPolicy.php
+++ b/app/Policies/TrainingPolicy.php
@@ -90,7 +90,7 @@ class TrainingPolicy
         }
 
         // Not active users are forced to ask for a manual creation of refresh
-        if (! $user->hasActiveTrainings(true) && $user->rating > 1 && ! $user->active) {
+        if (! $user->hasActiveTrainings(true) && $user->rating > 1 && ! $user->isActiveAtc()) {
             return Response::deny("Your ATC rating is inactive in {$divisionName}");
         }
 

--- a/app/Policies/VotePolicy.php
+++ b/app/Policies/VotePolicy.php
@@ -60,7 +60,7 @@ class VotePolicy
         }
 
         if ($vote->require_active) {
-            if (! $user->active) {
+            if (! $user->isActiveAtc()) {
                 return Response::deny('Sorry, you do not qualify to participate in this vote. You must hold an active ATC rank to vote.');
             }
         }

--- a/database/migrations/2024_02_13_182836_migrate_atc_active_to_area.php
+++ b/database/migrations/2024_02_13_182836_migrate_atc_active_to_area.php
@@ -1,12 +1,12 @@
 <?php
 
+use anlutro\LaravelSettings\Facade as Setting;
+use App\Models\AtcActivity;
+use App\Models\User;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
-use App\Models\User;
 use Illuminate\Support\Facades\Artisan;
-use App\Models\AtcActivity;
-use anlutro\LaravelSettings\Facade as Setting;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
@@ -19,7 +19,6 @@ return new class extends Migration
             $table->boolean('atc_active')->default(false)->after('start_of_grace_period');
         });
 
-
         // Update atc hours as this will basis for the migration
         //Artisan::call('update:atc:hours'); ENABLE ME BEFORE PUSHING DAMMI FUCK DAMMIT ASS
 
@@ -27,7 +26,7 @@ return new class extends Migration
         $users = User::where('atc_active', true)->get();
         foreach ($users as $user) {
             $activities = $user->atcActivity;
-            if($activities && $activities->count() > 0) {
+            if ($activities && $activities->count() > 0) {
                 foreach ($activities as $activity) {
                     // Let's deem everyone with hours active, this will be most correct as they might get withdrawn active status later on nightly cron job triggering a notification.
                     if ($activity->hours > 0 || $activity->start_of_grace_period != null && $activity->start_of_grace_period->addMonths(Setting::get('atcActivityGracePeriod'))->isFuture()) {
@@ -65,6 +64,6 @@ return new class extends Migration
         Schema::table('atc_activities', function (Blueprint $table) {
             $table->dropColumn('atc_active');
         });
-       
+
     }
 };

--- a/database/migrations/2024_02_13_182836_migrate_atc_active_to_area.php
+++ b/database/migrations/2024_02_13_182836_migrate_atc_active_to_area.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\User;
+use Illuminate\Support\Facades\Artisan;
+use App\Models\AtcActivity;
+use anlutro\LaravelSettings\Facade as Setting;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('atc_activities', function (Blueprint $table) {
+            $table->boolean('atc_active')->default(false)->after('start_of_grace_period');
+        });
+
+
+        // Update atc hours as this will basis for the migration
+        //Artisan::call('update:atc:hours'); ENABLE ME BEFORE PUSHING DAMMI FUCK DAMMIT ASS
+
+        // Get all atc_active `users` and loop through them and their hours and set the `atc_active` column in `atc_activities` to true if they meet the requirements
+        $users = User::where('atc_active', true)->get();
+        foreach ($users as $user) {
+            $activities = $user->atcActivity;
+            if($activities && $activities->count() > 0) {
+                foreach ($activities as $activity) {
+                    // Let's deem everyone with hours active, this will be most correct as they might get withdrawn active status later on nightly cron job triggering a notification.
+                    if ($activity->hours > 0 || $activity->start_of_grace_period != null && $activity->start_of_grace_period->addMonths(Setting::get('atcActivityGracePeriod'))->isFuture()) {
+                        $activity->atc_active = true;
+                        $activity->save();
+                    }
+                }
+            }
+        }
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('atc_active');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->tinyInteger('atc_active')->nullable()->after('subdivision');
+        });
+
+        // Loop through all atc_active `atc_activities` and set the `atc_active` column in `users` to true if they meet the requirements
+        $activities = AtcActivity::where('atc_active', true)->get();
+        foreach ($activities as $activity) {
+            if ($activity->atc_active) {
+                $activity->user->atc_active = true;
+                $activity->user->save();
+            }
+        }
+
+        Schema::table('atc_activities', function (Blueprint $table) {
+            $table->dropColumn('atc_active');
+        });
+       
+    }
+};

--- a/tests/Feature/BookingTest.php
+++ b/tests/Feature/BookingTest.php
@@ -61,14 +61,12 @@ class BookingTest extends TestCase
             'rating' => $rating->value,
         ]);
 
-        $userActivity = new \App\Models\AtcActivity([
+        $controller->atcActivity()->create([
             'user_id' => $controller->id,
             'area_id' => 1,
             'hours' => 100,
             'atc_active' => true,
         ]);
-
-        $userActivity->save();
 
         $setup($controller);
         $this->assertCreateBookingAvailable($controller);

--- a/tests/Feature/BookingTest.php
+++ b/tests/Feature/BookingTest.php
@@ -58,9 +58,18 @@ class BookingTest extends TestCase
     {
         $controller = User::factory()->create([
             'id' => fake()->numberBetween(100),
-            'atc_active' => true,
             'rating' => $rating->value,
         ]);
+
+        $userActivity = new \App\Models\AtcActivity([
+            'user_id' => $controller->id,
+            'area_id' => 1,
+            'hours' => 100,
+            'atc_active' => true,
+        ]);
+
+        $userActivity->save();
+
         $setup($controller);
         $this->assertCreateBookingAvailable($controller);
         $this->createBooking($controller)->assertValid();


### PR DESCRIPTION
A larger change that was not correctly implemented in the major version. This does the finishing touches by moving activity logic down to area level instead of (sub)division and adjusts the notifications to this.

See issue for more details.

Fixes #795 