### PR TITLE
feat(feedback): restrict correlated feedback to roles' area

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -238,13 +238,35 @@ class ReportController extends Controller
     /**
      * Index received feedback
      *
-     * @return \Illuminate\View\View
+     * @todo Convert or consider moving out of the ReportController, with slightly
+     *       cleaner separation of concerns.
+     * @todo Simplify & scope the permission names.
+     * @todo Attach controllers (reference users) to a set of areas based on their
+     *       activity, so that position-less feedback can be correlated to an area
+     *       via the controller for whom the feedback applies.
      */
-    public function feedback()
+    public function feedback(): View
     {
         $this->authorize('viewFeedback', ManagementReport::class);
 
-        $feedback = Feedback::latest()->get();
+        $user = auth()->user();
+        $correlatedScope = $user->accessibleAreasForPermission('view-correlated-feedback');
+        $canViewUncorrelated = $user->accessibleAreasForPermission('view-uncorrelated-feedback')->hasAccess();
+
+        $feedback = Feedback::with(['submitter', 'referenceUser', 'referencePosition.area'])
+            ->latest()
+            ->where(function ($q) use ($correlatedScope, $canViewUncorrelated) {
+                if ($correlatedScope->isGlobal) {
+                    $q->whereNotNull('reference_position_id');
+                } else {
+                    $q->whereHas('referencePosition', fn ($q) => $q->whereIn('area_id', $correlatedScope->areas->pluck('id')));
+                }
+
+                if ($canViewUncorrelated) {
+                    $q->orWhereNull('reference_position_id');
+                }
+            })
+            ->get();
 
         return view('reports.feedback', compact('feedback'));
     }

--- a/app/Policies/ManagementReportPolicy.php
+++ b/app/Policies/ManagementReportPolicy.php
@@ -50,11 +50,10 @@ class ManagementReportPolicy
 
     /** Determine whether the user can see the feedback index
      *
-     * @return bool
      */
