### PR TITLE
fix(psql): Training Interest should use booleans for a boolean column

### DIFF
--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -58,11 +58,7 @@ class Training extends Model
                 }
 
                 // Expire all related training interest models, as we assume the student is contacted and interested if their training status changes positively.
-                $expired = 1;
-                if ($expiredInterest) {
-                    $expired = 2;
-                }
-                TrainingInterest::where([['training_id', $this->id], ['expired', false]])->update(['updated_at' => now(), 'expired' => $expired]);
+                TrainingInterest::where([['training_id', $this->id], ['expired', false]])->update(['updated_at' => now(), 'expired' => true]);
             }
 
             // If training is completed or closed
@@ -70,11 +66,7 @@ class Training extends Model
                 $this->update(['closed_at' => now()]);
 
                 // Expire all related training interest models, as they will only cause problems if training is re-opened.
-                $expired = 1;
-                if ($expiredInterest) {
-                    $expired = 2;
-                }
-                TrainingInterest::where([['training_id', $this->id], ['expired', false]])->update(['updated_at' => now(), 'expired' => $expired]);
+                TrainingInterest::where([['training_id', $this->id], ['expired', false]])->update(['updated_at' => now(), 'expired' => true]);
 
                 // If paused is unchecked but training is paused, sum up the length and unpause.
                 if (isset($this->paused_at)) {


### PR DESCRIPTION
PostgreSQL is pickier about its booleans than MySQL. As I don't see the logical difference between expired = 1/2 as storage on mysql would still be 0/1 only, simplified it to just simply toggle false to true as the comment suggests it should do.

```
SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type boolean: "2"
CONTEXT:  unnamed portal parameter $1 = '...' (Connection: pgsql, SQL: update "training_interests" set "expired" = 2, "updated_at" = 2026-05-19 14:46:06 where ("training_id" = 67 and "expired" = 0))
```

## Summary by Sourcery

Bug Fixes:
- Fix invalid boolean value updates on training interest records by always setting the expired flag to true instead of integer values.