### PR TITLE
fix: Avoid exposing php version

### DIFF
--- a/container/configs/php.ini
+++ b/container/configs/php.ini
@@ -376,7 +376,7 @@ zend.exception_ignore_args = On
 ; threat in any way, but it makes it possible to determine whether you use PHP
 ; on your server or not.
 ; http://php.net/expose-php
-expose_php = On
+expose_php = Off
 
 ;;;;;;;;;;;;;;;;;;;
 ; Resource Limits ;


### PR DESCRIPTION
Minor security improvement to avoid broadcasting which exploits are likely to work on the deployment.