### PR TITLE
docs(permissions): document new role-based permission system

### DIFF
--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -2,36 +2,38 @@
 icon: material/shield-account
 ---
 
-# Permissions and Groups
+# Roles and Permissions
 
-Control Center uses a flexible system of groups and areas to manage user permissions. This allows for global and granular control over different parts.
+Control Center grants access through **roles**, **areas**, and a configurable **permission matrix**. This page covers how those pieces fit together; for the default roles, the shipped matrix, and how to customise them, see the [Roles and Permissions Reference](../reference/permissions.md).
 
-## Overview
+## The Three Layers
 
-Permissions are not assigned directly to users. Instead, users are assigned to one or more **groups**, and those groups are what grant permissions. For many administrative roles, these permissions are further scoped to a specific **area**.
+The system has three layers, intentionally separated so an operator can shift policy without changing code:
 
-## Key Concepts
+1. **Roles** describe what kind of contributor a user is — administrator, moderator, mentor, and so on. A role is an identifier you can assign to a user, optionally inside an area.
+2. **Permissions** describe individual capabilities — `manage-positions`, `view-management-reports`, and the like. They are not assigned to users directly; they are defined in a **matrix** that maps each permission to the roles that may exercise it.
+3. **Areas** scope a role assignment to part of the division (an ARTCC, a vACC, a sector group). The same user can hold the same role in several areas at once, in a single area, or globally.
 
-### Groups
+Both the role list and the matrix live in `config/roles.php`. Granting a role to a new permission, retiring a role, or introducing a new role is a configuration change, not a code change or migration.
 
-Groups are the primary way to define a set of permissions. The default groups in Control Center include:
+## How a Check Resolves
 
-- **Administrator**: Has unrestricted access to all features and all areas.
-- **Moderator**: Has administrative permissions, but they are typically restricted to one or more specific areas.
-- **Mentor**: Can manage training sessions, view student progress, and create tasks. Their permissions are also often scoped to an area.
-- **Member**: The default group for all users, granting basic access to user-facing features like booking ATC slots.
+Authorisation asks two questions when checking a permission:
 
-### Areas
+1. **Does the user hold a role that grants this permission?** The matrix is consulted to find which roles satisfy it.
+2. **Does at least one of those role assignments cover the relevant area?** If the action targets an area, the assignment must either be in that area or be a global one. Area-agnostic actions only need the role somewhere.
 
-Areas are used to represent organizational units within your division, such as an ARTCC, a vACC, or a specific region. By assigning moderators or mentors to a specific area, you limit their administrative powers to only the users and resources (like positions) within that area.
+The matrix is authoritative: a permission that is not listed grants no role — even `admin`. The familiar "administrators can do anything" behaviour is a **per-policy convention**, implemented as a `before` hook in individual policy classes (for example `PositionPolicy::before()` returns `true` when the user holds `admin`). Resources whose policies install that hook let admins through regardless of the matrix; gates and policies without it are bound strictly by it.
 
-## How it Works
+### Example
 
-When a user attempts to perform an action, the system checks two things:
+> A user holds `nav-editor` in Area A.
+>
+> - Editing a position in **Area A** — allowed: `manage-positions` includes `nav-editor`, and the assignment matches the position's area.
+> - Editing a position in **Area B** — denied: the role assignment does not cover Area B.
+> - Moving a position from **Area A to Area B** — denied unless the user also holds `nav-editor` (or another role granting `manage-positions`) in Area B.
 
-1. Is the user in a group that has permission for this action?
-2. If the action is area-specific (like editing a position), does the user's group membership apply to that area?
+## Next Steps
 
