### PR TITLE
feat(roles): introduce navigation editor support

### DIFF
--- a/app/Http/Controllers/Admin/PositionController.php
+++ b/app/Http/Controllers/Admin/PositionController.php
@@ -9,6 +9,7 @@ use App\Models\Area;
 use App\Models\Position;
 use App\Services\PositionService;
 use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class PositionController extends Controller
@@ -41,25 +42,43 @@ class PositionController extends Controller
 
         $position = Position::create($request->validated());
 
-        return redirect()->route('positions.index.area', $position->area_id)->with('success', 'Position ' . $position->callsign . ' created successfully.');
+        return $this->redirectAfterMutation($request, $position->area_id)
+            ->with('success', 'Position ' . $position->callsign . ' created successfully.');
     }
 
     public function update(PositionRequest $request, Position $position)
     {
         $this->authorize('update', $position);
-        $validatedData = $request->validated();
-        $position->update($validatedData);
 
-        return redirect()->route('positions.index.area', $position->area_id)->with('success', 'Position ' . $position->callsign . ' updated successfully.');
+        $validated = $request->validated();
+
+        if ($validated['area_id'] !== $position->area_id) {
+            $this->authorize('create', new Position(['area_id' => $validated['area_id']]));
+        }
+
+        $position->update($validated);
+
+        return $this->redirectAfterMutation($request, $position->area_id)
+            ->with('success', 'Position ' . $position->callsign . ' updated successfully.');
     }
 
-    public function destroy(Position $position)
+    public function destroy(Request $request, Position $position)
     {
         $this->authorize('delete', $position);
 
         $areaId = $position->area_id;
         $position->delete();
 
-        return redirect()->route('positions.index.area', $areaId)->with('success', 'Position ' . $position->callsign . ' deleted successfully.');
+        return $this->redirectAfterMutation($request, $areaId)
+            ->with('success', 'Position ' . $position->callsign . ' deleted successfully.');
+    }
+
+    private function redirectAfterMutation(Request $request, int $areaId): RedirectResponse
+    {
+        $route = $request->user()->hasRole('admin')
+            ? route('positions.index.area', $areaId)
+            : route('positions.index');
+
+        return redirect($route);
     }
 }

--- a/app/Policies/PositionPolicy.php
+++ b/app/Policies/PositionPolicy.php
@@ -8,11 +8,6 @@ use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Auth\Access\Response;
 
-/**
- * @todo Add a check to limit the positions that can be edited to only the ones that are in the user's area
- * @todo Introduce sector manager role that can edit positions in their sector
- * @todo Add a create rule when one exists
- */
 class PositionPolicy
 {
     use HandlesAuthorization;
@@ -33,21 +28,33 @@ class PositionPolicy
 
     public function update(User $user, Position $position): Response
     {
-        return Response::deny('You are not authorized to update this position.');
+        return $user->hasPermission('manage-positions', $position->area)
+            ? Response::allow()
+            : Response::deny('You are not authorized to update this position.');
     }
 
-    public function delete(User $user, Position $position): bool
+    public function delete(User $user, Position $position): Response
     {
-        return false;
+        return $user->hasPermission('manage-positions', $position->area)
+            ? Response::allow()
+            : Response::deny('You are not authorized to delete this position.');
     }
 
-    public function create(User $user, Position $position): bool
+    public function create(User $user, Position $position): Response
     {
-        return false;
+        // Resolve the area from area_id explicitly: $position->area is unreliable on
+        // unsaved models (e.g. when authorising a create with a transient Position).
+        $area = Area::find($position->area_id);
+
+        return $user->hasPermission('manage-positions', $area)
+            ? Response::allow()
+            : Response::deny('You are not authorized to create positions in this area.');
     }
 
-    public function createAny(User $user): bool
+    public function createAny(User $user): Response
     {
-        return false;
+        return $user->hasPermission('manage-positions')
+            ? Response::allow()
+            : Response::deny('You are not authorized to create positions.');
     }
 }

--- a/config/roles.php
+++ b/config/roles.php
@@ -21,6 +21,11 @@ return [
             'description' => 'Area moderator',
             'scope' => 'both',
         ],
