### PR TITLE
fix: Dynamically render training report series

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "bootstrap-table": "1.24.2",
                 "chart.js": "^4.4.0",
                 "chartjs-adapter-moment": "^1.0.1",
+                "chartjs-plugin-autocolors": "^0.3.1",
                 "core-js": "^3.37.1",
                 "easymde": "^2.18.0",
                 "flatpickr": "^4.6.13",
@@ -504,7 +505,8 @@
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
             "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@parcel/watcher": {
             "version": "2.5.1",
@@ -1287,6 +1289,16 @@
             "peerDependencies": {
                 "chart.js": ">=3.0.0",
                 "moment": "^2.10.2"
+            }
+        },
+        "node_modules/chartjs-plugin-autocolors": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/chartjs-plugin-autocolors/-/chartjs-plugin-autocolors-0.3.1.tgz",
+            "integrity": "sha512-8FHemt0Ef5BM7kQimh4eAkCRFPBav4seUFi7nEaShX+DjZMU9V4LqEDgXNglKbnYTTn3QmoG4v9gyiQDUAk9WQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@kurkle/color": "^0.3.1",
+                "chart.js": ">=2"
             }
         },
         "node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "bootstrap-table": "1.24.2",
         "chart.js": "^4.4.0",
         "chartjs-adapter-moment": "^1.0.1",
+        "chartjs-plugin-autocolors": "^0.3.1",
         "core-js": "^3.37.1",
         "easymde": "^2.18.0",
         "flatpickr": "^4.6.13",

--- a/resources/js/chart.js
+++ b/resources/js/chart.js
@@ -5,6 +5,7 @@
 import Chart from 'chart.js/auto';
 import * as helpers from 'chart.js/helpers';
 import 'chartjs-adapter-moment';
+import autocolors from 'chartjs-plugin-autocolors';
 
 
 /**
@@ -12,4 +13,5 @@ import 'chartjs-adapter-moment';
 */
 
 Chart.helpers = helpers;
+Chart.register(autocolors);
 window.Chart = Chart;

--- a/resources/views/reports/trainings.blade.php
+++ b/resources/views/reports/trainings.blade.php
@@ -11,7 +11,7 @@
             @if(\Auth::user()->isModeratorOrAbove($area))
                 <a class="btn btn-sm {{ $filterName == $area->name ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('reports.training.area', $area->id) }}">{{ $area->name }}</a>
             @endif
-        @endforeach 
+        @endforeach
     </div>
 @endsection
 @section('content')
@@ -114,7 +114,7 @@
             <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
                 <h6 class="m-0 fw-bold text-white">
                     Training requests last 12 months
-                </h6> 
+                </h6>
             </div>
             <div class="card-body">
                 <canvas id="trainingChart"></canvas>
@@ -131,7 +131,7 @@
             <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
                 <h6 class="m-0 fw-bold text-white">
                     New requests last 6 months
-                </h6> 
+                </h6>
             </div>
             <div class="card-body">
                 <canvas id="newTrainingRequests"></canvas>
@@ -144,7 +144,7 @@
             <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
                 <h6 class="m-0 fw-bold text-white">
                     Completed requests last 6 months
-                </h6> 
+                </h6>
             </div>
             <div class="card-body">
                 <canvas id="completedTrainingRequests"></canvas>
@@ -157,7 +157,7 @@
             <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
                 <h6 class="m-0 fw-bold text-white">
                     Closed requests last 6 months
-                </h6> 
+                </h6>
             </div>
             <div class="card-body">
                 <canvas id="closedTrainingRequests"></canvas>
@@ -170,7 +170,7 @@
             <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
                 <h6 class="m-0 fw-bold text-white">
                     Passed and failed exams last 6 months
-                </h6> 
+                </h6>
             </div>
             <div class="card-body">
                 <canvas id="TrainingPassFailRate"></canvas>
@@ -183,7 +183,7 @@
             <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
                 <h6 class="m-0 fw-bold text-white">
                     Estimated queue lengths
-                </h6> 
+                </h6>
             </div>
             <div class="card-body p-0">
                 <table class="table table-striped table-sm table-hover table-leftpadded mb-0" width="100%" cellspacing="0">
@@ -223,9 +223,8 @@
         ctx.canvas.width = 1000;
         ctx.canvas.height = 200;
 
