### PR TITLE
feat(training): add support for per-area training report templates

### DIFF
--- a/app/Http/Controllers/TrainingReportTemplateController.php
+++ b/app/Http/Controllers/TrainingReportTemplateController.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Area;
+use App\Models\TrainingReportTemplate;
+use Illuminate\Http\Request;
+
+/**
+ * Controller for managing training report templates
+ */
+class TrainingReportTemplateController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function index()
+    {
+        $this->authorize('viewAny', TrainingReportTemplate::class);
+
+        $templates = TrainingReportTemplate::with('areas')->orderBy('created_at', 'desc')->get();
+        $areas = Area::all();
+
+        return view('admin.reporttemplates', compact('templates', 'areas'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function create()
+    {
+        $this->authorize('create', TrainingReportTemplate::class);
+
+        $areas = Area::all();
+
+        return view('admin.reporttemplates.create', compact('areas'));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function store(Request $request)
+    {
+        $this->authorize('create', TrainingReportTemplate::class);
+
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'content' => 'required|string',
+            'contentimprove' => 'nullable|string',
+            'draft' => 'sometimes|boolean',
+            'areas' => 'sometimes|array',
+            'areas.*' => 'exists:areas,id',
+        ]);
+
+        $template = TrainingReportTemplate::create([
+            'name' => $data['name'],
+            'content' => $data['content'],
+            'contentimprove' => $data['contentimprove'] ?? null,
+            'draft' => $request->has('draft') ? (bool) $request->input('draft') : false,
+        ]);
+
+        if (isset($data['areas'])) {
+            $template->areas()->sync($data['areas']);
+        }
+
+        return redirect()->route('admin.reporttemplates')->withSuccess('Training report template created successfully.');
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function edit(TrainingReportTemplate $template)
+    {
+        $this->authorize('update', $template);
+
+        $areas = Area::all();
+        $template->load('areas');
+
+        return view('admin.reporttemplates.edit', compact('template', 'areas'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function update(Request $request, TrainingReportTemplate $template)
+    {
+        $this->authorize('update', $template);
+
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'content' => 'required|string',
+            'contentimprove' => 'nullable|string',
+            'draft' => 'sometimes|boolean',
+            'areas' => 'sometimes|array',
+            'areas.*' => 'exists:areas,id',
+        ]);
+
+        $template->update([
+            'name' => $data['name'],
+            'content' => $data['content'],
+            'contentimprove' => $data['contentimprove'] ?? null,
+            'draft' => $request->has('draft') ? (bool) $request->input('draft') : false,
+        ]);
+
+        if (isset($data['areas'])) {
+            $template->areas()->sync($data['areas']);
+        } else {
+            $template->areas()->detach();
+        }
+
+        return redirect()->route('admin.reporttemplates')->withSuccess('Training report template updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function destroy(TrainingReportTemplate $template)
+    {
+        $this->authorize('delete', $template);
+
+        $template->delete();
+
+        return redirect()->route('admin.reporttemplates')->withSuccess('Training report template deleted successfully.');
+    }
+}
+

--- a/app/Models/Area.php
+++ b/app/Models/Area.php
@@ -40,4 +40,9 @@ class Area extends Model
     {
         return $this->hasMany(Position::class);
     }
+
+    public function trainingReportTemplates()
+    {
+        return $this->belongsToMany(TrainingReportTemplate::class, 'training_report_template_area');
+    }
 }

--- a/app/Models/TrainingReportTemplate.php
+++ b/app/Models/TrainingReportTemplate.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TrainingReportTemplate extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'draft' => 'boolean',
+    ];
+
+    /**
+     * Get the areas that this template is assigned to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function areas()
+    {
+        return $this->belongsToMany(Area::class, 'training_report_template_area');
+    }
+}
+

--- a/app/Policies/TrainingReportTemplatePolicy.php
+++ b/app/Policies/TrainingReportTemplatePolicy.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\TrainingReportTemplate;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class TrainingReportTemplatePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any templates.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->isModeratorOrAbove();
+    }
+
+    /**
+     * Determine whether the user can view the template.
+     */
+    public function view(User $user, TrainingReportTemplate $template): bool
+    {
+        return $user->isModeratorOrAbove();
+    }
+
+    /**
+     * Determine whether the user can create templates.
+     */
+    public function create(User $user): bool
+    {
+        return $user->isModeratorOrAbove();
+    }
+
+    /**
+     * Determine whether the user can update the template.
+     */
+    public function update(User $user, TrainingReportTemplate $template): bool
+    {
+        return $user->isModeratorOrAbove();
+    }
+
+    /**
+     * Determine whether the user can delete the template.
+     */
+    public function delete(User $user, TrainingReportTemplate $template): bool
+    {
+        return $user->isModeratorOrAbove();
+    }
+}
+

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -14,6 +14,7 @@ class AuthServiceProvider extends ServiceProvider
     protected $policies = [
         'anlutro\LaravelSettings\Facade' => 'App\Policies\SettingPolicy',
         'Illuminate\Notifications\Notification' => 'App\Policies\NotificationPolicy',
+        \App\Models\TrainingReportTemplate::class => \App\Policies\TrainingReportTemplatePolicy::class,
     ];
 
     /**

--- a/database/migrations/2026_01_04_223423_create_training_report_templates_table.php
+++ b/database/migrations/2026_01_04_223423_create_training_report_templates_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('training_report_templates', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('content');
+            $table->boolean('draft')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('training_report_templates');
+    }
+};

--- a/database/migrations/2026_01_04_223424_create_training_report_template_area_table.php
+++ b/database/migrations/2026_01_04_223424_create_training_report_template_area_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Drop the table if it exists (from a previous failed migration)
+        Schema::dropIfExists('training_report_template_area');
+        
+        Schema::create('training_report_template_area', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('training_report_template_id');
+            $table->unsignedInteger('area_id');
+            $table->timestamps();
+
+            $table->foreign('training_report_template_id', 'trt_area_template_id_fk')->references('id')->on('training_report_templates')->onUpdate('CASCADE')->onDelete('CASCADE');
+            $table->foreign('area_id', 'trt_area_area_id_fk')->references('id')->on('areas')->onUpdate('CASCADE')->onDelete('CASCADE');
+            
+            $table->unique(['training_report_template_id', 'area_id'], 'trt_area_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('training_report_template_area');
+    }
+};

--- a/database/migrations/2026_01_04_223425_add_contentimprove_to_training_report_templates.php
+++ b/database/migrations/2026_01_04_223425_add_contentimprove_to_training_report_templates.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('training_report_templates', function (Blueprint $table) {
+            $table->text('contentimprove')->nullable()->after('content');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('training_report_templates', function (Blueprint $table) {
+            $table->dropColumn('contentimprove');
+        });
+    }
+};
+

--- a/resources/views/admin/reporttemplates.blade.php
+++ b/resources/views/admin/reporttemplates.blade.php
@@ -1,0 +1,94 @@
+@extends('layouts.app')
+
+@section('title', 'Report Templates')
+@section('title-flex')
+    <div>
+        @can('create', \App\Models\TrainingReportTemplate::class)
+            <a class="btn btn-success btn-sm" href="{{ route('admin.reporttemplates.create') }}">
+                <i class="fas fa-plus"></i> New Template
+            </a>
+        @endcan
+    </div>
+@endsection
+
+@section('content')
+
+@if(Session::has('success'))
+    <div class="alert alert-success" role="alert">
+        <i class="fas fa-lg fa-check-circle"></i>&nbsp;{!! Session::pull("success") !!}
+    </div>
+@endif
+
+<div class="row">
+    <div class="col-xl-12 col-md-12 mb-12">
+        <div class="card shadow mb-4">
+            <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
+                <h6 class="m-0 fw-bold text-white">Training Report Templates</h6>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-striped table-sm table-hover mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Name</th>
+                                <th>Areas</th>
+                                <th>Status</th>
+                                <th>Created</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse($templates as $template)
+                                <tr>
+                                    <td>{{ $template->name }}</td>
+                                    <td>
+                                        @if($template->areas->count() > 0)
+                                            @foreach($template->areas as $area)
+                                                <span class="badge bg-secondary">{{ $area->name }}</span>
+                                            @endforeach
+                                        @else
+                                            <span class="text-muted">No areas assigned</span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        @if($template->draft)
+                                            <span class="badge bg-warning">Draft</span>
+                                        @else
+                                            <span class="badge bg-success">Published</span>
+                                        @endif
+                                    </td>
+                                    <td>{{ $template->created_at->format('Y-m-d') }}</td>
+                                    <td>
+                                        <div class="btn-group" role="group">
+                                            @can('update', $template)
+                                                <a href="{{ route('admin.reporttemplates.edit', $template->id) }}" class="btn btn-sm btn-primary">
+                                                    <i class="fas fa-edit"></i> Edit
+                                                </a>
+                                            @endcan
+                                            @can('delete', $template)
+                                                <form action="{{ route('admin.reporttemplates.destroy', $template->id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this template?');">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="btn btn-sm btn-danger">
+                                                        <i class="fas fa-trash"></i> Delete
+                                                    </button>
+                                                </form>
+                                            @endcan
+                                        </div>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="5" class="text-center text-muted">No templates found. <a href="{{ route('admin.reporttemplates.create') }}">Create one?</a></td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@endsection
+

--- a/resources/views/admin/reporttemplates/create.blade.php
+++ b/resources/views/admin/reporttemplates/create.blade.php
@@ -1,0 +1,106 @@
+@extends('layouts.app')
+
+@section('title', 'Create Report Template')
+
+@section('content')
+
+<div class="row">
+    <div class="col-xl-12 col-md-12 mb-12">
+        <div class="card shadow mb-4">
+            <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
+                <h6 class="m-0 fw-bold text-white">Create Training Report Template</h6>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('admin.reporttemplates.store') }}" method="POST">
+                    @csrf
+
+                    <div class="mb-3">
+                        <label class="form-label" for="name">Template Name</label>
+                        <input
+                            id="name"
+                            class="form-control @error('name') is-invalid @enderror"
+                            type="text"
+                            name="name"
+                            value="{{ old('name') }}"
+                            required>
+                        @error('name')
+                            <span class="text-danger">{{ $errors->first('name') }}</span>
+                        @enderror
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label" for="contentBox">Report</label>
+                        <textarea class="form-control @error('content') is-invalid @enderror" name="content" id="contentBox" rows="10" placeholder="Write the report template content here in markdown format.">{{ old('content') }}</textarea>
+                        @error('content')
+                            <span class="text-danger">{{ $errors->first('content') }}</span>
+                        @enderror
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label" for="contentimproveBox">Areas to improve</label>
+                        <textarea class="form-control @error('contentimprove') is-invalid @enderror" name="contentimprove" id="contentimproveBox" rows="6" placeholder="In which areas does the student need to improve?">{{ old('contentimprove') }}</textarea>
+                        @error('contentimprove')
+                            <span class="text-danger">{{ $errors->first('contentimprove') }}</span>
+                        @enderror
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label" for="areas">Assign to Areas</label>
+                        <select class="form-select @error('areas') is-invalid @enderror" name="areas[]" id="areas" multiple size="5">
+                            @foreach($areas as $area)
+                                <option value="{{ $area->id }}" {{ in_array($area->id, old('areas', [])) ? 'selected' : '' }}>{{ $area->name }}</option>
+                            @endforeach
+                        </select>
+                        <small class="form-text text-muted">Hold Ctrl (or Cmd on Mac) to select multiple areas. Leave empty to assign to all areas.</small>
+                        @error('areas')
+                            <span class="text-danger">{{ $errors->first('areas') }}</span>
+                        @enderror
+                    </div>
+
+                    <div class="mb-3 form-check">
+                        <input type="checkbox" value="1" class="form-check-input @error('draft') is-invalid @enderror" name="draft" id="draftCheck" {{ old('draft', true) ? 'checked' : '' }}>
+                        <label class="form-check-label" for="draftCheck">Save as draft (not available for selection)</label>
+                        @error('draft')
+                            <span class="text-danger">{{ $errors->first('draft') }}</span>
+                        @enderror
+                    </div>
+
+                    <div class="d-flex justify-content-between">
+                        <a href="{{ route('admin.reporttemplates') }}" class="btn btn-secondary">Cancel</a>
+                        <button type="submit" class="btn btn-success">Create Template</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+@endsection
+
+@section('js')
+
+<!-- Markdown Editor -->
+@vite(['resources/js/easymde.js', 'resources/sass/easymde.scss'])
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        var simplemde1 = new EasyMDE({ 
+            element: document.getElementById("contentBox"), 
+            status: false, 
+            toolbar: ["bold", "italic", "heading-3", "|", "quote", "unordered-list", "ordered-list", "|", "link", "preview", "side-by-side", "fullscreen", "|", "guide"],
+            insertTexts: {
+                link: ["[","](link)"],
+            }
+        });
+        var simplemde2 = new EasyMDE({ 
+            element: document.getElementById("contentimproveBox"), 
+            status: false, 
+            toolbar: ["bold", "italic", "heading-3", "|", "quote", "unordered-list", "ordered-list", "|", "link", "preview", "side-by-side", "fullscreen", "|", "guide"],
+            insertTexts: {
+                link: ["[","](link)"],
+            }
+        });
+    });
+</script>
+
+@endsection
+

--- a/resources/views/admin/reporttemplates/edit.blade.php
+++ b/resources/views/admin/reporttemplates/edit.blade.php
@@ -1,0 +1,107 @@
+@extends('layouts.app')
+
+@section('title', 'Edit Report Template')
+
+@section('content')
+
+<div class="row">
+    <div class="col-xl-12 col-md-12 mb-12">
+        <div class="card shadow mb-4">
+            <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
+                <h6 class="m-0 fw-bold text-white">Edit Training Report Template</h6>
+            </div>
+            <div class="card-body">
+                <form action="{{ route('admin.reporttemplates.update', $template->id) }}" method="POST">
+                    @csrf
+                    @method('PATCH')
+
+                    <div class="mb-3">
+                        <label class="form-label" for="name">Template Name</label>
+                        <input
+                            id="name"
+                            class="form-control @error('name') is-invalid @enderror"
+                            type="text"
+                            name="name"
+                            value="{{ old('name', $template->name) }}"
+                            required>
+                        @error('name')
+                            <span class="text-danger">{{ $errors->first('name') }}</span>
+                        @enderror
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label" for="contentBox">Report</label>
+                        <textarea class="form-control @error('content') is-invalid @enderror" name="content" id="contentBox" rows="10" placeholder="Write the report template content here in markdown format.">{{ old('content', $template->content) }}</textarea>
+                        @error('content')
+                            <span class="text-danger">{{ $errors->first('content') }}</span>
+                        @enderror
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label" for="contentimproveBox">Areas to improve</label>
+                        <textarea class="form-control @error('contentimprove') is-invalid @enderror" name="contentimprove" id="contentimproveBox" rows="6" placeholder="In which areas does the student need to improve?">{{ old('contentimprove', $template->contentimprove) }}</textarea>
+                        @error('contentimprove')
+                            <span class="text-danger">{{ $errors->first('contentimprove') }}</span>
+                        @enderror
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label" for="areas">Assign to Areas</label>
+                        <select class="form-select @error('areas') is-invalid @enderror" name="areas[]" id="areas" multiple size="5">
+                            @foreach($areas as $area)
+                                <option value="{{ $area->id }}" {{ $template->areas->contains($area->id) || in_array($area->id, old('areas', [])) ? 'selected' : '' }}>{{ $area->name }}</option>
+                            @endforeach
+                        </select>
+                        <small class="form-text text-muted">Hold Ctrl (or Cmd on Mac) to select multiple areas. Leave empty to assign to all areas.</small>
+                        @error('areas')
+                            <span class="text-danger">{{ $errors->first('areas') }}</span>
+                        @enderror
+                    </div>
+
+                    <div class="mb-3 form-check">
+                        <input type="checkbox" value="1" class="form-check-input @error('draft') is-invalid @enderror" name="draft" id="draftCheck" {{ old('draft', $template->draft) ? 'checked' : '' }}>
+                        <label class="form-check-label" for="draftCheck">Save as draft (not available for selection)</label>
+                        @error('draft')
+                            <span class="text-danger">{{ $errors->first('draft') }}</span>
+                        @enderror
+                    </div>
+
+                    <div class="d-flex justify-content-between">
+                        <a href="{{ route('admin.reporttemplates') }}" class="btn btn-secondary">Cancel</a>
+                        <button type="submit" class="btn btn-success">Update Template</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+@endsection
+
+@section('js')
+
+<!-- Markdown Editor -->
+@vite(['resources/js/easymde.js', 'resources/sass/easymde.scss'])
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        var simplemde1 = new EasyMDE({ 
+            element: document.getElementById("contentBox"), 
+            status: false, 
+            toolbar: ["bold", "italic", "heading-3", "|", "quote", "unordered-list", "ordered-list", "|", "link", "preview", "side-by-side", "fullscreen", "|", "guide"],
+            insertTexts: {
+                link: ["[","](link)"],
+            }
+        });
+        var simplemde2 = new EasyMDE({ 
+            element: document.getElementById("contentimproveBox"), 
+            status: false, 
+            toolbar: ["bold", "italic", "heading-3", "|", "quote", "unordered-list", "ordered-list", "|", "link", "preview", "side-by-side", "fullscreen", "|", "guide"],
+            insertTexts: {
+                link: ["[","](link)"],
+            }
+        });
+    });
+</script>
+
+@endsection
+

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -207,7 +207,7 @@
         @if (\Auth::user()->isModeratorOrAbove())
 
             {{-- Nav Item - Utilities Collapse Menu --}}
-            <li class="nav-item {{ Route::is('admin.settings') || Route::is('vote.overview') || Route::is('admin.templates') || Route::is('admin.logs') ? 'active' : '' }}">
+            <li class="nav-item {{ Route::is('admin.settings') || Route::is('vote.overview') || Route::is('admin.templates') || Route::is('admin.templates.area') || Route::is('admin.reporttemplates*') || Route::is('admin.logs') ? 'active' : '' }}">
             <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseUtilities" aria-expanded="true" aria-controls="collapseUtilities">
                 <i class="fas fa-fw fa-cogs"></i>
                 <span>Administration</span>
@@ -222,6 +222,7 @@
 
                 @if (\Auth::user()->isModeratorOrAbove())
                     <a class="collapse-item" href="{{ route('admin.templates') }}">Notification templates</a>
+                    <a class="collapse-item" href="{{ route('admin.reporttemplates') }}">Report templates</a>
                 @endif
                 </div>
             </div>

--- a/resources/views/training/report/create.blade.php
+++ b/resources/views/training/report/create.blade.php
@@ -57,6 +57,27 @@
                     </div>
 
                     <div class="mb-3">
+                        <label class="form-label" for="templateSelect">Template (Optional)</label>
+                        @if(isset($templates) && $templates->count() > 0)
+                            <select class="form-select @error('template_id') is-invalid @enderror" name="template_id" id="templateSelect">
+                                <option value="">-- Select a template --</option>
+                                @foreach($templates as $template)
+                                    <option value="{{ $template->id }}" data-content="{{ htmlspecialchars($template->content, ENT_QUOTES, 'UTF-8') }}" data-contentimprove="{{ htmlspecialchars($template->contentimprove ?? '', ENT_QUOTES, 'UTF-8') }}">{{ $template->name }}</option>
+                                @endforeach
+                            </select>
+                            <small class="form-text text-muted">Select a template to pre-fill the report content.</small>
+                        @else
+                            <select class="form-select" name="template_id" id="templateSelect" disabled>
+                                <option value="">No templates available</option>
+                            </select>
+                            <small class="form-text text-muted">No published templates are available for this area. <a href="{{ route('admin.reporttemplates') }}">Create templates</a> in Administration.</small>
+                        @endif
+                        @error('template_id')
+                            <span class="text-danger">{{ $errors->first('template_id') }}</span>
+                        @enderror
+                    </div>
+
+                    <div class="mb-3">
                         <label class="form-label" for="contentBox">Report</label>
                         <textarea class="form-control @error('content') is-invalid @enderror" name="content" id="contentBox" rows="8" placeholder="Write the report here.">{{ old('content') }}</textarea>
                         @error('content')
@@ -139,6 +160,24 @@
                 link: ["[","](link)"],
             }
         });
+
+        // Handle template selection
+        var templateSelect = document.getElementById("templateSelect");
+        if (templateSelect) {
+            templateSelect.addEventListener("change", function() {
+                var selectedOption = this.options[this.selectedIndex];
+                if (selectedOption.value && selectedOption.dataset.content) {
+                    var currentContent = simplemde1.value();
+                    var currentContentImprove = simplemde2.value();
+                    var hasContent = currentContent || currentContentImprove;
+                    
+                    if (!hasContent || confirm("This will replace the current content. Continue?")) {
+                        simplemde1.value(selectedOption.dataset.content || '');
+                        simplemde2.value(selectedOption.dataset.contentimprove || '');
+                    }
+                }
+            });
+        }
 
         var submitClicked = false
         document.addEventListener("submit", function(event) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ use App\Http\Controllers\TrainingController;
 use App\Http\Controllers\TrainingExaminationController;
 use App\Http\Controllers\TrainingObjectAttachmentController;
 use App\Http\Controllers\TrainingReportController;
+use App\Http\Controllers\TrainingReportTemplateController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\VoteController;
 
@@ -106,6 +107,16 @@ Route::middleware(['auth', 'activity', 'suspended'])->group(function () {
     Route::get('/admin/templates/{id}', [NotificationController::class, 'index'])->name('admin.templates.area');
     Route::post('/admin/templates/update', [NotificationController::class, 'update'])->name('admin.templates.update');
     Route::get('/admin/log', [ActivityLogController::class, 'index'])->name('admin.logs');
+    
+    // Report Templates
+    Route::controller(TrainingReportTemplateController::class)->group(function () {
+        Route::get('/admin/reporttemplates', 'index')->name('admin.reporttemplates');
+        Route::get('/admin/reporttemplates/create', 'create')->name('admin.reporttemplates.create');
+        Route::post('/admin/reporttemplates', 'store')->name('admin.reporttemplates.store');
+        Route::get('/admin/reporttemplates/{template}/edit', 'edit')->name('admin.reporttemplates.edit');
+        Route::patch('/admin/reporttemplates/{template}', 'update')->name('admin.reporttemplates.update');
+        Route::delete('/admin/reporttemplates/{template}', 'destroy')->name('admin.reporttemplates.destroy');
+    });
 
     // Training routes
     Route::controller(TrainingController::class)->group(function () {


### PR DESCRIPTION
<img width="683" height="416" alt="image" src="https://github.com/user-attachments/assets/351faea8-c78e-46a0-9782-4dce8dad237a" />
<img width="1544" height="280" alt="image" src="https://github.com/user-attachments/assets/d2814ed6-ad06-4610-9c40-d8af630955f0" />
<img width="1780" height="1458" alt="image" src="https://github.com/user-attachments/assets/ae2b5ea3-adc7-4e0e-93ab-6e3b835e9131" />


Implementation for issue #1203

## Summary by Sourcery

Introduce reusable training report templates and integrate them into the training report workflow.

New Features:
- Allow moderators to create, edit, list, and delete training report templates, including per-area assignment and draft/published status.
- Enable instructors to select a training report template when creating a training report, pre-filling both report and improvement content fields.

Enhancements:
- Add authorization policy and sidebar navigation updates to manage access and visibility of training report template administration pages.

Chores:
- Add database schema and Eloquent models to store training report templates and their area assignments.