### PR TITLE
fix(reports): passed and failed exams overview

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -306,7 +306,7 @@ class ReportController extends Controller
         }
 
         // Fetch and process examination data
-        $passFailRequests = ['Passed' => array_fill(0, 7, 0), 'Failed' => array_fill(0, 7, 0)];
+        $passFailRequests = ['PASSED' => array_fill(0, 7, 0), 'FAILED' => array_fill(0, 7, 0)];
         $examinationsQuery = DB::table('training_examinations')
             ->select(DB::raw('count(training_examinations.id) as count'), DB::raw(Sql::month('training_examinations.examination_date', 'month')), 'result')
             ->join('trainings', 'trainings.id', '=', 'training_examinations.training_id')

--- a/resources/views/reports/trainings.blade.php
+++ b/resources/views/reports/trainings.blade.php
@@ -455,11 +455,11 @@
             datasets: [{
                 label: 'Failed',
                 backgroundColor: 'rgb(200, 100, 100)',
-                data: passFailRequestsData["Failed"]
+                data: passFailRequestsData["FAILED"]
             }, {
                 label: 'Passed',
                 backgroundColor: 'rgb(100, 200, 100)',
-                data: passFailRequestsData["Passed"]
+                data: passFailRequestsData["PASSED"]
             }]
 
         };


### PR DESCRIPTION
Fixes regression introduced in previous refactor.

## Summary by Sourcery

Fix regression in bi-annual training reports by aligning pass/fail data key casing between the controller and view

Bug Fixes:
- Correct passFailRequests array keys to uppercase ‘PASSED’ and ‘FAILED’ in the ReportController
- Update trainings blade to use uppercase data keys for passed and failed counts