### PR TITLE
chore: Update Read-me

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Training Management System created by [Daniel L.](https://github.com/blt950) (13
 - [Singapore vACC](https://sinvacc.org/)
 - [VATAdria](https://vatadria.com/)
 - [VATMEX](https://www.vatmex.com.mx/)
-- [Vietnam - Canbodia - Laos vACC](https://vclvacc.net/)
+- [Vietnam - Cambodia - Laos vACC](https://vclvacc.net/)
 - [Thailand vACC](https://vacc-tha.org/)
 - [VATSIM Italia](https://www.vatita.net/)
 - [VATPHIL](https://vatphil.com/)


### PR DESCRIPTION
* Added missing vACC (VATPHIL)
* Added new division (Portugal vACC) 🥳

## Summary by Sourcery

Update README to reflect current divisions using Control Center.

Documentation:
- Adjust the documented count of divisions using Control Center from 10 to 11.
- Add VATPHIL and Portugal vACC to the list of divisions using Control Center.