### PR TITLE
fix(training): persist one-time links and improve redirection

### DIFF
--- a/app/Http/Controllers/OneTimeLinkController.php
+++ b/app/Http/Controllers/OneTimeLinkController.php
@@ -64,13 +64,8 @@ class OneTimeLinkController extends Controller
         // Authorize that the user can access the link
         $this->authorize('access', [\App\Models\OneTimeLink::class, $link]);
 
-        // Check if the link has expired
-        if ($link->expires_at < now()) {
-            return abort(400, 'The one time link provided has expired');
-        }
-
-        // Do the redirect
-        session()->flash('onetimekey', $key);
+        // Do the redirect once we insert the one-time key into the session
+        $request->session()->put('onetimekey', $key);
 
         return redirect()->to($link->getRelatedLink());
     }

--- a/app/Http/Controllers/TrainingReportController.php
+++ b/app/Http/Controllers/TrainingReportController.php
@@ -49,9 +49,6 @@ class TrainingReportController extends Controller
 
         $positions = Position::all();
 
-        // Keep the onetimekey for another request
-        $request->session()->reflash();
-
         return view('training.report.create', compact('training', 'positions'));
     }
 
@@ -89,9 +86,8 @@ class TrainingReportController extends Controller
             $training->user->notify(new TrainingReportNotification($training, $report));
         }
 
-        if (($key = session()->get('onetimekey')) != null) {
-            // Remove the link
-            OneTimeLink::where('key', $key)->delete();
+        if (($key = OneTimeLink::getFromSession($training)) != null) {
+            $key->delete();
             session()->pull('onetimekey');
 
             return redirect(route('user.reports', Auth::user()))->withSuccess('Report successfully created');

--- a/app/Models/OneTimeLink.php
+++ b/app/Models/OneTimeLink.php
@@ -77,4 +77,25 @@ class OneTimeLink extends Model
                 break;
         }
     }
