### PR TITLE
fix: use SVG for top bar image instead of inline

### DIFF
--- a/resources/views/layouts/topbar.blade.php
+++ b/resources/views/layouts/topbar.blade.php
@@ -2,7 +2,7 @@
 
     <a class="sidebar-brand sidebar-brand-topbar align-items-center" href="{{ route('dashboard') }}">
         <div class="sidebar-brand-icon">
-            <img src="{{ asset('images/control-tower.svg') }}" alt="Control Tower" style="height: 40px; width: auto;">
+            <img src="{{ asset('images/control-tower.svg') }}" alt="Control Tower" class="brand-logo-img">
         </div>
 
         <div class="sidebar-brand-text mx-3" style="color: var(--color-body);">{{ config('app.name') }}</div>


### PR DESCRIPTION
When someone changes the control-tower.svg it'll also change the topbar svg you can see in mobile

## Summary by Sourcery

Enhancements:
- Replace the hardcoded inline SVG in the topbar with an image tag referencing the shared control-tower.svg asset.