### PR TITLE
fix: split personal notifications from work notifications

### DIFF
--- a/app/Models/TrainingInterest.php
+++ b/app/Models/TrainingInterest.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class TrainingInterest extends Model
 {
+    use HasFactory;
+
     protected $guarded = [];
 
     protected $casts = [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -167,7 +167,12 @@ class User extends Authenticatable
         return $this->hasMany(Feedback::class, 'reference_user_id');
     }
 
-    public function getNotificationEmailAttribute()
+    public function getPersonalNotificationEmailAttribute()
+    {
+        return $this->email;
+    }
+
+    public function getWorkNotificationEmailAttribute()
     {
         if ($this->setting_workmail_address) {
             return $this->setting_workmail_address;

--- a/app/Notifications/AtcSoonInactiveNotification.php
+++ b/app/Notifications/AtcSoonInactiveNotification.php
@@ -63,7 +63,7 @@ class AtcSoonInactiveNotification extends Notification implements ShouldQueue
         ];
 
         return (new WarningMail('ATC Inactivity Reminder', $this->user, $textLines))
-            ->to($this->user->notificationEmail, $this->user->name);
+            ->to($this->user->personalNotificationEmail, $this->user->name);
     }
 
     /**

--- a/app/Notifications/EndorsementCreatedNotification.php
+++ b/app/Notifications/EndorsementCreatedNotification.php
@@ -49,7 +49,7 @@ class EndorsementCreatedNotification extends Notification implements ShouldQueue
         ];
 
         return (new EndorsementMail('Training Endorsement Issued', $this->endorsement, $textLines))
-            ->to($this->endorsement->user->notificationEmail, $this->endorsement->user->name);
+            ->to($this->endorsement->user->personalNotificationEmail, $this->endorsement->user->name);
     }
 
     /**

--- a/app/Notifications/EndorsementExpiredNotification.php
+++ b/app/Notifications/EndorsementExpiredNotification.php
@@ -48,7 +48,7 @@ class EndorsementExpiredNotification extends Notification implements ShouldQueue
         ];
 
         return (new EndorsementMail('Training Endorsement Expired', $this->endorsement, $textLines))
-            ->to($this->endorsement->user->notificationEmail, $this->endorsement->user->name);
+            ->to($this->endorsement->user->personalNotificationEmail, $this->endorsement->user->name);
     }
 
     /**

--- a/app/Notifications/EndorsementModifiedNotification.php
+++ b/app/Notifications/EndorsementModifiedNotification.php
@@ -49,7 +49,7 @@ class EndorsementModifiedNotification extends Notification implements ShouldQueu
         ];
 
         return (new EndorsementMail('Training Endorsement Modified', $this->endorsement, $textLines))
-            ->to($this->endorsement->user->notificationEmail, $this->endorsement->user->name);
+            ->to($this->endorsement->user->personalNotificationEmail, $this->endorsement->user->name);
     }
 
     /**

--- a/app/Notifications/EndorsementRevokedNotification.php
+++ b/app/Notifications/EndorsementRevokedNotification.php
@@ -46,7 +46,7 @@ class EndorsementRevokedNotification extends Notification implements ShouldQueue
         ];
 
         return (new EndorsementMail('Training Endorsement Revoked', $this->endorsement, $textLines))
-            ->to($this->endorsement->user->notificationEmail, $this->endorsement->user->name);
+            ->to($this->endorsement->user->personalNotificationEmail, $this->endorsement->user->name);
     }
 
     /**

--- a/app/Notifications/FeedbackNotification.php
+++ b/app/Notifications/FeedbackNotification.php
@@ -67,7 +67,7 @@ class FeedbackNotification extends Notification implements ShouldQueue
 
         return (new StaffNoticeMail('Feedback submited', $textLines))
             ->to($feedbackForward)
-            ->replyTo($this->feedback->submitter->notificationEmail, $this->feedback->submitter->name);
+            ->replyTo($this->feedback->submitter->personalNotificationEmail, $this->feedback->submitter->name);
     }
 
     /**

--- a/app/Notifications/InactiveOnlineNotification.php
+++ b/app/Notifications/InactiveOnlineNotification.php
@@ -51,7 +51,7 @@ class InactiveOnlineNotification extends Notification implements ShouldQueue
         ];
 
         return (new WarningMail('Unauthorized network logon', $this->user, $textLines))
-            ->to($this->user->notificationEmail, $this->user->name);
+            ->to($this->user->personalNotificationEmail, $this->user->name);
     }
 
     /**

--- a/app/Notifications/InactiveOnlineStaffNotification.php
+++ b/app/Notifications/InactiveOnlineStaffNotification.php
@@ -61,7 +61,7 @@ class InactiveOnlineStaffNotification extends Notification implements ShouldQueu
         ];
 
         return (new StaffNoticeMail('Unauthorized network logon recorded', $textLines))
-            ->to($this->sendTo->pluck('notificationEmail'));
+            ->to($this->sendTo->pluck('workNotificationEmail'));
     }
 
     /**

--- a/app/Notifications/InactivityNotification.php
+++ b/app/Notifications/InactivityNotification.php
@@ -69,7 +69,7 @@ class InactivityNotification extends Notification implements ShouldQueue
         ];
 
         return (new WarningMail('You are now inactive', $this->user, $textLines))
-            ->to($this->user->notificationEmail, $this->user->name);
+            ->to($this->user->personalNotificationEmail, $this->user->name);
     }
 
     /**

--- a/app/Notifications/MentorExaminationNotification.php
+++ b/app/Notifications/MentorExaminationNotification.php
@@ -63,7 +63,7 @@ class MentorExaminationNotification extends Notification implements ShouldQueue
         ];
 
         return (new MentorNoticeMail('Your student\'s examination report', $textLines, $this->actionUrl, $this->actionText))
-            ->to($this->sendTo->pluck('notificationEmail'));
+            ->to($this->sendTo->pluck('workNotificationEmail'));
     }
 
     /**

--- a/app/Notifications/TaskNotification.php
+++ b/app/Notifications/TaskNotification.php
@@ -75,7 +75,7 @@ class TaskNotification extends Notification
 
         // Return the mail message
         return (new TaskMail('Task Digest', $this->user, $textLines))
-            ->to($this->user->notificationEmail);
+            ->to($this->user->workNotificationEmail);
     }
 
     /**

--- a/app/Notifications/TrainingClosedNotification.php
+++ b/app/Notifications/TrainingClosedNotification.php
@@ -89,8 +89,8 @@ class TrainingClosedNotification extends Notification implements ShouldQueue
         }
 
         return (new TrainingMail('Training Request Closed', $this->training, $textLines, $contactMail))
-            ->to($this->training->user->notificationEmail, $this->training->user->name)
-            ->bcc($bcc->pluck('notificationEmail'));
+            ->to($this->training->user->personalNotificationEmail, $this->training->user->name)
+            ->bcc($bcc->pluck('workNotificationEmail'));
     }
 
     /**

--- a/app/Notifications/TrainingCreatedNotification.php
+++ b/app/Notifications/TrainingCreatedNotification.php
@@ -71,8 +71,8 @@ class TrainingCreatedNotification extends Notification implements ShouldQueue
         $contactMail = $area->contact;
 
         return (new TrainingMail('New Training Request Confirmation', $this->training, $textLines, $contactMail))
-            ->to($this->training->user->notificationEmail, $this->training->user->name)
-            ->bcc($bcc->pluck('notificationEmail'));
+            ->to($this->training->user->personalNotificationEmail, $this->training->user->name)
+            ->bcc($bcc->pluck('workNotificationEmail'));
     }
 
     /**

--- a/app/Notifications/TrainingCustomNotification.php
+++ b/app/Notifications/TrainingCustomNotification.php
@@ -63,10 +63,10 @@ class TrainingCustomNotification extends Notification implements ShouldQueue
         // Only add CTA and Url if they are set
         if ($this->url && $this->cta) {
             return (new TrainingMail($this->title, $this->training, $this->messageLines, $contactMail, $this->url, $this->cta))
-                ->to($this->training->user->notificationEmail, $this->training->user->name);
+                ->to($this->training->user->personalNotificationEmail, $this->training->user->name);
         } else {
             return (new TrainingMail($this->title, $this->training, $this->messageLines, $contactMail))
-                ->to($this->training->user->notificationEmail, $this->training->user->name);
+                ->to($this->training->user->personalNotificationEmail, $this->training->user->name);
         }
     }
 

--- a/app/Notifications/TrainingExamNotification.php
+++ b/app/Notifications/TrainingExamNotification.php
@@ -67,8 +67,8 @@ class TrainingExamNotification extends Notification implements ShouldQueue
         }
 
         return (new TrainingMail('Training Examination Result', $this->training, $textLines, null, route('training.show', $this->training->id), 'Read Report'))
-            ->to($this->training->user->notificationEmail, $this->training->user->name)
-            ->bcc($bcc->pluck('notificationEmail'));
+            ->to($this->training->user->personalNotificationEmail, $this->training->user->name)
+            ->bcc($bcc->pluck('workNotificationEmail'));
     }
 
     /**

--- a/app/Notifications/TrainingInterestNotification.php
+++ b/app/Notifications/TrainingInterestNotification.php
@@ -77,7 +77,7 @@ class TrainingInterestNotification extends Notification implements ShouldQueue
         $actionUrl = route('training.confirm.interest', ['training' => $this->training->id, 'key' => $this->interest->key]);
 
         return (new TrainingMail($this->subjectPrefix . 'Confirm Continued Training Interest', $this->training, $textLines, $contactMail, $actionUrl, 'Confirm Interest', 'success'))
-            ->to($this->training->user->notificationEmail, $this->training->user->name);
+            ->to($this->training->user->personalNotificationEmail, $this->training->user->name);
     }
 
     /**

--- a/app/Notifications/TrainingMentorNotification.php
+++ b/app/Notifications/TrainingMentorNotification.php
@@ -59,7 +59,7 @@ class TrainingMentorNotification extends Notification implements ShouldQueue
         $contactMail = $area->contact;
 
         return (new TrainingMail('Training Mentor Assigned', $this->training, $textLines, $contactMail))
-            ->to($this->training->user->notificationEmail, $this->training->user->name);
+            ->to($this->training->user->personalNotificationEmail, $this->training->user->name);
     }
 
     /**

--- a/app/Notifications/TrainingPreStatusNotification.php
+++ b/app/Notifications/TrainingPreStatusNotification.php
@@ -53,7 +53,7 @@ class TrainingPreStatusNotification extends Notification implements ShouldQueue
         $contactMail = Area::find($this->training->area_id)->contact;
 
         return (new TrainingMail('Training Assigned', $this->training, $textLines, $contactMail))
-            ->to($this->training->user->notificationEmail, $this->training->user->name);
+            ->to($this->training->user->personalNotificationEmail, $this->training->user->name);
     }
 
     /**

--- a/app/Notifications/TrainingReportNotification.php
+++ b/app/Notifications/TrainingReportNotification.php
@@ -53,7 +53,7 @@ class TrainingReportNotification extends Notification implements ShouldQueue
         ];
 
         return (new TrainingMail('Training Report', $this->training, $textLines, null, route('training.show', $this->training->id), 'Read Report'))
-            ->to($this->training->user->notificationEmail, $this->training->user->name);
+            ->to($this->training->user->personalNotificationEmail, $this->training->user->name);
     }
 
     /**

--- a/database/factories/TrainingInterestFactory.php
+++ b/database/factories/TrainingInterestFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Training;
+use App\Models\TrainingInterest;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class TrainingInterestFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = TrainingInterest::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        return [
+            'training_id' => Training::factory(),
+            'key' => Str::random(16),
+            'deadline' => now()->addDays(7),
+        ];
+    }
+}

--- a/database/factories/TrainingReportFactory.php
+++ b/database/factories/TrainingReportFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\Position;
 use App\Models\TrainingReport;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class TrainingReportFactory extends Factory
@@ -25,6 +26,7 @@ class TrainingReportFactory extends Factory
         $date = $this->faker->dateTimeBetween($startDate = '-1 years', $endDate = 'now');
 
         return [
+            'written_by_id' => User::factory(),
             'report_date' => $date->format('Y-M-d'),
             'content' => $this->faker->paragraph(),
             'contentimprove' => $this->faker->paragraph(),

--- a/resources/views/feedback/create.blade.php
+++ b/resources/views/feedback/create.blade.php
@@ -28,7 +28,7 @@
 
                         <div class="col-md-4">
                             <label class="form-label">Your email</label>
-                            <input class="form-control" type="text" value="{{ Auth::user()->notificationEmail }}" disabled>
+                            <input class="form-control" type="text" value="{{ Auth::user()->email }}" disabled>
                         </div>
                     </div>
 

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -33,7 +33,7 @@
                     <dd>{{ $user->first_name.' '.$user->last_name }}<button type="button" onclick="navigator.clipboard.writeText('{{ $user->first_name.' '.$user->last_name }}')"><i class="fas fa-copy"></i></button></dd>
 
                     <dt>Email</dt>
-                    <dd class="separator pb-3">{{ $user->notificationEmail }}<button type="button" onclick="navigator.clipboard.writeText('{{ $user->notificationEmail }}')"><i class="fas fa-copy"></i></button></dd>
+                    <dd class="separator pb-3">{{ $user->email }}<button type="button" onclick="navigator.clipboard.writeText('{{ $user->email }}')"><i class="fas fa-copy"></i></button></dd>
 
                     <dt class="pt-2">ATC Rating</dt>
                     <dd>{{ $user->rating_short }}</dd>

--- a/tests/Feature/NotificationEmailTest.php
+++ b/tests/Feature/NotificationEmailTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Area;
+use App\Models\Group;
+use App\Models\Training;
+use App\Models\TrainingExamination;
+use App\Models\TrainingInterest;
+use App\Models\TrainingReport;
+use App\Models\User;
+use App\Notifications\TrainingCreatedNotification;
+use App\Notifications\TrainingExamNotification;
+use App\Notifications\TrainingInterestNotification;
+use App\Notifications\TrainingReportNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * Slightly ad-hoc feature test specifically for e-mail notifications.
+ */
+class NotificationEmailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected Group $moderatorGroup;
+
+    protected Area $area;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Notification::fake();
+
+        $this->moderatorGroup = Group::firstOrCreate(['id' => 2], ['name' => 'Moderator']);
+        $this->area = Area::factory()->create();
+        $this->user = User::factory()->create([
+            'email' => 'personal@example.com',
+            'setting_workmail_address' => 'work@example.com',
+        ]);
+    }
+
+    /**
+     * Test a few different notifications to ensure they are sent to the personal email.
+     *
+     * Limited to notifications that follow the same pattern of taking a training and a related model.
+     */
+    #[Test]
+    #[DataProvider('personalEmailNotificationProvider')]
+    public function sends_notification_to_personal_email(string $notificationClass, string $relatedModelClass): void
+    {
+        $training = Training::factory()->for($this->user)->for($this->area)->create();
+        $relatedModel = $relatedModelClass::factory()->for($training)->create();
+
+        $this->user->notify(new $notificationClass($training, $relatedModel));
+
+        Notification::assertSentTo(
+            $this->user,
+            $notificationClass,
+            function ($notification, $channels, $notifiable) {
+                $mailData = $notification->toMail($notifiable);
+                $this->assertEquals('personal@example.com', $mailData->to[0]['address']);
+                $this->assertNotEquals('work@example.com', $mailData->to[0]['address']);
+
+                return true;
+            }
+        );
+    }
+
+    public static function personalEmailNotificationProvider(): array
+    {
+        return [
+            'training report' => [TrainingReportNotification::class, TrainingReport::class],
+            'training interest' => [TrainingInterestNotification::class, TrainingInterest::class],
+            'training examination' => [TrainingExamNotification::class, TrainingExamination::class],
+        ];
+    }
+
+    #[Test]
+    public function sends_training_request_to_personal_email_and_bcc_to_work_email(): void
+    {
+        $anotherArea = Area::factory()->create();
+
+        $staffReceivesBcc = User::factory()->create([
+            'email' => 'staff.personal@example.com',
+            'setting_workmail_address' => 'staff.work@example.com',
+            'setting_notify_newreq' => true,
+        ]);
+        $staffReceivesBcc->groups()->attach($this->moderatorGroup, ['area_id' => $this->area->id]);
+
+        // Staff member who should NOT receive BCC (wrong area)
+        $staffWrongArea = User::factory()->create(['setting_notify_newreq' => true]);
+        $staffWrongArea->groups()->attach($this->moderatorGroup, ['area_id' => $anotherArea->id]);
+
+        // Staff member who should NOT receive BCC (notification setting disabled)
+        $staffNoNotify = User::factory()->create(['setting_notify_newreq' => false]);
+        $staffNoNotify->groups()->attach($this->moderatorGroup, ['area_id' => $this->area->id]);
+
+        $training = Training::factory()->for($this->user)->for($this->area)->create();
+
+        $this->user->notify(new TrainingCreatedNotification($training));
+
+        Notification::assertSentTo(
+            $this->user,
+            TrainingCreatedNotification::class,
+            function ($notification, $channels, $notifiable) {
+                $mailData = $notification->toMail($notifiable);
+                $this->assertEquals('personal@example.com', $mailData->to[0]['address']);
+
+                // Assert that the correct staff member is in the BCCs with their work email,
+                // yet is not in the BCCs with their personal email.
+                $this->assertTrue(collect($mailData->bcc)->contains('address', 'staff.work@example.com'));
+                $this->assertTrue(collect($mailData->bcc)->doesntContain('address', 'staff.personal@example.com'));
+
+                return true;
+            }
+        );
+
+        // Assert notification was NOT sent to other staff members
+        Notification::assertNotSentTo($staffWrongArea, TrainingCreatedNotification::class);
+        Notification::assertNotSentTo($staffNoNotify, TrainingCreatedNotification::class);
+    }
+}


### PR DESCRIPTION
Fixes #1179.

It's not the most perfect of solutions, but it adds a few tests and aims to use the work e-mail for all BCCs to staff.