### PR TITLE
fix(training): removes mentors when training is closed automatically

### DIFF
--- a/app/Console/Commands/SendTrainingInterestNotifications.php
+++ b/app/Console/Commands/SendTrainingInterestNotifications.php
@@ -74,6 +74,9 @@ class SendTrainingInterestNotifications extends Command
 
                     $oldStatus = $training->status;
 
+                    // Detach mentors before closing the training
+                    $training->mentors()->detach();
+
                     // Update the training
                     // Note: The training interest is set to expire through updateStatus()
                     $training->updateStatus(-4, true);

--- a/app/Console/Commands/UpdateMemberDetails.php
+++ b/app/Console/Commands/UpdateMemberDetails.php
@@ -87,6 +87,9 @@ class UpdateMemberDetails extends Command
                 continue;
             }
 
+            // Detach mentors before closing the training
+            $training->mentors()->detach();
+
             // Close the training
             $training->updateStatus(-4);
             $training->closed_reason = 'The student has left or is no longer part of our division.';


### PR DESCRIPTION
Fixes #1367.

## Summary by Sourcery

Bug Fixes:
- Ensure mentors are removed from trainings before automatic closure when expiring training interest or when a student leaves the division.