+        'nav-editor' => [
+            'name' => 'Navigational Editor',
+            'description' => 'Editor of navigational and operationally relevant sector data',
+            'scope' => 'area',
+        ],
         'mentor' => [
             'name' => 'Mentor',
             'description' => 'Training mentor',
@@ -58,8 +63,10 @@ return [
         'manage-users' => ['admin', 'moderator'],
         'view-user-access' => ['admin', 'moderator'],
 
-        // Infrastructure
-        'manage-positions' => ['admin', 'moderator'],
+        // Operations
+        'manage-positions' => ['admin', 'moderator', 'nav-editor'],
+
+        // Endorsements
         'manage-endorsements' => ['admin', 'moderator'],
         'manage-visiting-endorsements' => ['admin'],
         'manage-examiner-endorsements' => ['admin'],

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -199,7 +199,7 @@
             </li>
         @endif
 
-        @can('manage-users')
+        @if(auth()->user()->canAny(['view-system-health', 'manage-users']) || auth()->user()->can('viewAny', App\Models\Position::class))
 
             {{-- Nav Item - Utilities Collapse Menu --}}
             <li class="nav-item {{ Route::is('admin.*') || Route::is('positions.*') || Route::is('vote.overview') ? 'active' : '' }}">

--- a/tests/Feature/PositionsTest.php
+++ b/tests/Feature/PositionsTest.php
@@ -18,11 +18,11 @@ class PositionsTest extends TestCase
 
     private User $admin;
 
-    private User $moderator;
+    private User $permittedUser;
 
     private User $user;
 
-    private Area $moderatorArea;
+    private Area $permittedArea;
 
     private Area $area2;
 
@@ -39,21 +39,21 @@ class PositionsTest extends TestCase
         // Assume that we've already got group 1 and 2
 
         // Create Areas
-        $this->moderatorArea = Area::factory()->create();
+        $this->permittedArea = Area::factory()->create();
         $this->area2 = Area::factory()->create();
 
         // Create Users
         $this->admin = User::factory()->create();
-        $this->admin->roleAssignments()->create(['role' => 'admin', 'area_id' => $this->moderatorArea->id]);
+        $this->admin->roleAssignments()->create(['role' => 'admin', 'area_id' => $this->permittedArea->id]);
 
-        $this->moderator = User::factory()->create();
+        $this->permittedUser = User::factory()->create();
         $this->user = User::factory()->create();
 
-        // Assign moderator to area 1
-        $this->moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $this->moderatorArea->id]);
+        // Assign navigational editor to area 1
+        $this->permittedUser->roleAssignments()->create(['role' => 'nav-editor', 'area_id' => $this->permittedArea->id]);
 
         // Create Position in area 1
-        $this->existingPosition = Position::factory()->create(['area_id' => $this->moderatorArea->id]);
+        $this->existingPosition = Position::factory()->create(['area_id' => $this->permittedArea->id]);
 
         // Create Position in area 2
         $this->existingPositionOther = Position::factory()->create(['area_id' => $this->area2->id]);
@@ -64,7 +64,7 @@ class PositionsTest extends TestCase
             'frequency' => '123.450',
             'fir' => 'TEST',
             'rating' => VatsimRating::S3->value,
-            'area_id' => $this->moderatorArea->id,
+            'area_id' => $this->permittedArea->id,
         ];
     }
 
@@ -108,24 +108,23 @@ class PositionsTest extends TestCase
     }
     // endregion
 
-    // region Moderator tests
+    // region Permitted user tests
     #[Test]
-    public function moderator_can_view_index()
+    public function permitted_user_can_view_index()
     {
-        $response = $this->actingAs($this->moderator)->get(route('positions.index'));
+        $response = $this->actingAs($this->permittedUser)->get(route('positions.index'));
         $response->assertOk();
         $response->assertViewHas('positions');
         $response->assertViewHas('ratings');
         $response->assertViewHas('areas', function ($areas) {
-            return $areas->contains($this->moderatorArea) && ! $areas->contains($this->area2);
+            return $areas->contains($this->permittedArea) && ! $areas->contains($this->area2);
         });
     }
 
     #[Test]
-    public function moderator_can_store_position_in_managed_area()
+    public function permitted_user_can_store_position_in_managed_area()
     {
-        $this->markTestIncomplete('sector moderator not implemented');
-        $this->actingAs($this->moderator)
+        $this->actingAs($this->permittedUser)
             ->post(route('positions.store'), $this->positionData)
             ->assertRedirect(route('positions.index'));
 
@@ -133,18 +132,17 @@ class PositionsTest extends TestCase
     }
 
     #[Test]
-    public function moderator_is_forbidden_to_store_position_in_unmanaged_area()
+    public function permitted_user_is_forbidden_to_store_position_in_unmanaged_area()
     {
         $data = array_merge($this->positionData, ['area_id' => $this->area2->id]);
-        $this->actingAs($this->moderator)->post(route('positions.store'), $data)->assertForbidden();
+        $this->actingAs($this->permittedUser)->post(route('positions.store'), $data)->assertForbidden();
     }
 
     #[Test]
