### PR TITLE
feat(front): replace hardcoded tagline with APP_TAGLINE config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 APP_NAME="Control Center"
+APP_TAGLINE="Training Administration"
 APP_OWNER_NAME="Subdivision Name"
 APP_OWNER_NAME_SHORT="SCA"
 APP_OWNER_CODE="SCA"

--- a/config/app.php
+++ b/config/app.php
@@ -26,6 +26,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Tagline
+    |--------------------------------------------------------------------------
+    |
+    | A short description of the application, displayed beneath the name on
+    | the front page. Customise it to describe your deployment.
+    |
+    */
+
+    'tagline' => env('APP_TAGLINE') ?: 'Training Administration',
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Version
     |--------------------------------------------------------------------------
     |

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -14,6 +14,7 @@ Settings related to URLs, subdivision names and other core application settings.
 | Variable               | Default value      | Explanation                                                  |
 | ---------------------- | ------------------ | ------------------------------------------------------------ |
 | `APP_NAME`             | Control Center     | What you want to call the software                           |
+| `APP_TAGLINE`          | Training Administration | Short description shown beneath the name on the front page |
 | `APP_OWNER_NAME`       | (sub)division Name | Full name of your (sub)division such as `VATSIM Scandinavia` |
 | `APP_OWNER_NAME_SHORT` | SCA                | Short name of choice for your vACC e.g. `VATSCA`/`ESTVACC`   |
 | `APP_OWNER_CODE`       | SCA                | 3-4 letter name identifying your vACC within VATSIM APIs     |

--- a/resources/views/front.blade.php
+++ b/resources/views/front.blade.php
@@ -23,11 +23,7 @@
                 {{ config('app.name') }}
             </div>
             <div class="content-description">
-                @if(config('app.owner_code') == 'SCA')
-                Scandinavian Training Administration
-                @else
-                Training Administration
-                @endif
+                {{ config('app.tagline') }}
             </div>
             <a href="{{ route('login') }}" class="btn btn-success">Login</a>
 

--- a/tests/Feature/FrontpageTest.php
+++ b/tests/Feature/FrontpageTest.php
@@ -17,6 +17,15 @@ class FrontpageTest extends TestCase
     }
 
     #[Test]
+    public function front_page_shows_configured_tagline()
+    {
+        config(['app.tagline' => 'Nordic Training Administration']);
+
+        $response = $this->get('/');
+        $response->assertSee('Nordic Training Administration');
+    }
+
+    #[Test]
     public function user_gets_redirect_if_logged_in()
     {
         $user = User::factory()->make();


### PR DESCRIPTION
Removes the SCA-specific owner_code branch on the front page in favour of a configurable app.tagline value.

## Summary by Sourcery

Make the front page tagline configurable via application settings instead of hardcoded logic.

New Features:
- Introduce an APP_TAGLINE / app.tagline configuration value used as the front page tagline.

Enhancements:
- Simplify the front page view by removing owner_code-specific tagline branching.

Documentation:
- Document the APP_TAGLINE environment variable and its purpose in the environment variables reference.

Tests:
- Add a feature test to verify that the front page displays the configured application tagline.