### PR TITLE
ci: use chore for all deps until further notice

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
     "configMigration": true,
     "extends": [
         "config:recommended",
-        ":pinDevDependencies"
+        ":pinDevDependencies",
+        ":semanticPrefixChore"
     ]
 }


### PR DESCRIPTION
Uses the chore prefix for all deps until we make another rule to
separate out different ones. We generally need to make larger changes
for backwards incompatible changes such as Laravel upgrades anyway, and
so this should not impact that.
