### PR TITLE
fix: In mentor assigned email, change "you training" to "your training"

### DIFF
--- a/app/Notifications/TrainingMentorNotification.php
+++ b/app/Notifications/TrainingMentorNotification.php
@@ -46,7 +46,7 @@ class TrainingMentorNotification extends Notification implements ShouldQueue
     public function toMail($notifiable)
     {
         $textLines = [
-            "It's your turn! You've been assigned a mentor for you training: " . $this->training->getInlineRatings() . ' in ' . Area::find($this->training->area_id)->name . '.',
+            "It's your turn! You've been assigned a mentor for your training: " . $this->training->getInlineRatings() . ' in ' . Area::find($this->training->area_id)->name . '.',
             'Your mentor is: **' . $this->training->getInlineMentors() . '**. You can contact them through the message system at forums or search them up on [Discord](' . Setting::get('linkDiscord') . ').',
             'If you do not contact your mentor within 7 days, your training request will be closed and you lose the place in the queue.',
         ];

--- a/resources/views/admin/notificationtemplates.blade.php
+++ b/resources/views/admin/notificationtemplates.blade.php
@@ -111,7 +111,7 @@
                 </div>        
                 <div class="card-body">
                     <h4>Hello (NAME),</h4>
-                    <p>It's your turn! You've been assigned a mentor for you training: (RATINGS) in (FIR).</p>
+                    <p>It's your turn! You've been assigned a mentor for your training: (RATINGS) in (FIR).</p>
                     <p>Your mentor is: (MENTOR NAME). You can contact them through the message system at forums or search them up on Discord.</p>
                     <p>If you do not contact your mentor within 7 days, your training request will be closed and you lose the place in the queue.</p>
 


### PR DESCRIPTION
This PR changes the text "you training" to "your training" in the email notification for mentor assigned.

The full text should now read:
```
Hello (NAME),
It's your turn! You've been assigned a mentor for your training: [...]
```