### PR TITLE
fix: restrict valid frequencies to the real ones

### DIFF
--- a/app/Http/Requests/PositionRequest.php
+++ b/app/Http/Requests/PositionRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Helpers\VatsimRating;
+use App\Rules\VhfAirbandFrequency;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -37,7 +38,7 @@ class PositionRequest extends FormRequest
         return [
             'callsign' => ['required', 'uppercase', Rule::unique('positions')->ignore($position)],
             'name' => 'required',
-            'frequency' => 'required|numeric|decimal:3|min:117.975|max:137.000',
+            'frequency' => ['required', new VhfAirbandFrequency],
             'fir' => 'required|size:4|uppercase',
             'rating' => [
                 'required',

--- a/app/Rules/VhfAirbandFrequency.php
+++ b/app/Rules/VhfAirbandFrequency.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Rules;
+
+use App\Services\VhfAirbandCheckerService;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class VhfAirbandFrequency implements ValidationRule
+{
+    protected VhfAirbandCheckerService $service;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->service = app(VhfAirbandCheckerService::class);
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! $this->service->check((string) $value)) {
+            $fail($this->message());
+        }
+    }
+
+    /**
+     * Get the validation error message.
+     */
+    private function message(): string
+    {
+        return 'The frequency must be a valid VHF frequency between 118.000 and 136.990 MHz with valid spacing.';
+    }
+}

--- a/app/Services/VhfAirbandCheckerService.php
+++ b/app/Services/VhfAirbandCheckerService.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Services;
+
+class VhfAirbandCheckerService
+{
+    /**
+     * Validate that freq is in 25kHz or 8.33kHz spacing
+     * and that it is between 118.000 and 136.990 MHz.
+     */
+    public function check(string $freq): bool
+    {
+        if (! str_contains($freq, '.')) {
+            return false;
+        }
+
+        [$main, $sub] = explode('.', $freq, 2);
+
+        if (strlen($main) !== 3 || strlen($sub) !== 3) {
+            return false;
+        }
+
+        if (! ctype_digit($main) || ! ctype_digit($sub)) {
+            return false;
+        }
+
+        $main = (int) $main;
+        $sub = (int) $sub;
+
+        return $this->validateMain($main) && $this->validateSub($sub);
+    }
+
+    /**
+     * Validate that the input is between 118.000 and 136.990 MHz.
+     */
+    protected function validateMain(int $main): bool
+    {
+        return $main >= 118 && $main < 137;
+    }
+
+    /**
+     * Validate sub frequency.
+     */
+    protected function validateSub(int $sub): bool
+    {
+        return in_array($sub % 25, [0, 5, 10, 15], true);
+    }
+}

--- a/database/factories/PositionFactory.php
+++ b/database/factories/PositionFactory.php
@@ -25,7 +25,11 @@ class PositionFactory extends Factory
         return [
             'callsign' => strtoupper($this->faker->unique()->text(7)),
             'name' => $this->faker->word(),
-            'frequency' => sprintf('%.3f', $this->faker->randomFloat(3, 118, 136)),
+            'frequency' => sprintf(
+                '%03d.%03d',
+                $this->faker->numberBetween(118, 136),
+                $this->faker->randomElement([0, 5, 10, 15, 25, 30, 35, 40, 50, 55, 60, 65, 75, 80, 85, 90])
+            ),
             'fir' => strtoupper($this->faker->lexify('????')),
             'rating' => $this->faker->randomElement(VatsimRating::getControllerRatings()),
             'area_id' => Area::factory(),

--- a/tests/Unit/VhfAirbandCheckerServiceTest.php
+++ b/tests/Unit/VhfAirbandCheckerServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\VhfAirbandCheckerService;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class VhfAirbandCheckerServiceTest extends TestCase
+{
+    private VhfAirbandCheckerService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new VhfAirbandCheckerService();
+    }
+
+    #[Test]
+    public function it_validates_edge_frequencies()
+    {
+        $this->assertTrue($this->service->check('118.000'));
+        $this->assertTrue($this->service->check('136.990'));
+    }
+
+    #[Test]
+    public function it_validates_mid_frequencies()
+    {
+        $this->assertTrue($this->service->check('122.800'));
+        $this->assertTrue($this->service->check('131.705'));
+        $this->assertTrue($this->service->check('121.500'));
+        $this->assertTrue($this->service->check('118.005')); // 8.33kHz
+        $this->assertTrue($this->service->check('118.010')); // 8.33kHz
+        $this->assertTrue($this->service->check('118.015')); // 8.33kHz
+        $this->assertTrue($this->service->check('136.975')); // 25kHz
+        $this->assertTrue($this->service->check('136.980')); // 8.33kHz
+        $this->assertTrue($this->service->check('136.985')); // 8.33kHz
+    }
+
+    #[Test]
+    public function it_invalidates_frequencies_outside_range()
+    {
+        $this->assertFalse($this->service->check('117.995'));
+        $this->assertFalse($this->service->check('137.000'));
+    }
+
+    #[Test]
+    public function it_invalidates_frequencies_with_bad_spacing()
+    {
+        $this->assertFalse($this->service->check('118.020'));
+        $this->assertFalse($this->service->check('118.021'));
+        $this->assertFalse($this->service->check('122.845'));
+        $this->assertFalse($this->service->check('131.770'));
+        $this->assertFalse($this->service->check('135.995'));
+    }
+
+    #[Test]
+    public function it_invalidates_incorrectly_formatted_frequencies()
+    {
+        $this->assertFalse($this->service->check('118'));
+        $this->assertFalse($this->service->check('118.0'));
+        $this->assertFalse($this->service->check('118.00'));
+        $this->assertFalse($this->service->check('118.0000'));
+        $this->assertFalse($this->service->check('abc.def'));
+        $this->assertFalse($this->service->check('118.abc'));
+    }
+}


### PR DESCRIPTION
Fixes #1409. Prevents invalid frequencies from being used with positions.

/cc @meltinglava

## Summary by Sourcery

Validate VHF frequencies for positions using a dedicated service and validation rule, and align factories and tests with the allowed frequency range and spacing.

New Features:
- Introduce a VHF frequency validation service encapsulating range and spacing rules for aviation VHF channels.
- Add a reusable validation rule to enforce valid VHF frequencies on position records.

Bug Fixes:
- Prevent creation of positions with out-of-range or improperly spaced VHF frequencies by replacing the simple numeric validation with domain-specific checks.

Enhancements:
- Adjust the position factory to generate only realistically spaced VHF frequencies within the allowed range.

Tests:
- Add unit tests covering valid and invalid VHF frequencies, including edge cases, spacing, and formatting.