### PR TITLE
Feature: Limit feedback to area

### DIFF
--- a/app/Http/Controllers/GlobalSettingController.php
+++ b/app/Http/Controllers/GlobalSettingController.php
@@ -64,6 +64,7 @@ class GlobalSettingController extends Controller
             'divisionApiEnabled' => '',
             'feedbackEnabled' => '',
             'feedbackForwardEmail' => 'nullable|email',
+            'feedbackLimitToAreas' => '',
             'telemetryEnabled' => '',
         ]);
 
@@ -75,6 +76,7 @@ class GlobalSettingController extends Controller
         isset($data['atcActivityAllowInactiveControlling']) ? $atcActivityAllowInactiveControlling = true : $atcActivityAllowInactiveControlling = false;
         isset($data['divisionApiEnabled']) ? $divisionApiEnabled = true : $divisionApiEnabled = false;
         isset($data['feedbackEnabled']) ? $feedbackEnabled = true : $feedbackEnabled = false;
+        isset($data['feedbackLimitToAreas']) ? $feedbackLimitToAreas = true : $feedbackLimitToAreas = false;
 
         // The setting dependency doesn't support null values, so we need to set it to false if it's not set
         isset($data['linkMoodle']) ? $linkMoodle = $data['linkMoodle'] : $linkMoodle = false;
@@ -107,6 +109,7 @@ class GlobalSettingController extends Controller
         Setting::set('divisionApiEnabled', $divisionApiEnabled);
         Setting::set('feedbackEnabled', $feedbackEnabled);
         Setting::set('feedbackForwardEmail', $feedbackForwardEmail);
+        Setting::set('feedbackLimitToAreas', $feedbackLimitToAreas);
         Setting::set('telemetryEnabled', $telemetryEnabled);
         Setting::save();
 

--- a/app/Models/Feedback.php
+++ b/app/Models/Feedback.php
@@ -27,4 +27,14 @@ class Feedback extends Model
     {
         return $this->belongsTo(Position::class, 'reference_position_id');
     }
+
+    /**
+     * Get the area associated with this feedback through the reference position
+     *
+     * @return Area|null
+     */
+    public function getArea()
+    {
+        return $this->referencePosition?->area;
+    }
 }

--- a/database/migrations/2026_01_23_211207_add_feedback_limit_to_areas_setting.php
+++ b/database/migrations/2026_01_23_211207_add_feedback_limit_to_areas_setting.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table(Config::get('settings.table'))->insert([
+            ['key' => 'feedbackLimitToAreas', 'value' => false],
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table(Config::get('settings.table'))->where('key', 'feedbackLimitToAreas')->delete();
+    }
+};

--- a/resources/views/admin/globalsettings.blade.php
+++ b/resources/views/admin/globalsettings.blade.php
@@ -363,6 +363,14 @@
                                 <span class="text-danger">{{ $errors->first('feedbackForwardEmail') }}</span>
                             @enderror
 
+                            <div class="form-check mb-4">
+                                <input class="form-check-input @error('feedbackLimitToAreas') is-invalid @enderror" type="checkbox" id="checkFeedbackLimitToAreas" name="feedbackLimitToAreas" {{ Setting::get('feedbackLimitToAreas') ? "checked" : "" }}>
+                                <label class="form-check-label" for="checkFeedbackLimitToAreas">
+                                    Limit feedback visibility to moderators' assigned areas
+                                </label>
+                                <small class="form-text d-block">When enabled, moderators can only view feedback related to their assigned areas. <br />Administrators always see all feedback regardless of this setting.</small>
+                            </div>
+
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Fixes #1394.

## Summary by Sourcery

Introduce a configurable option to restrict feedback visibility to a user's assigned areas while preserving full visibility for administrators.

New Features:
- Add a global setting to limit feedback visibility to moderators' assigned areas and expose it in the admin settings UI.
- Scope feedback queries to a user's areas when the area-limiting setting is enabled, with administrators exempt from this restriction.

Enhancements:
- Add a helper on feedback records to access the associated area via the reference position relationship.

Chores:
- Add a database migration to register the new feedback visibility setting with a default value.