### PR TITLE
misc: improve login page layout

### DIFF
--- a/resources/sass/_global.scss
+++ b/resources/sass/_global.scss
@@ -160,7 +160,7 @@ dl.copyable{
         a {
             margin-top: 1.25rem;
             padding-top: 0.375;
-            width: 72%;
+            width: 100%;
         }
     }
 

--- a/resources/sass/_global.scss
+++ b/resources/sass/_global.scss
@@ -118,7 +118,7 @@ dl.copyable{
     background-position: 50% 50%;
 
     .content {
-        width: 500px;
+        width: fit-content;
         margin: auto;
         text-align: center;
 
@@ -129,16 +129,20 @@ dl.copyable{
         }
 
         &-title {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 1rem;
             font-size: 3rem;
             color: white;
-            line-height: 0;
 
             img {
                 height: 3rem;
-                margin-bottom: 0.625rem;
             }
 
             @include media-breakpoint-down(sm) {
+                flex-direction: column;
+                gap: 0.5rem;
                 font-size: 2rem;
             }
         }
@@ -148,6 +152,7 @@ dl.copyable{
             color: white;
 
             @include media-breakpoint-down(sm) {
+                margin-top: 0.5rem;
                 font-size: 1rem;
             }
         }


### PR DESCRIPTION
Improve login page layout to handle longer content title.

---

Before the improvement, longer app names did not fit into the box, which is visible on our dev environment. @blt950, if you do not agree on this, just reject it. It is not deal-breaking issue.

Change `APP_NAME='Control Center (DEV)'` in .env to see different between this and `main` branch.

Before:

<img width="2056" alt="before_desktop" src="https://github.com/Vatsim-Scandinavia/controlcenter/assets/10213870/ecdf75f6-ce11-450e-b15d-3a78e74ce636">
<img width="506" alt="before_mobile" src="https://github.com/Vatsim-Scandinavia/controlcenter/assets/10213870/4117d19a-fc41-443e-adef-8a846753c813">


After:

<img width="2052" alt="after_desktop" src="https://github.com/Vatsim-Scandinavia/controlcenter/assets/10213870/8647589f-7495-426b-8a07-8bea182271b5">
<img width="506" alt="after_mobile" src="https://github.com/Vatsim-Scandinavia/controlcenter/assets/10213870/d07cf089-29af-4b8b-a29d-5b238a441faa">
