### PR TITLE
fix(booking): use highest vatsim rating for combined training bookings

### DIFF
--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -56,7 +56,7 @@ class BookingController extends Controller
 
         if ($user->getActiveTraining(TrainingStatus::PRE_TRAINING->value)) {
             $positions = $positions->merge(
-                $user->getActiveTraining()->area->positions->where('rating', '<=', $user->getActiveTraining()->ratings()->first()->vatsim_rating)
+                $user->getActiveTraining()->area->positions->where('rating', '<=', $user->getActiveTraining()->getHighestVatsimRating()?->vatsim_rating)
             );
         }
 

--- a/app/Policies/BookingPolicy.php
+++ b/app/Policies/BookingPolicy.php
@@ -112,7 +112,7 @@ class BookingPolicy
         if (($booking->position->rating->value > $user->rating || $user->rating < VatsimRating::S1->value) && ! $user->hasRole('moderator')) {
             if (
                 $user->getActiveTraining(TrainingStatus::PRE_TRAINING->value) &&
-                ($user->getActiveTraining()->ratings()->first()->vatsim_rating >= $booking->position->rating->value || $user->getActiveTraining()->isFacilityTraining()) &&
+                ($user->getActiveTraining()->getHighestVatsimRating()?->vatsim_rating >= $booking->position->rating->value || $user->getActiveTraining()->isFacilityTraining()) &&
                 $user->getActiveTraining()->area->id === $booking->position->area->id
             ) {
                 return true;

--- a/tests/Feature/BookingTest.php
+++ b/tests/Feature/BookingTest.php
@@ -97,6 +97,31 @@ class BookingTest extends TestCase
     }
 
     #[Test]
+    public function student_with_combined_training_can_book_position_for_highest_rating(): void
+    {
+        $student = User::factory()->create([
+            'rating' => VatsimRating::S1->value,
+        ]);
+
+        // Combined S1+S2 training: the lower rating is attached first so an
+        // unordered ratings query would return S1 instead of S2.
+        $training = Training::factory()
+            ->has(Rating::factory(['vatsim_rating' => VatsimRating::S1]))
+            ->create(['user_id' => $student->id, 'type' => 1, 'status' => 2, 'area_id' => TEST_USER_TRAINING_AREA]);
+        $training->ratings()->save(Rating::factory()->create(['vatsim_rating' => VatsimRating::S2]));
+
+        $position = Position::factory()->create([
+            'rating' => VatsimRating::S2->value,
+            'callsign' => 'TEST_TWR',
+            'name' => 'Test Tower',
+            'area_id' => TEST_USER_TRAINING_AREA,
+        ]);
+
+        $this->assertCreateBookingAvailable($student, $position);
+        $this->createBooking($student, $position)->assertValid();
+    }
+
+    #[Test]
     public function controller_cannot_delete_discord_booking(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
Fixes #1329.

Students with a combined training (e.g. S1+S2) were denied bookings for positions matching their highest training rating, because both BookingPolicy::position() and BookingController::getBookablePositions() read an arbitrary rating via ratings()->first(). Use the existing Training::getHighestVatsimRating() instead.

## Summary by Sourcery

Allow students with combined training ratings to book positions according to their highest eligible training rating.

Bug Fixes:
- Use the highest VATSIM training rating for booking eligibility checks instead of an arbitrary first rating, ensuring combined-training students can book positions matching their top rating.

Tests:
- Add a feature test verifying that a student with combined S1+S2 training can successfully book a position requiring the higher S2 rating.