-    public function viewFeedback(User $user)
+    public function viewFeedback(User $user): bool
     {
-        return $user->hasPermission('view-management-reports');
+        return $user->accessibleAreasForPermission('view-correlated-feedback')->hasAccess();
     }
 
     /**

--- a/config/roles.php
+++ b/config/roles.php
@@ -77,6 +77,10 @@ return [
         'view-training-statistics' => ['admin', 'moderator'],
         'view-mentor-reports' => ['admin', 'moderator', 'mentor'],
 
+        // Feedback
+        'view-correlated-feedback' => ['admin', 'moderator'],
+        'view-uncorrelated-feedback' => ['admin', 'moderator'],
+
         // Bookings
         'bypass-booking-restrictions' => ['admin', 'moderator', 'mentor'],
     ],

--- a/database/factories/FeedbackFactory.php
+++ b/database/factories/FeedbackFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Feedback;
+use App\Models\Position;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Feedback>
+ */
+class FeedbackFactory extends Factory
+{
+    protected $model = Feedback::class;
+
+    public function definition(): array
+    {
+        return [
+            'submitter_user_id' => User::factory(),
+            'reference_user_id' => User::factory(),
+            'reference_position_id' => Position::factory(),
+            'feedback' => $this->faker->paragraph(),
+            'forwarded' => false,
+        ];
+    }
+
+    public function uncorrelated(): static
+    {
+        return $this->state(['reference_position_id' => null]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Helpers\FactoryHelper;
 use App\Helpers\TrainingStatus;
 use App\Models\Endorsement;
+use App\Models\Feedback;
 use App\Models\Position;
 use App\Models\Rating;
 use App\Models\Training;
@@ -126,6 +127,28 @@ class DatabaseSeeder extends Seeder
             User::factory()->create([
                 'id' => 10000000 + $i,
             ]);
+        }
+
+        // Seed feedback entries with a mix of correlated and uncorrelated
+        $users = User::inRandomOrder()->limit(30)->get();
+        $positions = Position::inRandomOrder()->limit(10)->get();
+
+        for ($i = 0; $i < 20; $i++) {
+            $submitter = $users->random();
+            $referenceUser = $users->random();
+
+            if ($positions->isNotEmpty() && rand(0, 3) > 0) {
+                Feedback::factory()->create([
+                    'submitter_user_id' => $submitter->id,
+                    'reference_user_id' => $referenceUser->id,
+                    'reference_position_id' => $positions->random()->id,
+                ]);
+            } else {
+                Feedback::factory()->uncorrelated()->create([
+                    'submitter_user_id' => $submitter->id,
+                    'reference_user_id' => $referenceUser->id,
+                ]);
+            }
         }
 
         // Populate trainings and other of the Scandinavian users

--- a/resources/views/reports/feedback.blade.php
+++ b/resources/views/reports/feedback.blade.php
@@ -34,6 +34,7 @@
                                 <th data-field="submitter" data-sortable="true" data-filter-control="input">Submitter</th>
                                 <th data-field="controller" data-sortable="true" data-filter-control="select">Controller</th>
                                 <th data-field="position" data-sortable="true" data-filter-control="select">Position</th>
+                                <th data-field="area" data-sortable="true" data-filter-control="select">Area</th>
                                 <th data-field="feedback" data-sortable="false" data-filter-control="input">Feedback</th>
                             </tr>
                         </thead>
@@ -56,6 +57,7 @@
                                             N/A
                                         @endisset
                                     </td>
+                                    <td>{{ $f->referencePosition?->area?->name ?? 'N/A' }}</td>
                                     <td>
                                         {!! nl2br($f->feedback) !!}
                                     </td>

--- a/tests/Feature/ReportControllerTest.php
+++ b/tests/Feature/ReportControllerTest.php
@@ -183,4 +183,122 @@ class ReportControllerTest extends TestCase
 
         $response->assertForbidden();
     }
+
+    #[Test]
+    public function area_moderator_can_access_feedback_page(): void
+    {
+        $area = Area::factory()->create();
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $response = $this->actingAs($moderator)->get(route('reports.feedback'));
+
+        $response->assertOk();
+    }
+
+    #[Test]
+    public function user_without_role_gets_403_on_feedback_page(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('reports.feedback'));
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function admin_sees_all_feedback(): void
+    {
+        $area1 = Area::factory()->create();
+        $area2 = Area::factory()->create();
+
+        $position1 = \App\Models\Position::factory()->create(['area_id' => $area1->id]);
+        $position2 = \App\Models\Position::factory()->create(['area_id' => $area2->id]);
+
+        $feedbackArea1 = \App\Models\Feedback::factory()->create(['reference_position_id' => $position1->id]);
+        $feedbackArea2 = \App\Models\Feedback::factory()->create(['reference_position_id' => $position2->id]);
+        $feedbackUncorrelated = \App\Models\Feedback::factory()->uncorrelated()->create();
+
+        $response = $this->actingAs($this->adminUser)->get(route('reports.feedback'));
+
+        $response->assertOk();
+        $response->assertViewHas('feedback', function ($feedback) use ($feedbackArea1, $feedbackArea2, $feedbackUncorrelated) {
+            return $feedback->contains($feedbackArea1)
+                && $feedback->contains($feedbackArea2)
+                && $feedback->contains($feedbackUncorrelated);
+        });
+    }
+
+    #[Test]
+    public function moderator_sees_only_their_area_correlated_feedback(): void
+    {
+        $area1 = Area::factory()->create();
+        $area2 = Area::factory()->create();
+
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area1->id]);
+
+        $position1 = \App\Models\Position::factory()->create(['area_id' => $area1->id]);
+        $position2 = \App\Models\Position::factory()->create(['area_id' => $area2->id]);
+
+        $feedbackInArea = \App\Models\Feedback::factory()->create(['reference_position_id' => $position1->id]);
+        $feedbackOtherArea = \App\Models\Feedback::factory()->create(['reference_position_id' => $position2->id]);
+
+        $response = $this->actingAs($moderator)->get(route('reports.feedback'));
+
+        $response->assertOk();
+        $response->assertViewHas('feedback', function ($feedback) use ($feedbackInArea, $feedbackOtherArea) {
+            return $feedback->contains($feedbackInArea)
+                && ! $feedback->contains($feedbackOtherArea);
+        });
+    }
+
+    #[Test]
+    public function moderator_sees_uncorrelated_feedback(): void
+    {
+        $area = Area::factory()->create();
+
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $feedbackUncorrelated = \App\Models\Feedback::factory()->uncorrelated()->create();
+
+        $response = $this->actingAs($moderator)->get(route('reports.feedback'));
+
+        $response->assertOk();
+        $response->assertViewHas('feedback', fn ($feedback) => $feedback->contains($feedbackUncorrelated));
+    }
+
+    #[Test]
+    public function moderator_does_not_see_other_area_feedback(): void
+    {
+        $area1 = Area::factory()->create();
+        $area2 = Area::factory()->create();
+
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area1->id]);
+
+        $position2 = \App\Models\Position::factory()->create(['area_id' => $area2->id]);
+        $feedbackOtherArea = \App\Models\Feedback::factory()->create(['reference_position_id' => $position2->id]);
+
+        $response = $this->actingAs($moderator)->get(route('reports.feedback'));
+
+        $response->assertOk();
+        $response->assertViewHas('feedback', fn ($feedback) => ! $feedback->contains($feedbackOtherArea));
+    }
+
+    #[Test]
+    public function feedback_page_shows_area_column(): void
+    {
+        $area = Area::factory()->create(['name' => 'Test Area']);
+        $position = \App\Models\Position::factory()->create(['area_id' => $area->id]);
+        \App\Models\Feedback::factory()->create(['reference_position_id' => $position->id]);
+        \App\Models\Feedback::factory()->uncorrelated()->create();
+
+        $response = $this->actingAs($this->adminUser)->get(route('reports.feedback'));
+
+        $response->assertOk();
+        $response->assertSee('Test Area');
+        $response->assertSee('Unknown');
+    }
 }

--- a/tests/Feature/ReportControllerTest.php
+++ b/tests/Feature/ReportControllerTest.php
@@ -299,6 +299,6 @@ class ReportControllerTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('Test Area');
-        $response->assertSee('Unknown');
+        $response->assertSee('N/A');
     }
 }


### PR DESCRIPTION
Fixes #1394. Supersedes #1387.

The feedback report is now scoped to area: moderators only see feedback
tied to positions in their area(s), while uncorrelated feedback (no
position attached) is visible to all moderators under a dedicated
permission that can be tightened later. Admins see everything. A new
Area column in the table shows the area name or "Unknown" for
uncorrelated entries.

## Summary by Sourcery

Restrict the feedback report to role- and area-based access while exposing appropriate data to admins and enhancing the report view.

New Features:
- Introduce area-scoped access control for correlated feedback based on user roles and area assignments.
- Add separate permissions for viewing correlated and uncorrelated feedback in the feedback report.
- Display the area associated with feedback entries in the feedback report table, showing a fallback label for uncorrelated feedback.

Enhancements:
- Refine the feedback report query to eager-load related models and apply conditional area and correlation filters.
- Seed sample correlated and uncorrelated feedback data to better support development and testing.
- Add a factory for creating feedback records with support for correlated and uncorrelated variants.

Tests:
- Expand report controller feature tests to cover feedback access control by role and area and to verify the new area column output.