### PR TITLE
Fixes api/users returning null when division mode is on

### DIFF
--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -55,7 +55,7 @@ class UserController extends Controller
                 $subdivisions = array_map('trim', explode(',', Setting::get('trainingSubDivisions')));
                 $returnUsers = User::whereIn('subdivision', $subdivisions);
             } else {
-                $returnUsers = User::where('subdivision', config('app.owner_code'));
+                $returnUsers = User::where('division', config('app.owner_code'));
             }
 
             if ($paramOnlyActive) {


### PR DESCRIPTION
Fixed a type in app/Http/Controllers/API/UserController.php causing api/users to return an empty array when app mode is set to division. Fixes #1221 