-For example, a user who is a **Moderator** for "Area A" can edit positions in "Area A", but cannot edit positions in "Area B" unless they are also a moderator for "Area B".
-
-System administrators are a special case, as their permissions bypass any area-specific checks.
+- The [Roles and Permissions Reference](../reference/permissions.md) lists every shipped role, the full default permission matrix, and the steps to customise them.
+- `config/roles.php` is the source of truth in the codebase.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -121,13 +121,14 @@ nav:
           - Mentoring: concepts/mentors.md
           - Ratings: concepts/ratings.md
           - Positions: concepts/positions.md
-          - Permissions and Groups: concepts/permissions.md
+          - Roles and Permissions: concepts/permissions.md
   - Reference:
       - Activity: activity.md
       - Contribute: contribute.md
       - API: api.md
       - Background jobs: background-jobs.md
       - Environment variables: reference/environment-variables.md
+      - Roles and Permissions: reference/permissions.md
       - Upgrading: upgrade.md
   - Integrations:
       # Insert discord.md and others here

--- a/docs/reference/permissions.md
+++ b/docs/reference/permissions.md
@@ -1,0 +1,93 @@
+---
+icon: material/file-tree
+---
+
+# Roles and Permissions Reference
+
+The catalogue of roles, permissions, and configuration knobs that ship with Control Center. For the conceptual picture and a worked example, see [Roles and Permissions](../concepts/permissions.md).
+
+## Default Roles
+
+| Role | Scope | Description |
+| --- | --- | --- |
+| `admin` | `global` | System-wide administrator. Bypasses area checks (via the per-policy `before` hook) and is expected to be listed against every permission you want unrestricted. |
+| `moderator` | `both` | Area moderator. Manages users, reports, positions, and endorsements within the assigned area, or system-wide if assigned globally. |
+| `nav-editor` | `area` | Navigational editor. May edit operationally relevant sector data such as positions within the assigned area. |
+| `mentor` | `area` | Training mentor. Can manage and view training within the assigned area. |
+| `buddy` | `area` | Training buddy. Limited training visibility within the assigned area. |
+
+### Role Scope
+
+The `scope` field on a role restricts where assignments are allowed:
+
+- `global` — only system-wide assignments (no `area_id`).
+- `area` — only area-scoped assignments (`area_id` required).
+- `both` — either; an area-less assignment behaves as system-wide.
+
+## Default Permission Matrix
+
+The matrix in `config/roles.php`:
+
+```php
+'matrix' => [
+    // Training
+    'view-training' => ['admin', 'moderator', 'mentor', 'buddy'],
+    'create-training' => ['admin', 'moderator', 'mentor'],
+    'update-training' => ['admin', 'moderator'],
+    'delete-training' => ['admin'],
+
+    // Area & system
+    'manage-area' => ['admin'],
+    'view-system-health' => ['admin'],
+
+    // Users & access
+    'manage-users' => ['admin', 'moderator'],
+    'view-user-access' => ['admin', 'moderator'],
+
+    // Operations
+    'manage-positions' => ['admin', 'moderator', 'nav-editor'],
+
+    // Endorsements
+    'manage-endorsements' => ['admin', 'moderator'],
+    'manage-visiting-endorsements' => ['admin'],
+    'manage-examiner-endorsements' => ['admin'],
+
+    // Reports
+    'view-management-reports' => ['admin', 'moderator'],
+    'view-training-activities' => ['admin', 'moderator'],
+    'view-training-statistics' => ['admin', 'moderator'],
+    'view-mentor-reports' => ['admin', 'moderator', 'mentor'],
+
+    // Bookings
+    'bypass-booking-restrictions' => ['admin', 'moderator', 'mentor'],
+],
+```
+
+A permission that is not listed in the matrix grants no role — `admin` included. The "administrators can do anything" behaviour is a per-policy convention (a `before` hook), not a property of the matrix.
+
+## Customising Roles and Permissions
+
+`config/roles.php` is the single source of truth.
+
+- **Rewire** an existing permission by changing the role list for that key in the `matrix` block. Example: drop `mentor` from `bypass-booking-restrictions` to tighten booking enforcement.
+- **Add** a new role by adding an entry under `roles` with a `name`, `description`, and `scope`, then add it to whichever permissions it should hold in the `matrix`.
+- **Remove** a role you don't use by deleting it from `roles`, dropping it from any permission lists in the `matrix`, and clearing its assignments from the `role_user` table.
+
+After changing the file, clear the config cache so the new mapping is picked up:
+
+```sh
+php artisan optimize:clear
+```
+
+## Storage: the `role_user` Table
+
+User role assignments live in the `role_user` table.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `user_id` | unsigned bigint | The assignee. |
+| `role` | string | Must match a key in `config/roles.php` for the assignment to grant anything. |
+| `area_id` | unsigned int (nullable) | `null` for global assignments. |
+| `created_at`, `updated_at` | timestamps | |
+
+A unique constraint covers `(user_id, role, area_id)`.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -73,6 +73,32 @@ If you had customized colors in your `.env` file:
 For detailed information on using themes as an end-user, see the [User Theme Guide](user-themes.md).  
 For customizing themes as an operator, see [Theme Setup](setup/theme.md)
 