-        var requestData = {!! json_encode($totalRequests) !!} 
-        
-        var color = Chart.helpers.color;
+        var requestData = {!! json_encode($totalRequests) !!}
+
         var cfg = {
             type: 'line',
             data: {
@@ -253,7 +252,7 @@
                         type: 'time',
                         time: {
                             unit: 'month',
-                            tooltipFormat:'DD/MM/YYYY', 
+                            tooltipFormat:'DD/MM/YYYY',
                         },
                         ticks: {
                             major: {
@@ -288,6 +287,14 @@
         // New request chart
         var newRequestsData = {!! json_encode($newRequests) !!}
 
+        var datasets = [];
+        for (const rating in newRequestsData) {
+            datasets.push({
+                label: rating,
+                data: newRequestsData[rating]
+            })
+        }
+
         var barChartData = {
             labels: [moment().subtract(6, "month").startOf("month").format('MMMM'),
                     moment().subtract(5, "month").startOf("month").format('MMMM'),
@@ -296,68 +303,7 @@
                     moment().subtract(2, "month").startOf("month").format('MMMM'),
                     moment().subtract(1, "month").startOf("month").format('MMMM'),
                     moment().startOf("month").format('MMMM')],
-            datasets: [{
-                label: 'S1',
-                backgroundColor: 'rgb(250, 150, 150)',
-                data: newRequestsData["S1"]
-            }, {
-                label: 'S2',
-                backgroundColor: 'rgb(200, 100, 100)',
-                data: newRequestsData["S2"]
-            }, {
-                label: 'S3',
-                backgroundColor: 'rgb(100, 100, 200)',
-                data: newRequestsData["S3"]
-            }, {
-                label: 'C1',
-                backgroundColor: 'rgb(100, 200, 100)',
-                data: newRequestsData["C1"]
-            }, {
-                label: 'C3',
-                backgroundColor: 'rgb(150, 200, 100)',
-                data: newRequestsData["C3"]
-            }, {
-                label: 'MAE ENGM TWR',
-                backgroundColor: 'rgb(25, 25, 25)',
-                data: newRequestsData["MAE ENGM TWR"],
-                hidden: true
-            }, {
-                label: 'MAE ENGM APP',
-                backgroundColor: 'rgb(50, 50, 50)',
-                data: newRequestsData["MAE ENGM APP"],
-                hidden: true
-            }, {
-                label: 'MAE ESSA TWR',
-                backgroundColor: 'rgb(75, 75, 75)',
-                data: newRequestsData["MAE ESSA TWR"],
-                hidden: true
-            }, {
-                label: 'MAE ESSA APP',
-                backgroundColor: 'rgb(100, 100, 100)',
-                data: newRequestsData["MAE ESSA APP"],
-                hidden: true
-            }, {
-                label: 'MAE EKCH TWR',
-                backgroundColor: 'rgb(125, 125, 125)',
-                data: newRequestsData["MAE EKCH TWR"],
-                hidden: true
-            }, {
-                label: 'MAE EKCH APP',
-                backgroundColor: 'rgb(150, 150, 150)',
-                data: newRequestsData["MAE EKCH APP"],
-                hidden: true
-            }, {
-                label: 'Oceanic BICC',
-                backgroundColor: 'rgb(150, 150, 255)',
-                data: newRequestsData["Oceanic BICC"],
-                hidden: true
-            }, {
-                label: 'Oceanic ENOB',
-                backgroundColor: 'rgb(75, 75, 255)',
-                data: newRequestsData["Oceanic ENOB"],
-                hidden: true
-            }]
-
+            datasets: datasets
         };
 
         var mix = document.getElementById("newTrainingRequests").getContext('2d');
@@ -393,6 +339,14 @@
         // Completed requests chart
         var completedRequestsData = {!! json_encode($completedRequests) !!}
 
+        var datasets = [];
+        for (const rating in completedRequestsData) {
+            datasets.push({
+                label: rating,
+                data: completedRequestsData[rating]
+            })
+        }
+
         var barChartData = {
             labels: [moment().subtract(6, "month").startOf("month").format('MMMM'),
                     moment().subtract(5, "month").startOf("month").format('MMMM'),
@@ -401,68 +355,7 @@
                     moment().subtract(2, "month").startOf("month").format('MMMM'),
                     moment().subtract(1, "month").startOf("month").format('MMMM'),
                     moment().startOf("month").format('MMMM')],
-            datasets: [{
-                label: 'S1',
-                backgroundColor: 'rgb(250, 150, 150)',
-                data: completedRequestsData["S1"]
-            }, {
-                label: 'S2',
-                backgroundColor: 'rgb(200, 100, 100)',
-                data: completedRequestsData["S2"]
-            }, {
-                label: 'S3',
-                backgroundColor: 'rgb(100, 100, 200)',
-                data: completedRequestsData["S3"]
-            }, {
-                label: 'C1',
-                backgroundColor: 'rgb(100, 200, 100)',
-                data: completedRequestsData["C1"]
-            }, {
-                label: 'C3',
-                backgroundColor: 'rgb(150, 200, 100)',
-                data: completedRequestsData["C3"]
-            }, {
-                label: 'MAE ENGM TWR',
-                backgroundColor: 'rgb(25, 25, 25)',
-                data: completedRequestsData["MAE ENGM TWR"],
-                hidden: true
-            }, {
-                label: 'MAE ENGM APP',
-                backgroundColor: 'rgb(50, 50, 50)',
-                data: completedRequestsData["MAE ENGM APP"],
-                hidden: true
-            }, {
-                label: 'MAE ESSA TWR',
-                backgroundColor: 'rgb(75, 75, 75)',
-                data: completedRequestsData["MAE ESSA TWR"],
-                hidden: true
-            }, {
-                label: 'MAE ESSA APP',
-                backgroundColor: 'rgb(100, 100, 100)',
-                data: completedRequestsData["MAE ESSA APP"],
-                hidden: true
-            }, {
-                label: 'MAE EKCH TWR',
-                backgroundColor: 'rgb(125, 125, 125)',
-                data: completedRequestsData["MAE EKCH TWR"],
-                hidden: true
-            }, {
-                label: 'MAE EKCH APP',
-                backgroundColor: 'rgb(150, 150, 150)',
-                data: completedRequestsData["MAE EKCH APP"],
-                hidden: true
-            }, {
-                label: 'Oceanic BICC',
-                backgroundColor: 'rgb(150, 150, 255)',
-                data: completedRequestsData["Oceanic BICC"],
-                hidden: true
-            }, {
-                label: 'Oceanic ENOB',
-                backgroundColor: 'rgb(75, 75, 255)',
-                data: completedRequestsData["Oceanic ENOB"],
-                hidden: true
-            }]
-
+            datasets: datasets
         };
 
         var mix = document.getElementById("completedTrainingRequests").getContext('2d');
@@ -499,6 +392,14 @@
         // Closed requests chart
         var closedRequestsData = {!! json_encode($closedRequests) !!}
 
+        var datasets = [];
+        for (const rating in closedRequestsData) {
+            datasets.push({
+                label: rating,
+                data: closedRequestsData[rating]
+            })
+        }
+
         var barChartData = {
             labels: [moment().subtract(6, "month").startOf("month").format('MMMM'),
                     moment().subtract(5, "month").startOf("month").format('MMMM'),
@@ -507,68 +408,7 @@
                     moment().subtract(2, "month").startOf("month").format('MMMM'),
                     moment().subtract(1, "month").startOf("month").format('MMMM'),
                     moment().startOf("month").format('MMMM')],
-            datasets: [{
-                label: 'S1',
-                backgroundColor: 'rgb(250, 150, 150)',
-                data: closedRequestsData["S1"]
-            }, {
-                label: 'S2',
-                backgroundColor: 'rgb(200, 100, 100)',
-                data: closedRequestsData["S2"]
-            }, {
-                label: 'S3',
-                backgroundColor: 'rgb(100, 100, 200)',
-                data: closedRequestsData["S3"]
-            }, {
-                label: 'C1',
-                backgroundColor: 'rgb(100, 200, 100)',
-                data: closedRequestsData["C1"]
-            }, {
-                label: 'C3',
-                backgroundColor: 'rgb(150, 200, 100)',
-                data: closedRequestsData["C3"]
-            }, {
-                label: 'MAE ENGM TWR',
-                backgroundColor: 'rgb(25, 25, 25)',
-                data: closedRequestsData["MAE ENGM TWR"],
-                hidden: true
-            }, {
-                label: 'MAE ENGM APP',
-                backgroundColor: 'rgb(50, 50, 50)',
-                data: closedRequestsData["MAE ENGM APP"],
-                hidden: true
-            }, {
-                label: 'MAE ESSA TWR',
-                backgroundColor: 'rgb(75, 75, 75)',
-                data: closedRequestsData["MAE ESSA TWR"],
-                hidden: true
-            }, {
-                label: 'MAE ESSA APP',
-                backgroundColor: 'rgb(100, 100, 100)',
-                data: closedRequestsData["MAE ESSA APP"],
-                hidden: true
-            }, {
-                label: 'MAE EKCH TWR',
-                backgroundColor: 'rgb(125, 125, 125)',
-                data: closedRequestsData["MAE EKCH TWR"],
-                hidden: true
-            }, {
-                label: 'MAE EKCH APP',
-                backgroundColor: 'rgb(150, 150, 150)',
-                data: closedRequestsData["MAE EKCH APP"],
-                hidden: true
-            }, {
-                label: 'Oceanic BICC',
-                backgroundColor: 'rgb(150, 150, 255)',
-                data: closedRequestsData["Oceanic BICC"],
-                hidden: true
-            }, {
-                label: 'Oceanic ENOB',
-                backgroundColor: 'rgb(75, 75, 255)',
-                data: closedRequestsData["Oceanic ENOB"],
-                hidden: true
-            }]
-
+            datasets: datasets
         };
 
         var mix = document.getElementById("closedTrainingRequests").getContext('2d');


### PR DESCRIPTION
The Reports Training series have been hardcoded in the view. This PR updates the flow with the following changes:

- fix: Training graphs now generate series from DB instead of hardcoded for VATSCA
- feat: Training graph series now use generated color palette to increase contrast between series
- feat: All zero series across all graphs are excluded to reduce clutter
- refactor(reports): Unify queries with and without areaFilter to reduce duplication of complex queries

Also closes #1144.