### PR TITLE
docs: add ATC activity and VATEUD sync logic documentation

### DIFF
--- a/docs/activity.md
+++ b/docs/activity.md
@@ -1,0 +1,43 @@
+---
+icon: material/pulse
+---
+
+# ATC Activity
+
+Control Center automatically tracks the controlling activity of your members to determine their active status. This status (`atc_active`) is critical as it influences roster management, API synchronizations, and potentially endorsement validity.
+
+## How it works
+
+The activity tracking system runs in two distinct phases via background jobs.
+
+### 1. Data Collection
+
+This job runs periodically to fetch raw session data.
+
+- **Source**: It queries the public **VATSIM Data API** to retrieve ATC sessions for your members. No personal tokens are required for this.
+- **Scope**: It looks back a configurable number of months defined by the `atcActivityQualificationPeriod`.
+- **Filtering**: It filters sessions based on the **Callsigns** defined for your Areas (FIRs/ACCs). Only time spent on positions matching your facility's prefixes is counted.
+- **Storage**: The calculated hours are stored per user, per area.
+
+### 2. Status Evaluation
+
+This job analyzes the collected data to set the `atc_active` flag for each user.
+
+A user is considered **Active** if they meet **either** of the following criteria:
+
+1. **Grace Period**: The user has a valid `Grace Period` set in their profile (e.g., for new members or returning controllers) that has not yet expired.
+2. **Minimum Hours**: The user has accumulated enough controlling hours to meet the `atcActivityRequirement` (default: 10 hours) within the qualification period.
+
+If a user fails both checks:
+
+- Their `atc_active` status is set to `false`.
+- If configured, they may be removed from external rosters (see [Division Integrations](integrations/vateud.md)) during the next synchronization.
+
+## Configuration
+
+You can customize the activity logic in **Administration > Settings**:
+
+- **ATC Activity Requirement**: Minimum hours required (default: 10).
+- **ATC Activity Qualification Period**: How far back to count hours (default: 12 months).
+- **Grace Period Duration**: Default duration for new grace periods (default: 12 months).
+- **Activity Mode**: Whether activity is calculated based on **Total Hours** (sum of all areas) or **Per Area** (requiring hours in specific areas to remain active there).

--- a/docs/integrations/vateud.md
+++ b/docs/integrations/vateud.md
@@ -9,8 +9,37 @@ We provide a integration for the VATSIM Europe Division (VATEUD). This calls the
 - Rating upgrades (via Tasks) 
 - Theory test requests (via Tasks)
 
-!!! info
+!!! info "The Source of Truth"
     Control Center works as the source of truth, so it's important that existing data in VATEUD Core is in sync prior to enabling this integration. Sync all your members, endorsements and such within the VATEUD Core portal manually. 
 
-!!! tip "Activate in settings"
-    Remember turning on the Division API setting in Administration > Settings
+!!! tip "Activate in Settings"
+    Remember to enable the *Division API* setting in **Administration* > *Settings*
+
+## Synchronization Logic
+
+The integration performs automatic synchronization to ensure the VATEUD roster matches your local Control Center database. It is important to understand when and why data is added or removed.
+
+### Roster Sync
+
+This job ensures the list of controllers on the VATEUD roster matches your **Active** members.
+
+- **Adds**:
+    - **Active Home Members**: Users with `atc_active = true`.
+    - **Visiting Members**: Users with a valid, non-expired `VISITING` endorsement.
+- **Removes**:
+    - **Inactive Members**: Home members who have failed to meet activity requirements (`atc_active = false`).
+    - **Expired Visitors**: Visiting members whose endorsement has expired or been revoked.
+    - **Transfers**: Members who have left the subdivision.
+
+### Endorsement Sync
+
+This job manages *Tier 1* (T1) and *Tier 2* (T2) facility endorsements.
+
+- **Syncs**: Only checks endorsements for users who are currently **Active** or valid **Visitors**.
+- **Removes**: Endorsements are removed from the VATEUD API if:
+    - The user becomes **Inactive** (even if they still hold the endorsement locally).
+    - The endorsement is **revoked** or **expired** in Control Center.
+    - The user loses their **Visiting** status.
+
+!!! warning "Activity is Key"
+    If a controller goes inactive locally (due to lack of hours), they will be **removed** from the VATEUD roster and their endorsements will be stripped from the API during the next sync. Ensure your members maintain their [ATC Activity](../activity.md) or have a valid Grace Period.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
           - Mentoring: concepts/mentors.md
           - Ratings: concepts/ratings.md
   - Reference:
+      - Activity: activity.md
       - Contribute: contribute.md
       - API: api.md
       - Background jobs: background-jobs.md


### PR DESCRIPTION
Attempt to improve the documentation by expanding on how ATC activity works, and how the integration interfaces with different areas.

## Summary by Sourcery

Document ATC activity tracking and clarify how it drives VATEUD division roster and endorsement synchronization behavior.

Enhancements:
- Update documentation navigation to include the new ATC activity reference page.

Documentation:
- Add a dedicated ATC activity reference page explaining data collection, status evaluation, and configuration options.
- Extend VATEUD integration docs with synchronization logic for rosters and endorsements, emphasizing the impact of member activity status.