-    public function moderator_can_update_position_in_managed_area()
+    public function permitted_user_can_update_position_in_managed_area()
     {
-        $this->markTestIncomplete('sector moderator not implemented');
         $data = array_merge($this->positionData, ['name' => 'Updated Name']);
-        $this->actingAs($this->moderator)
+        $this->actingAs($this->permittedUser)
             ->put(route('positions.update', $this->existingPosition), $data)
             ->assertRedirect(route('positions.index'));
 
@@ -152,18 +150,31 @@ class PositionsTest extends TestCase
     }
 
     #[Test]
-    public function moderator_is_forbidden_to_update_position_in_unmanaged_area()
+    public function permitted_user_is_forbidden_to_update_position_in_unmanaged_area()
     {
         $positionInArea2 = Position::factory()->create(['area_id' => $this->area2->id]);
         $data = array_merge($this->positionData, ['name' => 'Updated Name']);
-        $this->actingAs($this->moderator)->put(route('positions.update', $positionInArea2), $data)->assertForbidden();
+        $this->actingAs($this->permittedUser)->put(route('positions.update', $positionInArea2), $data)->assertForbidden();
     }
 
     #[Test]
-    public function moderator_can_destroy_position_in_managed_area()
+    public function permitted_user_is_forbidden_to_move_position_to_another_area()
     {
-        $this->markTestIncomplete('sector moderator not implemented');
-        $this->actingAs($this->moderator)
+        $data = array_merge($this->positionData, ['area_id' => $this->area2->id]);
+        $this->actingAs($this->permittedUser)
+            ->put(route('positions.update', $this->existingPosition), $data)
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('positions', [
+            'id' => $this->existingPosition->id,
+            'area_id' => $this->permittedArea->id,
+        ]);
+    }
+
+    #[Test]
+    public function permitted_user_can_destroy_position_in_managed_area()
+    {
+        $this->actingAs($this->permittedUser)
             ->delete(route('positions.destroy', $this->existingPosition))
             ->assertRedirect(route('positions.index'));
 
@@ -171,25 +182,25 @@ class PositionsTest extends TestCase
     }
 
     #[Test]
-    public function moderator_can_view_required_endorsement_in_modal()
+    public function permitted_user_can_view_required_endorsement_in_modal()
     {
         $rating = \App\Models\Rating::factory()->create(['name' => 'Test Endorsement']);
         Position::factory()->create([
-            'area_id' => $this->moderatorArea->id,
+            'area_id' => $this->permittedArea->id,
             'required_facility_rating_id' => $rating->id,
         ]);
 
-        $this->actingAs($this->moderator)
+        $this->actingAs($this->permittedUser)
             ->get(route('positions.index'))
             ->assertOk()
             ->assertSee($rating->name);
     }
 
     #[Test]
-    public function moderator_is_forbidden_to_destroy_position_in_unmanaged_area()
+    public function permitted_user_is_forbidden_to_destroy_position_in_unmanaged_area()
     {
         $positionInArea2 = Position::factory()->create(['area_id' => $this->area2->id]);
-        $this->actingAs($this->moderator)->delete(route('positions.destroy', $positionInArea2))->assertForbidden();
+        $this->actingAs($this->permittedUser)->delete(route('positions.destroy', $positionInArea2))->assertForbidden();
     }
     // endregion
 
@@ -380,8 +391,8 @@ class PositionsTest extends TestCase
         $otherModerator = User::factory()->create();
         $otherModerator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $this->area2->id]); // Moderator of Area 2
 
-        // Case 1: Explicitly requesting Area 1 (moderatorArea) should be forbidden
-        $response = $this->actingAs($otherModerator)->get(route('positions.index.area', $this->moderatorArea->id));
+        // Case 1: Explicitly requesting Area 1 (permittedArea) should be forbidden
+        $response = $this->actingAs($otherModerator)->get(route('positions.index.area', $this->permittedArea->id));
         $response->assertForbidden();
 
         // Case 2: General Index should only show Area 2 positions


### PR DESCRIPTION
Allows other users the designation of Navigation Editor to edit position-related data.

- refactor: normalize PositionPolicy return types to Response
- fix: only move positions between areas if they're correct
- refactor: extract redirect-after-mutation helper in PositionController
- fix: address review feedback on area-move guard, policy, and tests

## Summary by Sourcery

Allow navigation editors to manage positions while tightening area-based authorization and navigation flows.

New Features:
- Introduce a navigation editor role that can manage position-related data within an assigned area.
- Expose position management navigation in the sidebar to users authorized to view system health, manage users, or view positions.

Bug Fixes:
- Prevent position updates from moving positions between areas without appropriate authorization.
- Ensure redirection after position mutations respects non-admin users by sending them to the general positions index instead of area-specific views when appropriate.

Enhancements:
- Align PositionPolicy methods to consistently return authorization Response objects and base permissions on the manage-positions ability.
- Refine tests to cover navigation editor capabilities and restrictions, including area scoping and forbidden cross-area operations.