### PR TITLE
ci: try to avoid double push/pull_request jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,10 @@ on:
     paths-ignore:
       - "**.md"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   IMAGE_NAME: vatsim-scandinavia/control-center
   TARGET_PLATFORMS: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure GitHub Actions concurrency grouping and in-progress run cancellation to avoid double execution of push and pull_request jobs.