+
+    /**
+     * Get the one time link from session for a given training
+     */
+    public static function getFromSession(?Training $training = null): ?OneTimeLink
+    {
+        $key = session()->get('onetimekey');
+
+        if ($key === null) {
+            return null;
+        }
+
+        if ($training === null) {
+            return static::where([['key', '=', $key]])->first();
+        }
+
+        return static::where([
+            ['training_id', '=', $training->id],
+            ['key', '=', $key],
+        ])->first();
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -439,16 +439,18 @@ class User extends Authenticatable
      */
     public function isExaminer(?Area $area = null)
     {
-        if ($area == null) {
-            return $this->endorsements->where('type', 'EXAMINER')->where('revoked', false)->where('expired', false)->count();
+        $query = $this->endorsements()
+            ->where('type', 'EXAMINER')
+            ->where('revoked', false)
+            ->where('expired', false);
+
+        if ($area === null) {
+            return $query->exists();
         }
 
-        // Check if the user has an active examiner endorsement for the area
-        if ($this->endorsements->where('type', 'EXAMINER')->where('revoked', false)->where('expired', false)->first()) {
-            return $this->endorsements->where('type', 'EXAMINER')->where('revoked', false)->where('expired', false)->first()->areas()->wherePivot('area_id', $area->id)->count();
-        }
-
-        return false;
+        return $query->whereHas('areas', function ($q) use ($area) {
+            $q->where('areas.id', $area->id);
+        })->exists();
     }
 
     /**

--- a/app/Policies/TrainingExaminationPolicy.php
+++ b/app/Policies/TrainingExaminationPolicy.php
@@ -35,7 +35,7 @@ class TrainingExaminationPolicy
         }
 
         // If one-time link is used
-        if (($link = $this->getOneTimeLink($training)) != null) {
+        if (($link = OneTimeLink::getFromSession($training)) != null) {
             return $user->isExaminer($link->training->area) && $user->isNot($training->user);
         }
 
@@ -66,26 +66,5 @@ class TrainingExaminationPolicy
     public function delete(User $user, TrainingExamination $trainingExamination)
     {
         return $user->isModeratorOrAbove($trainingExamination->training->area) || $user->isAdmin();
-    }
-
-    /**
-     * Get the one time link from a session given a training
-     *
-     * @return null
-     */
-    private function getOneTimeLink($training)
-    {
-        $link = null;
-
-        $key = session()->get('onetimekey');
-
-        if ($key != null) {
-            $link = OneTimeLink::where([
-                ['training_id', '=', $training->id],
-                ['key', '=', $key],
-            ])->get()->first();
-        }
-
-        return $link;
     }
 }

--- a/resources/views/training/report/create.blade.php
+++ b/resources/views/training/report/create.blade.php
@@ -84,7 +84,7 @@
 
                     <hr>
 
-                    @if(session()->get('onetimekey') == null)
+                    @can('create-draft', [\App\Models\TrainingReport::class, $training])
                         <div class="mb-3 form-check">
                             <input type="checkbox" value="1" class="form-check-input @error('draft') is-invalid @enderror" name="draft" id="draftCheck">
                             <label class="form-check-label" name="draft" for="draftCheck">Save as draft</label>
@@ -92,7 +92,11 @@
                                 <span class="text-danger">{{ $errors->first('draft') }}</span>
                             @enderror
                         </div>
-                    @endif
+                    @else
+                        <div class="mb-3">
+                            <span class="text-secondary">You cannot create a draft of this training report.</span>
+                        </div>
+                    @endcan
 
                     <button type="submit" id="training-submit-btn" class="btn btn-success">Save report</button>
                 </form>

--- a/tests/Feature/TrainingExaminationsTest.php
+++ b/tests/Feature/TrainingExaminationsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Area;
 use App\Models\Endorsement;
+use App\Models\OneTimeLink;
 use App\Models\Position;
 use App\Models\Rating;
 use App\Models\Training;
@@ -12,6 +13,7 @@ use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Notification;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -23,40 +25,54 @@ class TrainingExaminationsTest extends TestCase
 
     private TrainingExamination $examination;
 
+    private User $examiner;
+
+    private OneTimeLink $oneTimeLink;
+
     protected function setUp(): void
     {
         parent::setUp();
 
+        Notification::fake();
+
+        // Create area for training
+        $area = Area::factory()->create();
+
+        // Create training with AWAITING_EXAM status for one-time link tests
         $this->training = Training::factory()->create([
-            'user_id' => User::factory()->create([
-                'id' => 10000009,
-            ])->id,
+            'user_id' => User::factory()->create()->id,
+            'area_id' => $area->id,
+            'status' => 3, // AWAITING_EXAM
         ]);
 
-        $examiner = User::factory()->create([
-            'id' => 10000001,
-        ]);
+        // Create examiner with endorsement
+        $this->examiner = User::factory()->create();
 
         $examinerEndorsement = Endorsement::factory()->create([
-            'user_id' => $examiner->id,
+            'user_id' => $this->examiner->id,
             'type' => 'EXAMINER',
             'valid_from' => Carbon::now(),
+            'expired' => false,
+            'revoked' => false,
         ]);
 
         $examinerEndorsement->ratings()->save(Rating::find(5));
-        $examinerEndorsement->areas()->save(Area::find(1));
+        $examinerEndorsement->areas()->save($area);
 
+        // Create examination for testing
         $this->examination = TrainingExamination::factory()->make([
             'training_id' => $this->training->id,
-            'examiner_id' => $examiner->id,
+            'examiner_id' => $this->examiner->id,
             'position_id' => 1,
             'examination_date' => Carbon::now(),
         ]);
 
-        $examinerEndorsement = Endorsement::factory()->create([
-            'user_id' => $this->examination->examiner->id,
-            'type' => 'EXAMINER',
-            'valid_from' => Carbon::now(),
+        // Create one-time link for testing
+        $this->oneTimeLink = OneTimeLink::create([
+            'training_id' => $this->training->id,
+            'training_object_type' => OneTimeLink::TRAINING_EXAMINATION_TYPE,
+            'key' => 'test-onetime-key-123',
+            'expires_at' => now()->addDays(7),
         ]);
     }
 
@@ -66,28 +82,6 @@ class TrainingExaminationsTest extends TestCase
         $this->actingAs($this->training->user)->get(route('training.examination.create', ['training' => $this->training]))
             ->assertStatus(403);
     }
-
-    /** Test is broken due to notifications triggering when you create a new examination. This breaks typically on Github Workflow where notifications are not configured.  */
-    /*
-    #[Test]
-    public function examiner_can_store_examination()
-    {
-        $data = $this->examination->getAttributes();
-
-        // When we push json, the controller requests a bit different data
-        $data['examination_date'] = Carbon::parse($data['examination_date'])->format('d/m/Y');
-        $data['position'] = Position::find($data['position_id'])->callsign;
-
-        $this->actingAs($this->examination->examiner)->followingRedirects()
-            ->postJson(route('training.examination.store', ['training' => $this->training]), $data)
-            ->assertStatus(200);
-
-        $this->assertDatabaseHas('training_examinations', [
-            'training_id' => $data['training_id'],
-            'examiner_id' => $data['examiner_id'],
-        ]);
-
-    }*/
 
     #[Test]
     public function student_cant_store_examination()
@@ -137,7 +131,7 @@ class TrainingExaminationsTest extends TestCase
 
         $examination = TrainingExamination::create($this->examination->getAttributes());
 
-        $moderator = User::factory()->create(['id' => 10000004]);
+        $moderator = User::factory()->create();
         $moderator->groups()->attach(2, ['area_id' => $this->training->area->id]);
 
         $this->actingAs($moderator)->followingRedirects()
@@ -154,7 +148,7 @@ class TrainingExaminationsTest extends TestCase
 
         $examination = TrainingExamination::create($this->examination->getAttributes());
 
-        $mentor = User::factory()->create(['id' => 10000004]);
+        $mentor = User::factory()->create();
         $mentor->groups()->attach(3, ['area_id' => $this->training->area->id]);
 
         $this->actingAs($mentor)->followingRedirects()
@@ -162,5 +156,228 @@ class TrainingExaminationsTest extends TestCase
             ->assertStatus(403);
 
         $this->assertDatabaseHas('training_examinations', ['id' => $examination->id]);
+    }
+
+    #[Test]
+    public function examiner_can_store_examination()
+    {
+        $data = $this->examination->getAttributes();
+
+        // When we push json, the controller requests a bit different data
+        $data['examination_date'] = Carbon::now()->format('d/m/Y');
+        $data['position'] = Position::find($data['position_id'])->callsign;
+
+        $this->actingAs($this->examination->examiner)->followingRedirects()
+            ->postJson(route('training.examination.store', ['training' => $this->training]), $data)
+            ->assertStatus(200);
+
+        $this->assertDatabaseHas('training_examinations', [
+            'training_id' => $data['training_id'],
+            'examiner_id' => $data['examiner_id'],
+        ]);
+    }
+
+    #[Test]
+    public function examiner_without_one_time_link_cannot_view_training_directly()
+    {
+        $response = $this->actingAs($this->examiner)
+            ->get(route('training.show', $this->training->id));
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function examiner_with_one_time_link_can_successfully_create_exam_results()
+    {
+        $this->assertTrue($this->examiner->isExaminer($this->training->area), 'Examiner should have examiner endorsement for the training area');
+        $this->assertTrue($this->examiner->isNot($this->training->user), 'Examiner should not be the training owner');
+
+        $response = $this->actingAs($this->examiner)
+            ->followingRedirects()
+            ->get(route('training.onetimelink.redirect', ['key' => $this->oneTimeLink->key]));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('training.exam.create');
+
+        $this->assertTrue(session()->has('onetimekey'));
+        $this->assertEquals($this->oneTimeLink->key, session()->get('onetimekey'));
+
+        $examData = [
+            'position' => Position::find(1)->callsign,
+            'result' => 'PASSED',
+            'examination_date' => Carbon::now()->format('d/m/Y'),
+        ];
+
+        $response = $this->actingAs($this->examiner)
+            ->post(route('training.examination.store', ['training' => $this->training]), $examData);
+
+        $this->assertDatabaseHas('training_examinations', [
+            'training_id' => $this->training->id,
+            'examiner_id' => $this->examiner->id,
+            'result' => 'PASSED',
+        ]);
+
+        $response->assertRedirect('/dashboard');
+        $response->assertSessionHas('success', 'Examination successfully added');
+
+        $this->assertDatabaseMissing('one_time_links', [
+            'key' => $this->oneTimeLink->key,
+        ]);
+
+        $this->assertFalse(session()->has('onetimekey'));
+    }
+
+    #[Test]
+    public function examiner_with_one_time_link_can_retry_after_invalid_data_submission_without_losing_session()
+    {
+        $response = $this->actingAs($this->examiner)
+            ->get(route('training.onetimelink.redirect', ['key' => $this->oneTimeLink->key]));
+
+        $response->assertRedirect(route('training.examination.create', ['training' => $this->training]));
+        $this->assertEquals($this->oneTimeLink->key, session()->get('onetimekey'));
+
+        $invalidExamData = [
+            'position' => '', // Invalid: empty position
+            'result' => 'INVALID_RESULT', // Invalid: not in allowed values
+            'examination_date' => 'invalid-date', // Invalid: wrong format
+        ];
+
+        $response = $this->actingAs($this->examiner)
+            ->post(route('training.examination.store', ['training' => $this->training]), $invalidExamData);
+
+        $response->assertRedirect();
+        $response->assertSessionHasErrors(['position', 'result', 'examination_date']);
+
+        $this->assertTrue(session()->has('onetimekey'), 'Session variable should persist after validation failure');
+        $this->assertEquals('test-onetime-key-123', session()->get('onetimekey'));
+
+        $response = $this->actingAs($this->examiner)
+            ->get(route('training.examination.create', ['training' => $this->training]));
+        $response->assertStatus(200);
+
+        $validExamData = [
+            'position' => Position::find(1)->callsign,
+            'result' => 'PASSED',
+            'examination_date' => Carbon::now()->format('d/m/Y'),
+        ];
+
+        $response = $this->actingAs($this->examiner)
+            ->post(route('training.examination.store', ['training' => $this->training]), $validExamData);
+
+        $this->assertDatabaseHas('training_examinations', [
+            'training_id' => $this->training->id,
+            'examiner_id' => $this->examiner->id,
+            'result' => 'PASSED',
+        ]);
+
+        $response->assertRedirect(route('dashboard'));
+        $response->assertSessionHas('success', 'Examination successfully added');
+
+        $this->assertDatabaseMissing('one_time_links', [
+            'key' => $this->oneTimeLink->key,
+        ]);
+
+        $this->assertFalse(session()->has('onetimekey'));
+    }
+
+    /**
+     * Tests the bug scenario where session loss causes incorrect redirect behavior.
+     *
+     * This test demonstrates a specific bug where losing the session variable after
+     * accessing the one-time link, before publishing the results, causes examiners to
+     * be redirected to the training view instead of the dashboard.
+     *
+     * The fixed version instead redirects to the dashboard if the user does not
+     * have access to view the training.
+     */
+    #[Test]
+    public function examiner_with_one_time_link_gets_nice_redirect_when_session_variable_is_lost_before_publishing()
+    {
+        $response = $this->actingAs($this->examiner)
+            ->get(route('training.onetimelink.redirect', ['key' => $this->oneTimeLink->key]));
+
+        $response->assertRedirect(route('training.examination.create', ['training' => $this->training]));
+        $this->assertEquals($this->oneTimeLink->key, session()->get('onetimekey'));
+
+        session()->forget('onetimekey');
+
+        $examData = [
+            'position' => Position::find(1)->callsign,
+            'result' => 'PASSED',
+            'examination_date' => Carbon::now()->format('d/m/Y'),
+        ];
+
+        $response = $this->actingAs($this->examiner)
+            ->post(route('training.examination.store', ['training' => $this->training]), $examData);
+
+        $this->assertDatabaseHas('training_examinations', [
+            'training_id' => $this->training->id,
+            'examiner_id' => $this->examiner->id,
+            'result' => 'PASSED',
+        ]);
+
+        $response->assertRedirect(route('dashboard'));
+        $finalResponse = $this->actingAs($this->examiner)
+            ->followingRedirects()
+            ->get(route('training.show', $this->training->id));
+
+        $finalResponse->assertStatus(403);
+    }
+
+    #[Test]
+    public function examiner_with_one_time_link_can_access_exam_creation()
+    {
+        $response = $this->actingAs($this->examiner)
+            ->get(route('training.onetimelink.redirect', ['key' => $this->oneTimeLink->key]));
+
+        $response->assertRedirect(route('training.examination.create', ['training' => $this->training]));
+
+        $response->assertSessionHas('onetimekey', $this->oneTimeLink->key);
+    }
+
+    #[Test]
+    public function examiner_with_expired_one_time_link_is_rejected()
+    {
+        $this->oneTimeLink->update([
+            'expires_at' => now()->subDay(),
+        ]);
+
+        $this->assertTrue($this->oneTimeLink->expires_at < now(), 'One-time link should be expired');
+
+        $response = $this->actingAs($this->examiner)
+            ->get(route('training.onetimelink.redirect', ['key' => $this->oneTimeLink->key]));
+
+        $response->assertStatus(404);
+        $this->assertFalse(session()->has('onetimekey'), 'Session variable should not be set for expired link');
+    }
+
+    #[Test]
+    public function examiner_for_area_without_one_time_link_for_area_can_access_exam_creation()
+    {
+        $response = $this->actingAs($this->examiner)
+            ->get(route('training.examination.create', ['training' => $this->training]));
+
+        $response->assertStatus(200);
+    }
+
+    #[Test]
+    public function examiner_without_one_time_link_from_different_area_cannot_access_exam_creation()
+    {
+        // Create examiner with endorsement for different area
+        $differentArea = Area::factory()->create();
+        $examinerForDifferentArea = User::factory()->create();
+        $endorsement = Endorsement::factory()->create([
+            'user_id' => $examinerForDifferentArea->id,
+            'type' => 'EXAMINER',
+            'valid_from' => Carbon::now(),
+            'expired' => false,
+            'revoked' => false,
+        ]);
+        $endorsement->areas()->save($differentArea);
+
+        $response = $this->actingAs($examinerForDifferentArea)
+            ->get(route('training.examination.create', ['training' => $this->training]));
+
+        $response->assertStatus(403);
     }
 }


### PR DESCRIPTION
Fixes #1287. 

Introduces regression tests as well as the solution to the problem. Note that the specific bug fixed is more limited: if you browse to other pages, the session one-time key will no longer be valid. This means that you can't lookup other sessions, dates, or even open up the dashboard without losing the one-time key which is necessary for the redirect to work.

This fix also limits the ability to *store* such a report in the event the one-time key is invalid, whereas before it would partially work even though it shouldn't have.

tests: adds several one-time link tests
  Adds a relatively comprehensive suite of tests to ensure it works as
  expected.

tests: re-enables the examination store test by faking notifications
  By faking notifications, we can easily re-enable these tests.

refactor: isExaminer()
  Includes a minor refactor of isExaminer() that aims to simplify the
  method.

Release-As: 6.3.5