### PR TITLE
build: add a nix development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,10 @@ tests
 .devcontainer
 # Don't care about docs either, they're online.
 docs
+# Don't care about no mise or nix files either, they're for development.
+.mise.toml
+flake.nix
+flake.lock
+# Don't care about these either, they're for local development.
+.direnv
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 .env
+.envrc
+.direnv/
 .htaccess
 .idea/
 .vscode/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,86 @@
+{
+  description = "VATSIM Scandinavia Control Center – Laravel dev environment with PHP 8.3/8.4/8.5 and MySQL";
+
+  # nixos-unstable has php85; use a recent nixpkgs for all three PHP versions
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }: let
+    inherit (nixpkgs) lib;
+    forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+    pkgsFor = system: import nixpkgs {
+      inherit system;
+      config.allowUnfree = true;
+    };
+
+    # Laravel-typical PHP extensions (pdo_mysql, intl, zip, opcache where available)
+    phpExts = { enabled, all }: enabled ++ (with all; [
+      intl
+      zip
+      pdo_mysql
+    ]) ++ lib.optional (all ? opcache) all.opcache;
+
+    mkPhpEnv = phpBase: phpBase.buildEnv {
+      extensions = phpExts;
+      extraConfig = ''
+        memory_limit = 512M
+        date.timezone = UTC
+      '';
+    };
+
+    mkDevShell = system: let
+      pkgs = pkgsFor system;
+      # Keep version setup compact so adding/removing versions only changes one list.
+      desiredPhpVersions = [ "83" "84" "85" ];
+      availablePhpVersions = builtins.filter (version: builtins.hasAttr "php${version}" pkgs) desiredPhpVersions;
+      defaultPhpVersion = lib.last availablePhpVersions;
+      mkPhpVersion = version: let
+        phpAttr = "php${version}";
+        phpEnv = mkPhpEnv pkgs.${phpAttr};
+      in {
+        name = "php${version}";
+        env = phpEnv;
+        wrapper = pkgs.writeShellScriptBin "php${version}" ''exec "${phpEnv}/bin/php" "$@"'';
+      };
+      phpBins = map mkPhpVersion availablePhpVersions;
+      phpByName = builtins.listToAttrs (map (phpBin: {
+        name = phpBin.name;
+        value = phpBin;
+      }) phpBins);
+      defaultPhpEnv = phpByName."php${defaultPhpVersion}".env;
+      defaultComposer = pkgs.${"php${defaultPhpVersion}Packages"}.composer;
+      phpVersionStatusLines = lib.concatStringsSep "\n" (map (version: ''
+        echo "  php${version}           $(php${version} -v 2>/dev/null | head -1)"
+      '') availablePhpVersions);
+    in assert lib.assertMsg (availablePhpVersions != [])
+      "No supported PHP versions are available in nixpkgs. Checked: ${lib.concatStringsSep ", " desiredPhpVersions}";
+      pkgs.mkShell {
+      name = "controlcenter-dev";
+      packages = [
+        defaultPhpEnv   # default `php` and `php-fpm` etc.
+      ] ++ (map (phpBin: phpBin.wrapper) phpBins) ++ [
+        pkgs.mariadb   # client (mysql, mysqldump) and server (mysqld) when needed
+        defaultComposer
+      ];
+
+      env.PHP_PEAR_SYSCONF_DIR = "/tmp";
+
+      shellHook = ''
+        echo ""
+        echo "────────────────────────────────────"
+        echo " VATSIM Scandinavia Control Center"
+        echo " Development environment"
+        echo "────────────────────────────────────"
+        echo ""
+        echo "  PHP (default)   $(php -v 2>/dev/null | head -1)"
+        ${phpVersionStatusLines}
+        echo "  mysql           $(mysql --version 2>/dev/null || true)"
+        echo "  composer        $(composer --version 2>/dev/null || true)"
+        echo ""
+      '';
+    };
+  in {
+    devShells = forAllSystems (system: {
+      default = mkDevShell system;
+    });
+  };
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a Nix flake-based development shell for the project with multiple PHP versions and database tooling.

New Features:
- Provide a reproducible Nix development environment exposing PHP 8.3/8.4/8.5 and MySQL tooling via a flake devShell.

Build:
- Introduce flake.nix and flake.lock to define and pin the Nix-based development environment for the project.