### PR TITLE
fix(booking): facility training no longer bypasses position rating check

### DIFF
--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -97,7 +97,7 @@ class Training extends Model
     public function getInlineRatings(bool $vatsimRatingOnly = false): string
     {
         $ratings = $vatsimRatingOnly
-            ? $this->ratings->where('vatsim_rating', true)
+            ? $this->ratings->whereNotNull('vatsim_rating')
             : $this->ratings;
 
         return $ratings->pluck('name')->implode(' + ');
@@ -116,7 +116,7 @@ class Training extends Model
      */
     public function isFacilityTraining(): bool
     {
-        return $this->ratings->contains(fn ($rating) => $rating->vatsim_rating == null);
+        return $this->ratings->whereNull('vatsim_rating')->isNotEmpty();
     }
 
     /**
@@ -124,7 +124,7 @@ class Training extends Model
      */
     public function hasVatsimRatings(): bool
     {
-        return $this->ratings->contains(fn ($rating) => $rating->vatsim_rating != null);
+        return $this->ratings->whereNotNull('vatsim_rating')->isNotEmpty();
     }
 
     /**
@@ -132,7 +132,7 @@ class Training extends Model
      */
     public function getHighestVatsimRating(): ?Rating
     {
-        return $this->ratings->where('vatsim_rating', true)->sortByDesc('vatsim_rating')->first();
+        return $this->ratings->whereNotNull('vatsim_rating')->sortByDesc('vatsim_rating')->first();
     }
 
     /**

--- a/app/Policies/BookingPolicy.php
+++ b/app/Policies/BookingPolicy.php
@@ -112,7 +112,7 @@ class BookingPolicy
         if (($booking->position->rating->value > $user->rating || $user->rating < VatsimRating::S1->value) && ! $user->hasRole('moderator')) {
             if (
                 $user->getActiveTraining(TrainingStatus::PRE_TRAINING->value) &&
-                ($user->getActiveTraining()->getHighestVatsimRating()?->vatsim_rating >= $booking->position->rating->value || $user->getActiveTraining()->isFacilityTraining()) &&
+                $user->getActiveTraining()->getHighestVatsimRating()?->vatsim_rating >= $booking->position->rating->value &&
                 $user->getActiveTraining()->area->id === $booking->position->area->id
             ) {
                 return true;

--- a/tests/Feature/BookingTest.php
+++ b/tests/Feature/BookingTest.php
@@ -103,12 +103,13 @@ class BookingTest extends TestCase
             'rating' => VatsimRating::S1->value,
         ]);
 
-        // Combined S1+S2 training: the lower rating is attached first so an
-        // unordered ratings query would return S1 instead of S2.
+        // Combined S1+S2+facility training: the lower rating is attached first
+        // so an unordered ratings query would return S1 instead of S2.
         $training = Training::factory()
             ->has(Rating::factory(['vatsim_rating' => VatsimRating::S1]))
             ->create(['user_id' => $student->id, 'type' => 1, 'status' => 2, 'area_id' => TEST_USER_TRAINING_AREA]);
         $training->ratings()->save(Rating::factory()->create(['vatsim_rating' => VatsimRating::S2]));
+        $training->ratings()->save(Rating::factory()->create(['vatsim_rating' => null]));
 
         $position = Position::factory()->create([
             'rating' => VatsimRating::S2->value,
@@ -119,6 +120,38 @@ class BookingTest extends TestCase
 
         $this->assertCreateBookingAvailable($student, $position);
         $this->createBooking($student, $position)->assertValid();
+    }
+
+    #[Test]
+    public function student_with_facility_training_cannot_book_position_above_their_rating(): void
+    {
+        $student = User::factory()->create([
+            'rating' => VatsimRating::S1->value,
+        ]);
+
+        // Facility (MAE) training: no VATSIM rating attached
+        Training::factory()
+            ->has(Rating::factory(['vatsim_rating' => null]))
+            ->create(['user_id' => $student->id, 'type' => 1, 'status' => 2, 'area_id' => TEST_USER_TRAINING_AREA]);
+
+        $position = Position::factory()->create([
+            'rating' => VatsimRating::C1->value,
+            'callsign' => 'TEST_APP',
+            'name' => 'Test Approach',
+            'area_id' => TEST_USER_TRAINING_AREA,
+        ]);
+
+        $startDate = Carbon::tomorrow()->addHours(2);
+        $bookingRequest = [
+            'date' => $startDate->format('d/m/Y'),
+            'start_at' => $startDate->format('H:i'),
+            'end_at' => $startDate->copy()->addHours(2)->format('H:i'),
+            'position' => $position->callsign,
+        ];
+
+        $this->actingAs($student)->post(route('booking.store'), $bookingRequest)
+            ->assertStatus(403);
+        $this->assertNull(Booking::first());
     }
 
     #[Test]

--- a/tests/Feature/NotificationEmailTest.php
+++ b/tests/Feature/NotificationEmailTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Helpers\VatsimRating;
 use App\Models\Area;
+use App\Models\Rating;
 use App\Models\Training;
 use App\Models\TrainingExamination;
 use App\Models\TrainingInterest;
@@ -75,6 +77,27 @@ class NotificationEmailTest extends TestCase
             'training interest' => [TrainingInterestNotification::class, TrainingInterest::class],
             'training examination' => [TrainingExamNotification::class, TrainingExamination::class],
         ];
+    }
+
+    #[Test]
+    public function training_notification_lists_both_facility_and_vatsim_ratings(): void
+    {
+        $training = Training::factory()
+            ->has(Rating::factory(['vatsim_rating' => VatsimRating::S2, 'name' => 'TST-S2']))
+            ->for($this->user)->for($this->area)->create();
+        $training->ratings()->save(Rating::factory()->create(['vatsim_rating' => null, 'name' => 'TST-MAE']));
+
+        $this->user->notify(new TrainingCreatedNotification($training->fresh()));
+
+        Notification::assertSentTo(
+            $this->user,
+            TrainingCreatedNotification::class,
+            function ($notification, $channels, $notifiable) {
+                $this->assertStringContainsString('TST-S2 + TST-MAE', $notification->toMail($notifiable)->render());
+
+                return true;
+            }
+        );
     }
 
     #[Test]

--- a/tests/Feature/TrainingsTest.php
+++ b/tests/Feature/TrainingsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Helpers\VatsimRating;
 use App\Models\Area;
 use App\Models\Rating;
 use App\Models\Training;
@@ -35,6 +36,32 @@ class TrainingsTest extends TestCase
     //        $this->assertJson($this->postJson('/training/store', $attributes)->content());
     //        $this->assertDatabaseHas('trainings', ['motivation' => $attributes['motivation']]);
     //    }
+
+    #[Test]
+    public function training_page_only_offers_rating_tasks_for_vatsim_rating_trainings()
+    {
+        $moderator = User::factory()->create();
+
+        $facilityTraining = Training::factory()
+            ->has(Rating::factory(['vatsim_rating' => null]))
+            ->create(['user_id' => User::factory()->create()->id]);
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $facilityTraining->area->id]);
+
+        $this->actingAs($moderator)->get($facilityTraining->path())
+            ->assertSeeText('Custom Request')
+            ->assertDontSeeText('Rating Upgrade')
+            ->assertDontSeeText('Theoretical Exam Access');
+
+        $combinedTraining = Training::factory()
+            ->has(Rating::factory(['vatsim_rating' => VatsimRating::S2, 'name' => 'TST-S2']))
+            ->create(['user_id' => User::factory()->create()->id, 'area_id' => $facilityTraining->area_id]);
+        $combinedTraining->ratings()->save(Rating::factory()->create(['vatsim_rating' => null, 'name' => 'TST-MAE']));
+
+        $this->actingAs($moderator)->get($combinedTraining->path())
+            ->assertSeeText('Rating Upgrade')
+            ->assertSeeText('Theoretical Exam Access')
+            ->assertSee('for <b>TST-S2</b> rating', false);
+    }
 
     #[Test]
     public function guest_cant_create_training_request()


### PR DESCRIPTION
An endorsement training alone allowed students to book any position in the training area, regardless of its rating. Booking above your own rating now requires the training to hold a VATSIM rating at or above the position rating, e.g. an endorsement training combined with a higher VATSIM rating.

Fix tests with behavior-level coverage of endorsement vs VATSIM ratings: task request types offered on the training page, the task modal rating label, booking authorization for endorsement-training students, and rating names in the training created notification.

Includes a minor refactor that builds on 5fd9fbd7: The loose `where("vatsim_rating", true)` comparison worked but read oddly; `whereNotNull` states the intent directly.

getInlineRatings(), isFacilityTraining() and hasVatsimRatings() relied on loose truthiness/equality against vatsim_rating to separate VATSIM GCAP ratings from endorsement ratings. whereNull/whereNotNull state the intent directly.

## Summary by Sourcery

Tighten booking authorization to prevent facility-only training from bypassing VATSIM rating checks and clarify how VATSIM vs facility ratings are handled across bookings, training views, and notifications.

Bug Fixes:
- Disallow students with facility-only training from booking positions above their own VATSIM rating.
- Ensure booking authorization uses only non-null VATSIM ratings when determining the highest training rating.

Enhancements:
- Clarify rating handling by distinguishing VATSIM ratings from facility ratings using explicit null/non-null checks in training helpers.
- Ensure training pages only offer rating-related task types when the training includes a VATSIM rating.
- Include both VATSIM and facility ratings in training created notification emails when applicable.

Tests:
- Expand booking feature tests to cover facility-only training and combined training scenarios for rating-based booking authorization.
- Add feature tests to verify available training task types for facility vs combined trainings on the training page.
- Add notification tests to ensure inline rating strings display both VATSIM and facility ratings.