+### Permissions and Roles Refactor
+
+The permission and group system has been rebuilt around a configurable role matrix. See [Permissions and Roles](concepts/permissions.md) for the new model.
+
+#### Breaking Changes
+
+1. **Database tables replaced**: The `groups` and `permissions` tables are dropped. User assignments now live in a single `role_user` table that stores the role name as a string and an optional `area_id` (null for global roles).
+2. **Permissions are no longer stored in the database**: They are defined in `config/roles.php` as a *matrix* that maps each permission to the list of roles that hold it. Editing roles or permissions now means editing that file (and clearing config cache), not the database.
+3. **Admins are now strictly global**: Any `area_id` previously attached to an admin assignment is discarded by the migration. An admin assignment without a target area applies system-wide.
+4. **Custom groups are not migrated**: Only the four standard groups (Administrator, Moderator, Mentor, Buddy) are converted to roles. Any custom group rows you added directly to the `groups` or `permissions` tables will be dropped along with the tables. Note them down before upgrading and re-create them as roles in `config/roles.php` afterwards.
+5. **The `nav-editor` role is new in this version**: It ships in `config/roles.php` (see [Permissions and Roles](concepts/permissions.md)) but is not derived from any legacy group, so no users will be auto-assigned to it during the migration. Grant it explicitly to whoever needs to edit navigational data within an area.
+
+#### Migration Steps
+
+1. **Audit any custom groups** you may have added outside the four defaults; capture their members so you can re-grant access after the upgrade.
+2. **Run the database migration**:
+   ```sh
+   php artisan migrate
+   ```
+   This creates `role_user`, copies the four standard groups across, and drops the old tables.
+3. **Review `config/roles.php`** and adjust the matrix if your division wants different permissions per role, or wants to add roles beyond the defaults.
+4. **Clear caches**:
+   ```sh
+   php artisan optimize:clear
+   ```
+
 ## Upgrading to 6.0.0
 
 This release contains breaking changes and requires you to backup your data before upgrading.


### PR DESCRIPTION
Fixes #1472.

Rewrite the permission page around roles, include the config-driven permission matrix, role scope (global/area/both), list the five default roles with their scopes, document how authorisation is resolved, and how to rewire or extend the matrix.

Includes a breaking change notice for the permissions refactor, plus migration steps.

## Summary by Sourcery

Document the new configurable, role-based permission system and its migration path from the old groups/permissions model.

Documentation:
- Rewrite the permissions concept page around roles, areas, and the config-driven permission matrix, including default roles, scopes, and authorisation flow.
- Add documentation on customising roles and permissions via config, including how role assignments are stored.
- Update navigation labels to refer to the new roles-based permissions documentation.

Chores:
- Add upgrade notes describing the permissions and roles refactor, including breaking changes and migration steps from database-driven groups to config-based roles.