### PR TITLE
feat: pre-training completed state

### DIFF
--- a/app/Exceptions/InvalidTrainingActivityType.php
+++ b/app/Exceptions/InvalidTrainingActivityType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use Throwable;
+
+class InvalidTrainingActivityType extends Exception
+{
+    /**
+     * Missing InvalidTrainingActivityType constructor.
+     *
+     * @param  string  $user
+     * @param  string  $message
+     * @param  int  $code
+     */
+    public function __construct($message = '', $code = 500, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/Http/Controllers/TrainingActivityController.php
+++ b/app/Http/Controllers/TrainingActivityController.php
@@ -4,10 +4,17 @@ namespace App\Http\Controllers;
 
 use App\Models\Training;
 use App\Models\TrainingActivity;
+use Exception;
 use Illuminate\Http\Request;
 
 class TrainingActivityController extends Controller
 {
+
+    /* 
+    * A table over allowed activity types
+    */
+    public static $activityTypes = ['STATUS' => true, 'TYPE' => true, 'MENTOR' => true, 'PAUSE' => true, 'ENDORSEMENT' => true, 'COMMENT' => true, 'PRETRAINING' => true];
+
     /**
      * Store a newly created resource in storage.
      *
@@ -18,6 +25,14 @@ class TrainingActivityController extends Controller
      */
     public static function create(int $trainingId, string $type, ?int $new_data = null, ?int $old_data = null, ?int $userId = null, ?string $comment = null)
     {
+
+        // Check is this type is accepted
+        try{
+            TrainingActivityController::$activityTypes[$type];
+        } catch (\Exception $e) {
+            throw new \App\Exceptions\InvalidTrainingActivityType('The type ' . $type . ' is not supported.');
+        }
+
         $activity = new TrainingActivity();
         $activity->training_id = $trainingId;
         $activity->type = $type;

--- a/app/Http/Controllers/TrainingActivityController.php
+++ b/app/Http/Controllers/TrainingActivityController.php
@@ -4,13 +4,11 @@ namespace App\Http\Controllers;
 
 use App\Models\Training;
 use App\Models\TrainingActivity;
-use Exception;
 use Illuminate\Http\Request;
 
 class TrainingActivityController extends Controller
 {
-
-    /* 
+    /*
     * A table over allowed activity types
     */
     public static $activityTypes = ['STATUS' => true, 'TYPE' => true, 'MENTOR' => true, 'PAUSE' => true, 'ENDORSEMENT' => true, 'COMMENT' => true, 'PRETRAINING' => true];
@@ -27,7 +25,7 @@ class TrainingActivityController extends Controller
     {
 
         // Check is this type is accepted
-        try{
+        try {
             TrainingActivityController::$activityTypes[$type];
         } catch (\Exception $e) {
             throw new \App\Exceptions\InvalidTrainingActivityType('The type ' . $type . ' is not supported.');

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -685,21 +685,22 @@ class TrainingController extends Controller
         return redirect($training->path())->withSuccess('Training successfully closed.');
     }
 
-    /** 
+    /**
      * Mark specific resource as pre-training is completed in storage
-     * 
+     *
      * @param Training
      * @return \Illuminate\Http\RedirectResponse
-     * 
+     *
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function togglePreTrainingCompleted(Training $training){
+    public function togglePreTrainingCompleted(Training $training)
+    {
         $this->authorize('togglePreTrainingCompleted', $training);
 
         // Fetch the user, states and update them
         $user = Auth::user();
         $state = $training->pre_training_completed;
-        $newState = !$state;
+        $newState = ! $state;
         $newStateText = (($newState) ? 'completed' : 'not completed');
 
         // Update the state in database
@@ -710,7 +711,7 @@ class TrainingController extends Controller
         ActivityLogController::warning('TRAINING', 'Student marked pre-training as completed ' . $training->id);
         TrainingActivityController::create($training->id, 'PRETRAINING', $newState, $state, $user->id);
 
-        return redirect($training->path())->withSuccess('Pre-training marked as ' . $newStateText); 
+        return redirect($training->path())->withSuccess('Pre-training marked as ' . $newStateText);
     }
 
     /**

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -685,6 +685,34 @@ class TrainingController extends Controller
         return redirect($training->path())->withSuccess('Training successfully closed.');
     }
 
+    /** 
+     * Mark specific resource as pre-training is completed in storage
+     * 
+     * @param Training
+     * @return \Illuminate\Http\RedirectResponse
+     * 
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function togglePreTrainingCompleted(Training $training){
+        $this->authorize('togglePreTrainingCompleted', $training);
+
+        // Fetch the user, states and update them
+        $user = Auth::user();
+        $state = $training->pre_training_completed;
+        $newState = !$state;
+        $newStateText = (($newState) ? 'completed' : 'not completed');
+
+        // Update the state in database
+        $training->pre_training_completed = $newState;
+        $training->save();
+
+        // Logging
+        ActivityLogController::warning('TRAINING', 'Student marked pre-training as completed ' . $training->id);
+        TrainingActivityController::create($training->id, 'PRETRAINING', $newState, $state, $user->id);
+
+        return redirect($training->path())->withSuccess('Pre-training marked as ' . $newStateText); 
+    }
+
     /**
      * Confirm the continued interest in the training
      *

--- a/app/Policies/TrainingPolicy.php
+++ b/app/Policies/TrainingPolicy.php
@@ -58,13 +58,14 @@ class TrainingPolicy
         return $user->is($training->user) && $training->status == TrainingStatus::IN_QUEUE->value;
     }
 
-    /** 
+    /**
      * Determine whether the user can mark their pre-training as completed.
-     * 
+     *
      * @return bool
      */
-    public function togglePreTrainingCompleted(User $user, Training $training){
-        return $training->status == TrainingStatus::PRE_TRAINING->value && 
+    public function togglePreTrainingCompleted(User $user, Training $training)
+    {
+        return $training->status == TrainingStatus::PRE_TRAINING->value &&
                 ($training->pre_training_completed == false || $user->isModeratorOrAbove($training->area));
     }
 

--- a/app/Policies/TrainingPolicy.php
+++ b/app/Policies/TrainingPolicy.php
@@ -58,6 +58,16 @@ class TrainingPolicy
         return $user->is($training->user) && $training->status == TrainingStatus::IN_QUEUE->value;
     }
 
+    /** 
+     * Determine whether the user can mark their pre-training as completed.
+     * 
+     * @return bool
+     */
+    public function togglePreTrainingCompleted(User $user, Training $training){
+        return $training->status == TrainingStatus::PRE_TRAINING->value && 
+                ($training->pre_training_completed == false || $user->isModeratorOrAbove($training->area));
+    }
+
     /**
      * Check whether the given user is allowed to apply for training
      *

--- a/database/migrations/2024_07_04_124209_add_pretraining_completed_check.php
+++ b/database/migrations/2024_07_04_124209_add_pretraining_completed_check.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('trainings', function (Blueprint $table) {
+            $table->boolean('pre_training_completed')->default(false)->after('experience');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('trainings', function (Blueprint $table) {
+            $table->dropColumn('pre_training_completed');
+        });
+    }
+};

--- a/database/migrations/2024_07_08_194628_add_trainingactivity_pretraining_type.php
+++ b/database/migrations/2024_07_08_194628_add_trainingactivity_pretraining_type.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+
+        // Since we're going away from enums, we need to create the new column, transfer the data and then delete the enum and finish with a rename.
+        Schema::table('training_activity', function (Blueprint $table) {
+            $table->string('type_new')->after('triggered_by_id');
+        });
+
+        DB::statement('UPDATE training_activity SET type_new = type');
+
+        Schema::table('training_activity', function (Blueprint $table) {
+            $table->dropColumn('type');
+            $table->renameColumn('type_new', 'type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Breaking but harmless change
+    }
+};

--- a/database/migrations/2024_07_08_194628_add_trainingactivity_pretraining_type.php
+++ b/database/migrations/2024_07_08_194628_add_trainingactivity_pretraining_type.php
@@ -21,6 +21,9 @@ return new class extends Migration
 
         Schema::table('training_activity', function (Blueprint $table) {
             $table->dropColumn('type');
+        });
+
+        Schema::table('training_activity', function (Blueprint $table) {
             $table->renameColumn('type_new', 'type');
         });
     }

--- a/resources/views/reports/activities.blade.php
+++ b/resources/views/reports/activities.blade.php
@@ -79,6 +79,8 @@
                                             <i class="fas fa-check-square"></i>
                                         @elseif($activity->type == "COMMENT")
                                             <i class="fas fa-comment"></i>
+                                        @elseif($activity->type == 'PRETRAINING')
+                                            <i class="fas fa-graduation-cap"></i>
                                         @endif
 
                                         @if($activity->type == "STATUS")
@@ -141,6 +143,17 @@
                                             @if($activity->created_at != $activity->updated_at)
                                                 <span class="text-muted">(edited)</span>
                                             @endif
+                                        @elseif($activity->type == "PRETRAINING")
+                                            Pre-training marked as
+                                            <span class="badge text-bg-light">
+                                                @if($activity->new_data)
+                                                    <i class="fas fa-check"></i>
+                                                    Completed
+                                                @else
+                                                    <i class="fas fa-xmark"></i>
+                                                    Not completed
+                                                @endif
+                                            </span>
                                         @endif
 
                                     </td>

--- a/resources/views/training/index.blade.php
+++ b/resources/views/training/index.blade.php
@@ -51,7 +51,10 @@
                             @foreach($openTrainings as $training)
                             <tr>
                                 <td>
-                                    <i class="{{ $statuses[$training->status]["icon"] }} text-{{ $statuses[$training->status]["color"] }}"></i>&ensp;
+                                    <i class="{{ $statuses[$training->status]["icon"] }} text-{{ $statuses[$training->status]["color"] }}"></i>
+                                    @if($training->status == \App\Helpers\TrainingStatus::PRE_TRAINING->value && $training->pre_training_completed )
+                                        <i class="fas fa-check text-success"></i>
+                                    @endif
 
                                     @if($training->activities->where('type', 'COMMENT')->count())
 

--- a/resources/views/training/show.blade.php
+++ b/resources/views/training/show.blade.php
@@ -4,7 +4,14 @@
 @section('title-flex')
     <div>
         @can('close', $training)
-            <a href="{{ route('training.close', $training->id) }}" onclick="return confirm('Are you sure you want to close your training?')" class="btn btn-danger"><i class="fas fa-xmark"></i> Close my training</a>
+            <a href="{{ route('training.action.close', $training->id) }}" onclick="return confirm('Are you sure you want to close your training?')" class="btn btn-danger"><i class="fas fa-xmark"></i> Close my training</a>
+        @endcan
+        @can('togglePreTrainingCompleted', $training)
+            @if($training->pre_training_completed)
+                <a href="{{ route('training.action.pretraining', $training->id) }}" onclick="return confirm('Are you sure you want to mark this pre-training as not completed?')" class="btn btn-primary"><i class="fas fa-xmark"></i> Mark pre-training as not completed</a>
+            @else
+                <a href="{{ route('training.action.pretraining', $training->id) }}" onclick="return confirm('Are you sure you want to mark this pre-training as completed?')" class="btn btn-success"><i class="fas fa-check"></i> Mark pre-training as completed</a>
+            @endif
         @endcan
     </div>
 @endsection
@@ -70,7 +77,14 @@
             <div class="card-body">
                 <dl class="copyable">
                     <dt>State</dt>
-                    <dd><i class="{{ $statuses[$training->status]["icon"] }} text-{{ $statuses[$training->status]["color"] }}"></i>&ensp;{{ $statuses[$training->status]["text"] }}{{ isset($training->paused_at) ? ' (PAUSED)' : '' }}</dd>
+                    <dd>
+                        <i class="{{ $statuses[$training->status]["icon"] }} text-{{ $statuses[$training->status]["color"] }}"></i>
+                        @if($training->status == \App\Helpers\TrainingStatus::PRE_TRAINING->value && $training->pre_training_completed )
+                            <i class="fas fa-check text-success"></i>
+                        @endif
+                        {{ $statuses[$training->status]["text"] }}
+                        {{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
+                    </dd>
 
                     <dt>Type</dt>
                     <dd><i class="{{ $types[$training->type]["icon"] }} text-primary"></i>&ensp;{{ $types[$training->type]["text"] }}</dd>
@@ -249,6 +263,8 @@
                                         <i class="fas fa-check-square"></i>
                                     @elseif($activity->type == "COMMENT")
                                         <i class="fas fa-comment"></i>
+                                    @elseif($activity->type == 'PRETRAINING')
+                                        <i class="fas fa-graduation-cap"></i>
                                     @endif
 
                                     @isset($activity->triggered_by_id)
@@ -324,6 +340,17 @@
                                         @if($activity->created_at != $activity->updated_at)
                                             <span class="text-muted">(edited)</span>
                                         @endif
+                                    @elseif($activity->type == "PRETRAINING")
+                                        Pre-training marked as
+                                        <span class="badge text-bg-light">
+                                            @if($activity->new_data)
+                                                <i class="fas fa-check"></i>
+                                                Completed
+                                            @else
+                                                <i class="fas fa-xmark"></i>
+                                                Not completed
+                                            @endif
+                                        </span>
                                     @endif
 
                                 </p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -116,7 +116,8 @@ Route::middleware(['auth', 'activity', 'suspended'])->group(function () {
         Route::get('/training/edit/{training}', 'edit')->name('training.edit');
         Route::patch('/training/edit/{training}', 'updateRequest')->name('training.update.request');
         Route::post('/training/store', 'store')->name('training.store');
-        Route::get('/training/{training}/close', 'close')->name('training.close');
+        Route::get('/training/{training}/action/close', 'close')->name('training.action.close');
+        Route::get('/training/{training}/action/pretraining', 'togglePreTrainingCompleted')->name('training.action.pretraining');
         Route::patch('/training/{training}', 'updateDetails')->name('training.update.details');
         Route::get('/training/{training}', 'show')->name('training.show');
 


### PR DESCRIPTION
Added a pre-training toggle which students can use at their training view. This can be used to indicate that they've finished the theory training and ready for next step.

- There's now a button for students and staff in training details to mark pre-training as (not) completed.
- The "⌛Pre-training" state changes then to "⌛✅Pre-training" so it's easy to distinguish
- Staff have access to revert this toggle on behalf of student

Fixes #871 