### PR TITLE
ci: run prerelease release-please for prereleases

### DIFF
--- a/.github/release-please/release-please-config-alpha.json
+++ b/.github/release-please/release-please-config-alpha.json
@@ -8,7 +8,8 @@
   "packages": {
     ".": {
       "prerelease": true,
-      "prerelease-type": "alpha"
+      "prerelease-type": "alpha",
+      "versioning": "prerelease"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/.github/release-please/release-please-config-beta.json
+++ b/.github/release-please/release-please-config-beta.json
@@ -8,7 +8,8 @@
   "packages": {
     ".": {
       "prerelease": true,
-      "prerelease-type": "beta"
+      "prerelease-type": "beta",
+      "versioning": "prerelease"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/.github/release-please/release-please-config-rc.json
+++ b/.github/release-please/release-please-config-rc.json
@@ -8,7 +8,8 @@
   "packages": {
     ".": {
       "prerelease": true,
-      "prerelease-type": "rc"
+      "prerelease-type": "rc",
+      "versioning": "prerelease"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/.github/workflows/release-please-prerelease.yaml
+++ b/.github/workflows/release-please-prerelease.yaml
@@ -2,6 +2,11 @@
 name: Release (pre-release-please)
 
 on:
+  push:
+    branches:
+      - main
+      - ci/release-please
+
   workflow_dispatch:
     inputs:
       prerelease_type:
@@ -18,6 +23,10 @@ on:
         required: false
         default: "main"
         type: string
+      release_as:
+        description: "Version to release"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -26,30 +35,53 @@ permissions:
 jobs:
   release-please-prerelease:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' || (
+        contains(github.event.head_commit.message, 'release') && (
+          contains(github.event.head_commit.message, '-alpha') ||
+          contains(github.event.head_commit.message, '-beta') ||
+          contains(github.event.head_commit.message, '-rc')
+        )
+      )
     steps:
       - name: Run release-please (alpha)
-        if: ${{ github.event.inputs.prerelease_type == 'alpha' }}
-        uses: googleapis/release-please-action@v4
+        if: >-
+          github.event.inputs.prerelease_type == 'alpha' || (
+            github.event_name == 'push' &&
+            contains(github.event.head_commit.message, 'release') &&
+            contains(github.event.head_commit.message, '-alpha')
+          )
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.VATSCA_BOT_TOKEN }}
-          target-branch: ${{ github.event.inputs.target_branch }}
+          target-branch: ${{ github.event.inputs.target_branch || github.ref_name }}
           config-file: .github/release-please/release-please-config-alpha.json
-          versioning-strategy: prerelease
+          release-as: ${{ github.event.inputs.release_as }}
 
       - name: Run release-please (beta)
-        if: ${{ github.event.inputs.prerelease_type == 'beta' }}
-        uses: googleapis/release-please-action@v4
+        if: >-
+          github.event.inputs.prerelease_type == 'beta' || (
+            github.event_name == 'push' &&
+            contains(github.event.head_commit.message, 'release') &&
+            contains(github.event.head_commit.message, '-beta')
+          )
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.VATSCA_BOT_TOKEN }}
-          target-branch: ${{ github.event.inputs.target_branch }}
+          target-branch: ${{ github.event.inputs.target_branch || github.ref_name }}
           config-file: .github/release-please/release-please-config-beta.json
-          versioning-strategy: prerelease
+          release-as: ${{ github.event.inputs.release_as }}
 
       - name: Run release-please (rc)
-        if: ${{ github.event.inputs.prerelease_type == 'rc' }}
-        uses: googleapis/release-please-action@v4
+        if: >-
+          github.event.inputs.prerelease_type == 'rc' || (
+            github.event_name == 'push' &&
+            contains(github.event.head_commit.message, 'release') &&
+            contains(github.event.head_commit.message, '-rc')
+          )
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.VATSCA_BOT_TOKEN }}
-          target-branch: ${{ github.event.inputs.target_branch }}
+          target-branch: ${{ github.event.inputs.target_branch || github.ref_name }}
           config-file: .github/release-please/release-please-config-rc.json
-          versioning-strategy: prerelease
+          release-as: ${{ github.event.inputs.release_as }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -19,7 +19,15 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' || !(
+        contains(github.event.head_commit.message, 'release') && (
+          contains(github.event.head_commit.message, '-alpha') ||
+          contains(github.event.head_commit.message, '-beta') ||
+          contains(github.event.head_commit.message, '-rc')
+        )
+      )
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.VATSCA_BOT_TOKEN }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
   ],
   "packages": {
     ".": {
-      "prerelease": true
+      "prerelease": false,
+      "versioning": "prerelease"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Includes an important discovery: versioning-strategy is never passed from the action to the underlying library. Instead, use the undocumented manifest variable "versioning" to set the strategy to "prerelease".

## Summary by Sourcery

Configure separate CI workflows for stable and prerelease Release Please runs and upgrade to the latest action version.

CI:
- Trigger the prerelease Release Please workflow on pushes to main or ci/release-please with prerelease commit messages, in addition to manual dispatch.
- Ensure the main Release Please workflow is skipped for prerelease-tagged release commits and only handles stable releases.
- Upgrade all Release Please GitHub Action usages from v4 to v5.
- Allow prerelease workflow inputs to override the target branch and release version for alpha, beta, and rc releases.