### PR TITLE
feat(roles): add director role & make admins global

### DIFF
--- a/app/Console/Commands/UpdateWorkmails.php
+++ b/app/Console/Commands/UpdateWorkmails.php
@@ -42,9 +42,9 @@ class UpdateWorkmails extends Command
         // Check for expired workmails
         DB::table('users')->where('setting_workmail_expire', '<=', date('Y-m-d H:i:s'))->update(['setting_workmail_address' => null, 'setting_workmail_expire' => null]);
 
-        // Check for users that no longer hold a moderator or admin rank
+        // Check for users that no longer hold a moderator, admin or director rank
         foreach (User::whereNotNull('setting_workmail_address')->get() as $user) {
-            if ($user->roleAssignments()->count() == 0 || (! $user->hasRole('moderator') && ! $user->hasRole('admin'))) {
+            if ($user->roleAssignments()->count() == 0 || ! $user->hasRole(['moderator', 'admin', 'director'])) {
                 $user->setting_workmail_address = null;
                 $user->setting_workmail_expire = null;
                 $user->save();

--- a/app/Console/Commands/UserMakeAdmin.php
+++ b/app/Console/Commands/UserMakeAdmin.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands;
 
-use App\Models\Area;
 use App\Models\User;
 use Illuminate\Console\Command;
 
@@ -24,39 +23,29 @@ class UserMakeAdmin extends Command
 
     /**
      * Execute the console command.
-     *
-     * @return int
      */
-    public function handle()
+    public function handle(): int
     {
-
-        // Input user
         $cid = $this->ask("What is the user's CID?");
-        if ($user = User::find($cid)) {
-            $this->info('User found: ' . $user->name);
 
-            $areas = Area::all();
-            $area = $this->choice('Which area? The admin has access across areas, but an area must be selected regardless.', $areas->pluck('name')->toArray());
-            if ($area != null) {
-                $area = Area::where('name', $area)->first();
-
-                // Give the user permission to the area
-                $user->roleAssignments()->create(['role' => 'admin', 'area_id' => $area->id]);
-                $this->info('User ' . $user->name . ' has been given admin permissions for ' . $area->name . '.');
-
-                return Command::SUCCESS;
-            } else {
-                $this->error('No area was selected.');
-
-                return Command::FAILURE;
-            }
-
-        } else {
+        $user = User::find($cid);
+        if (! $user) {
             $this->error('No records of ' . $cid . ' was found.');
 
             return Command::FAILURE;
         }
 
-        return Command::FAILURE;
+        $this->info('User found: ' . $user->name);
+
+        if ($user->hasGlobalRole('admin')) {
+            $this->info($user->name . ' is already an administrator.');
+
+            return Command::SUCCESS;
+        }
+
+        $user->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+        $this->info('User ' . $user->name . ' has been given system-wide admin permissions.');
+
+        return Command::SUCCESS;
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -313,7 +313,8 @@ class UserController extends Controller
         $this->authorize('update', $user);
         $permissions = [];
 
-        // Generate a list of possible validations
+        // Generate a list of possible validations: one key per area/role cell,
+        // plus the global row (area-less assignments) keyed as global_{role}
         foreach (Area::all() as $area) {
             foreach (config('roles.roles') as $roleKey => $role) {
                 // Only process ranks the user is allowed to change
@@ -326,6 +327,14 @@ class UserController extends Controller
             }
         }
 
+        foreach (config('roles.roles') as $roleKey => $role) {
+            if (! Gate::inspect('updateRole', [$user, $roleKey, null])->allowed()) {
+                continue;
+            }
+
+            $permissions['global_' . $roleKey] = '';
+        }
+
         // Valiate and allow these fields, then loop through permissions to set the final data set
         $data = $request->validate($permissions);
         foreach ($permissions as $key => $value) {
@@ -334,13 +343,17 @@ class UserController extends Controller
 
         // Check and update the permissions
         foreach ($permissions as $key => $value) {
-            $str = explode('_', $key);
+            [$scopeKey, $roleKey] = explode('_', $key, 2);
+            $area = $scopeKey === 'global' ? null : Area::find($scopeKey);
 
-            $area = Area::where('id', $str[0])->get()->first();
-            $roleKey = $str[1];
+            $assignments = $user->roleAssignments()->where('role', $roleKey)->when(
+                $area === null,
+                fn ($query) => $query->whereNull('area_id'),
+                fn ($query) => $query->where('area_id', $area->id),
+            );
 
             // Check if permission is not set, and set it or other way around.
-            if ($user->roleAssignments()->where('area_id', $area->id)->where('role', $roleKey)->count() == 0) {
+            if ($assignments->count() == 0) {
                 if ($value == true) {
                     $this->authorize('updateRole', [$user, $roleKey, $area]);
 
@@ -353,7 +366,7 @@ class UserController extends Controller
                     }
 
                     // Attach the new permission
-                    $user->roleAssignments()->create(['role' => $roleKey, 'area_id' => $area->id]);
+                    $user->roleAssignments()->create(['role' => $roleKey, 'area_id' => $area?->id]);
                 }
             } else {
                 if ($value == false) {
@@ -368,12 +381,12 @@ class UserController extends Controller
                     }
 
                     // Detach the permission
-                    $user->roleAssignments()->where('area_id', $area->id)->where('role', $roleKey)->delete();
+                    $assignments->delete();
                 }
             }
 
             // Check and detach trainings from mentor
-            if ($user->teaches()->where('area_id', $area->id)->count() > 0 && ! $user->hasRole('mentor') && $value == false) {
+            if ($area !== null && $user->teaches()->where('area_id', $area->id)->count() > 0 && ! $user->hasRole('mentor') && $value == false) {
                 $user->teaches()->detach($user->teaches->where('area_id', $area->id));
             }
         }

--- a/app/Models/RoleAssignment.php
+++ b/app/Models/RoleAssignment.php
@@ -48,7 +48,11 @@ class RoleAssignment extends Model
                 );
             }
 
-            // TODO: enforce global scope (admin must have area_id = null)
+            if ($scope === 'global' && $assignment->area_id !== null) {
+                throw new \InvalidArgumentException(
+                    "Role '{$assignment->role}' is global and cannot be assigned to an area."
+                );
+            }
 
             if ($scope === 'area' && $assignment->area_id === null) {
                 throw new \InvalidArgumentException(

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -522,4 +522,17 @@ class User extends Authenticatable
 
         return false;
     }
+
+    /**
+     * Check if the user holds any of the given roles as a global (area-less) assignment.
+     *
+     * @param  string|array<string>  $roles
+     */
+    public function hasGlobalRole($roles): bool
+    {
+        return $this->roleAssignments
+            ->whereIn('role', (array) $roles)
+            ->whereNull('area_id')
+            ->isNotEmpty();
+    }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -60,13 +60,42 @@ class UserPolicy
         return $user->hasPermission('manage-users');
     }
 
-    public function updateRole(User $user, User $model, string $requestedRole, Area $requestedArea)
+    /**
+     * Determine whether the user may grant or revoke the requested role
+     * for the model user. A null area means a global (area-less) assignment.
+     */
+    public function updateRole(User $user, User $model, string $requestedRole, ?Area $requestedArea): bool
     {
         if (! $this->update($user, $model)) {
             return false;
         }
 
+        // The admin role is managed exclusively through the user:makeadmin CLI command
+        if ($requestedRole === 'admin') {
+            return false;
+        }
+
+        // Global assignments require the role's scope to allow them
+        if ($requestedArea === null && ! in_array(config("roles.roles.{$requestedRole}.scope"), ['both', 'global'], true)) {
+            return false;
+        }
+
         if ($user->hasRole('admin')) {
+            return true;
+        }
+
+        // Only global directors may grant or revoke the director role
+        if ($requestedRole === 'director') {
+            return $user->hasGlobalRole('director');
+        }
+
+        // Global assignments of the remaining roles also require a global director
+        if ($requestedArea === null) {
+            return $user->hasGlobalRole('director');
+        }
+
+        // Directors manage the remaining roles within their scope
+        if ($user->hasRole('director', $requestedArea)) {
             return true;
         }
 

--- a/config/roles.php
+++ b/config/roles.php
@@ -13,8 +13,13 @@ return [
     'roles' => [
         'admin' => [
             'name' => 'Administrator',
-            'description' => 'System-wide administrator',
-            'scope' => 'global', // 'global', 'area', or 'both'
+            'description' => 'System-wide administrator, assignable only via the user:makeadmin CLI command',
+            'scope' => 'global',
+        ],
+        'director' => [
+            'name' => 'Director',
+            'description' => 'Director of an area or the whole organisation',
+            'scope' => 'both',
         ],
         'moderator' => [
             'name' => 'Moderator',
@@ -48,10 +53,10 @@ return [
     */
     'matrix' => [
         // Training permissions
-        'view-training' => ['admin', 'moderator', 'mentor', 'buddy'],
-        'create-training' => ['admin', 'moderator', 'mentor'],
-        'update-training' => ['admin', 'moderator'],
-        'delete-training' => ['admin'],
+        'view-training' => ['admin', 'director', 'moderator', 'mentor', 'buddy'],
+        'create-training' => ['admin', 'director', 'moderator', 'mentor'],
+        'update-training' => ['admin', 'director', 'moderator'],
+        'delete-training' => ['admin', 'director'],
 
         // Area management
         'manage-area' => ['admin'],
@@ -60,28 +65,28 @@ return [
         'view-system-health' => ['admin'],
 
         // Users & Access
-        'manage-users' => ['admin', 'moderator'],
-        'view-user-access' => ['admin', 'moderator'],
+        'manage-users' => ['admin', 'director', 'moderator'],
+        'view-user-access' => ['admin', 'director', 'moderator'],
 
         // Operations
-        'manage-positions' => ['admin', 'moderator', 'nav-editor'],
+        'manage-positions' => ['admin', 'director', 'moderator', 'nav-editor'],
 
         // Endorsements
-        'manage-endorsements' => ['admin', 'moderator'],
-        'manage-visiting-endorsements' => ['admin'],
-        'manage-examiner-endorsements' => ['admin'],
+        'manage-endorsements' => ['admin', 'director', 'moderator'],
+        'manage-visiting-endorsements' => ['admin', 'director'],
+        'manage-examiner-endorsements' => ['admin', 'director'],
 
         // Reports
-        'view-management-reports' => ['admin', 'moderator'],
-        'view-training-activities' => ['admin', 'moderator'],
-        'view-training-statistics' => ['admin', 'moderator'],
-        'view-mentor-reports' => ['admin', 'moderator', 'mentor'],
+        'view-management-reports' => ['admin', 'director', 'moderator'],
+        'view-training-activities' => ['admin', 'director', 'moderator'],
+        'view-training-statistics' => ['admin', 'director', 'moderator'],
+        'view-mentor-reports' => ['admin', 'director', 'moderator', 'mentor'],
 
         // Feedback
-        'view-correlated-feedback' => ['admin', 'moderator'],
-        'view-uncorrelated-feedback' => ['admin', 'moderator'],
+        'view-correlated-feedback' => ['admin', 'director', 'moderator'],
+        'view-uncorrelated-feedback' => ['admin', 'director', 'moderator'],
 
         // Bookings
-        'bypass-booking-restrictions' => ['admin', 'moderator', 'mentor'],
+        'bypass-booking-restrictions' => ['admin', 'director', 'moderator', 'mentor'],
     ],
 ];

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -74,7 +74,7 @@ class DatabaseSeeder extends Seeder
                 case 9:
                     $name_last = 'Nine';
                     $rating_id = 11;
-                    $role = 'admin';
+                    $role = 'director';
                     break;
                 case 10:
                     $name_first = 'Team';

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -498,11 +498,13 @@
                                     <tr>
                                         <td><strong>Global</strong></td>
                                         @foreach($roles as $roleKey => $roleData)
-                                            <td class="text-center">
-                                                <input type="checkbox"
-                                                       {{ $user->roleAssignments->where('role', $roleKey)->whereNull('area_id')->isNotEmpty() ? 'checked' : '' }}
-                                                       disabled>
-                                            </td>
+
+                                            @if (\Illuminate\Support\Facades\Gate::inspect('updateRole', [$user, $roleKey, null])->allowed())
+                                                <td class="text-center"><input type="checkbox" name="global_{{ $roleKey }}" {{ $user->roleAssignments->where('role', $roleKey)->whereNull('area_id')->isNotEmpty() ? 'checked' : '' }}></td>
+                                            @else
+                                                <td class="text-center"><input type="checkbox" {{ $user->roleAssignments->where('role', $roleKey)->whereNull('area_id')->isNotEmpty() ? 'checked' : '' }} disabled></td>
+                                            @endif
+
                                         @endforeach
                                     </tr>
 

--- a/resources/views/usersettings.blade.php
+++ b/resources/views/usersettings.blade.php
@@ -61,7 +61,7 @@
                                 
                             @endif
 
-                            @if($user->hasRole(['admin', 'moderator']))
+                            @if($user->hasRole(['admin', 'director', 'moderator']))
                                 <hr>
 
                                 <h5>Moderator Notifications</h5>

--- a/tests/Feature/PositionsTest.php
+++ b/tests/Feature/PositionsTest.php
@@ -45,7 +45,7 @@ class PositionsTest extends TestCase
 
         // Create Users
         $this->admin = User::factory()->create();
-        $this->admin->roleAssignments()->create(['role' => 'admin', 'area_id' => $this->permittedArea->id]);
+        $this->admin->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
 
         $this->permittedUser = User::factory()->create();
         $this->user = User::factory()->create();

--- a/tests/Feature/TrainingReportsTest.php
+++ b/tests/Feature/TrainingReportsTest.php
@@ -330,7 +330,7 @@ class TrainingReportsTest extends TestCase
             'draft' => false,
         ]);
         $otherModerator = User::factory()->create(['id' => 10000101]);
-        $otherModerator->roleAssignments()->create(['role' => 'admin', 'area_id' => $training->area->id]);
+        $otherModerator->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
 
         $this->actingAs($otherModerator)
             ->get(route('training.report.delete', ['report' => $report->id]));

--- a/tests/Feature/TrainingsTest.php
+++ b/tests/Feature/TrainingsTest.php
@@ -123,7 +123,7 @@ class TrainingsTest extends TestCase
             'user_id' => User::factory()->create(['id' => 10000005])->id,
         ]);
         $moderator = User::factory()->create();
-        $moderator->roleAssignments()->create(['role' => 'admin', 'area_id' => $training->area->id]);
+        $moderator->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
 
         $this->actingAs($moderator)->patch(route('training.update', ['training' => $training->id]), ['status' => 0]);
 

--- a/tests/Feature/UpdateWorkmailsTest.php
+++ b/tests/Feature/UpdateWorkmailsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Area;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UpdateWorkmailsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_director_can_see_workmail_field_in_settings(): void
+    {
+        $area = Area::factory()->create();
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $area->id]);
+
+        $response = $this->actingAs($director)->get(route('user.settings'));
+
+        $response->assertOk();
+        $response->assertSee('name="setting_workmail_address"', false);
+    }
+
+    public function test_director_keeps_workmail_while_roleless_user_loses_it(): void
+    {
+        $area = Area::factory()->create();
+
+        $director = User::factory()->create(['setting_workmail_address' => 'director@example.test']);
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $area->id]);
+
+        $roleless = User::factory()->create(['setting_workmail_address' => 'roleless@example.test']);
+
+        $mentor = User::factory()->create(['setting_workmail_address' => 'mentor@example.test']);
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+
+        $this->artisan('update:workmails')->assertExitCode(0);
+
+        $this->assertEquals('director@example.test', $director->fresh()->setting_workmail_address);
+        $this->assertNull($roleless->fresh()->setting_workmail_address);
+        $this->assertNull($mentor->fresh()->setting_workmail_address);
+    }
+}

--- a/tests/Feature/UserMakeAdminTest.php
+++ b/tests/Feature/UserMakeAdminTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class UserMakeAdminTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function test_command_assigns_global_admin(): void
+    {
+        $user = User::factory()->create();
+
+        $this->artisan('user:makeadmin')
+            ->expectsQuestion("What is the user's CID?", $user->id)
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('role_user', [
+            'user_id' => $user->id,
+            'role' => 'admin',
+            'area_id' => null,
+        ]);
+    }
+
+    #[Test]
+    public function test_command_is_idempotent(): void
+    {
+        $user = User::factory()->create();
+        $user->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        $this->artisan('user:makeadmin')
+            ->expectsQuestion("What is the user's CID?", $user->id)
+            ->assertExitCode(0);
+
+        $this->assertEquals(1, $user->roleAssignments()->where('role', 'admin')->count());
+    }
+
+    #[Test]
+    public function test_command_fails_for_unknown_cid(): void
+    {
+        $this->artisan('user:makeadmin')
+            ->expectsQuestion("What is the user's CID?", 999999999)
+            ->assertExitCode(1);
+    }
+}

--- a/tests/Feature/UserRoleAssignmentTest.php
+++ b/tests/Feature/UserRoleAssignmentTest.php
@@ -76,9 +76,9 @@ class UserRoleAssignmentTest extends TestCase
         $response->assertSee('Global');
     }
 
-    public function test_global_admin_can_assign_admin_role_per_area(): void
+    public function test_global_admin_can_assign_director_per_area(): void
     {
-        $key = $this->area->id . '_admin';
+        $key = $this->area->id . '_director';
 
         $response = $this->actingAs($this->admin)
             ->patch(route('user.update', $this->target), [$key => 'on']);
@@ -87,15 +87,15 @@ class UserRoleAssignmentTest extends TestCase
 
         $this->assertDatabaseHas('role_user', [
             'user_id' => $this->target->id,
-            'role' => 'admin',
+            'role' => 'director',
             'area_id' => $this->area->id,
         ]);
     }
 
-    public function test_global_admin_can_revoke_admin_role_per_area(): void
+    public function test_global_admin_can_revoke_director_per_area(): void
     {
         $this->target->roleAssignments()->create([
-            'role' => 'admin',
+            'role' => 'director',
             'area_id' => $this->area->id,
         ]);
 
@@ -106,26 +106,200 @@ class UserRoleAssignmentTest extends TestCase
 
         $this->assertDatabaseMissing('role_user', [
             'user_id' => $this->target->id,
-            'role' => 'admin',
+            'role' => 'director',
             'area_id' => $this->area->id,
         ]);
     }
 
-    public function test_moderator_cannot_assign_admin_role_per_area(): void
+    public function test_admin_role_cannot_be_assigned_via_ui_even_by_global_admin(): void
     {
-        $moderator = User::factory()->create();
-        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $this->area->id]);
-
         $key = $this->area->id . '_admin';
 
-        $response = $this->actingAs($moderator)
+        $response = $this->actingAs($this->admin)
             ->patch(route('user.update', $this->target), [$key => 'on']);
 
         $response->assertRedirect();
         $this->assertDatabaseMissing('role_user', [
             'user_id' => $this->target->id,
             'role' => 'admin',
+        ]);
+    }
+
+    public function test_admin_role_cannot_be_revoked_via_ui(): void
+    {
+        $this->target->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        $response = $this->actingAs($this->admin)
+            ->patch(route('user.update', $this->target), []);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('role_user', [
+            'user_id' => $this->target->id,
+            'role' => 'admin',
+            'area_id' => null,
+        ]);
+    }
+
+    public function test_area_director_can_assign_moderator_in_their_area(): void
+    {
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $this->area->id]);
+
+        $key = $this->area->id . '_moderator';
+
+        $response = $this->actingAs($director)
+            ->patch(route('user.update', $this->target), [$key => 'on']);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('role_user', [
+            'user_id' => $this->target->id,
+            'role' => 'moderator',
             'area_id' => $this->area->id,
         ]);
+    }
+
+    public function test_area_director_cannot_assign_director(): void
+    {
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $this->area->id]);
+
+        $key = $this->area->id . '_director';
+
+        $response = $this->actingAs($director)
+            ->patch(route('user.update', $this->target), [$key => 'on']);
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('role_user', [
+            'user_id' => $this->target->id,
+            'role' => 'director',
+        ]);
+    }
+
+    public function test_global_director_can_assign_director_per_area(): void
+    {
+        $globalDirector = User::factory()->create();
+        $globalDirector->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
+
+        $key = $this->area->id . '_director';
+
+        $response = $this->actingAs($globalDirector)
+            ->patch(route('user.update', $this->target), [$key => 'on']);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('role_user', [
+            'user_id' => $this->target->id,
+            'role' => 'director',
+            'area_id' => $this->area->id,
+        ]);
+    }
+
+    public function test_moderator_cannot_assign_director_or_admin(): void
+    {
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $this->area->id]);
+
+        $response = $this->actingAs($moderator)
+            ->patch(route('user.update', $this->target), [
+                $this->area->id . '_director' => 'on',
+                $this->area->id . '_admin' => 'on',
+            ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('role_user', ['user_id' => $this->target->id, 'role' => 'director']);
+        $this->assertDatabaseMissing('role_user', ['user_id' => $this->target->id, 'role' => 'admin']);
+    }
+
+    public function test_global_admin_can_assign_global_moderator(): void
+    {
+        $response = $this->actingAs($this->admin)
+            ->patch(route('user.update', $this->target), ['global_moderator' => 'on']);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('role_user', [
+            'user_id' => $this->target->id,
+            'role' => 'moderator',
+            'area_id' => null,
+        ]);
+    }
+
+    public function test_global_admin_can_revoke_global_moderator(): void
+    {
+        $this->target->roleAssignments()->create(['role' => 'moderator', 'area_id' => null]);
+
+        $response = $this->actingAs($this->admin)
+            ->patch(route('user.update', $this->target), []);
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('role_user', [
+            'user_id' => $this->target->id,
+            'role' => 'moderator',
+        ]);
+    }
+
+    public function test_global_mentor_key_is_ignored_due_to_area_scope(): void
+    {
+        $response = $this->actingAs($this->admin)
+            ->patch(route('user.update', $this->target), ['global_mentor' => 'on']);
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('role_user', [
+            'user_id' => $this->target->id,
+            'role' => 'mentor',
+        ]);
+    }
+
+    public function test_global_admin_key_is_ignored(): void
+    {
+        $response = $this->actingAs($this->admin)
+            ->patch(route('user.update', $this->target), ['global_admin' => 'on']);
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('role_user', [
+            'user_id' => $this->target->id,
+            'role' => 'admin',
+        ]);
+    }
+
+    public function test_global_director_can_assign_global_director(): void
+    {
+        $globalDirector = User::factory()->create();
+        $globalDirector->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
+
+        $response = $this->actingAs($globalDirector)
+            ->patch(route('user.update', $this->target), ['global_director' => 'on']);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('role_user', [
+            'user_id' => $this->target->id,
+            'role' => 'director',
+            'area_id' => null,
+        ]);
+    }
+
+    public function test_area_director_cannot_assign_global_roles(): void
+    {
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $this->area->id]);
+
+        $response = $this->actingAs($director)
+            ->patch(route('user.update', $this->target), ['global_moderator' => 'on']);
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('role_user', [
+            'user_id' => $this->target->id,
+            'role' => 'moderator',
+        ]);
+    }
+
+    public function test_global_row_renders_enabled_checkboxes_for_admin(): void
+    {
+        $response = $this->actingAs($this->admin)
+            ->get(route('user.show', $this->target));
+
+        $response->assertOk();
+        $response->assertSee('name="global_moderator"', false);
+        $response->assertSee('name="global_director"', false);
+        $response->assertDontSee('name="global_admin"', false);
+        $response->assertDontSee('name="global_mentor"', false);
     }
 }

--- a/tests/Unit/DirectorRoleTest.php
+++ b/tests/Unit/DirectorRoleTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Area;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DirectorRoleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function director_should_not_have_system_level_permissions()
+    {
+        $area = Area::factory()->create();
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $area->id]);
+
+        $this->assertFalse($director->hasPermission('view-system-health'));
+        $this->assertFalse($director->hasPermission('manage-area', $area));
+    }
+
+    #[Test]
+    public function area_director_permissions_do_not_leak_to_other_areas()
+    {
+        $area = Area::factory()->create();
+        $otherArea = Area::factory()->create();
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $area->id]);
+
+        $this->assertFalse($director->hasPermission('manage-users', $otherArea));
+    }
+}

--- a/tests/Unit/RoleAssignmentScopeTest.php
+++ b/tests/Unit/RoleAssignmentScopeTest.php
@@ -76,6 +76,59 @@ class RoleAssignmentScopeTest extends TestCase
     }
 
     #[Test]
+    public function admin_cannot_be_assigned_to_an_area()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Role 'admin' is global and cannot be assigned to an area.");
+
+        $this->user->roleAssignments()->create(['role' => 'admin', 'area_id' => $this->area->id]);
+    }
+
+    #[Test]
+    public function director_can_be_assigned_to_a_specific_area()
+    {
+        $this->user->roleAssignments()->create(['role' => 'director', 'area_id' => $this->area->id]);
+
+        $this->assertDatabaseHas('role_user', ['role' => 'director', 'area_id' => $this->area->id]);
+    }
+
+    #[Test]
+    public function director_can_be_assigned_globally()
+    {
+        $this->user->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
+
+        $this->assertDatabaseHas('role_user', ['role' => 'director', 'area_id' => null]);
+    }
+
+    #[Test]
+    public function global_role_cannot_be_assigned_to_an_area()
+    {
+        config(['roles.roles.system.scope' => 'global']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Role 'system' is global and cannot be assigned to an area.");
+
+        $this->user->roleAssignments()->create(['role' => 'system', 'area_id' => $this->area->id]);
+    }
+
+    #[Test]
+    public function updating_global_role_to_an_area_throws()
+    {
+        config(['roles.roles.system.scope' => 'global']);
+
+        $assignment = RoleAssignment::create([
+            'user_id' => $this->user->id,
+            'role' => 'system',
+            'area_id' => null,
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Role 'system' is global and cannot be assigned to an area.");
+
+        $assignment->update(['area_id' => $this->area->id]);
+    }
+
+    #[Test]
     public function unknown_role_throws_on_create()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/Unit/RolePermissionTest.php
+++ b/tests/Unit/RolePermissionTest.php
@@ -95,4 +95,26 @@ class RolePermissionTest extends TestCase
         $this->assertTrue($user->hasRole(['admin', 'moderator'], $area));
         $this->assertFalse($user->hasRole(['admin', 'mentor'], $area));
     }
+
+    public function test_has_global_role_only_matches_area_less_assignments()
+    {
+        $user = User::factory()->create();
+        $area = Area::factory()->create();
+
+        $user->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $this->assertFalse($user->hasGlobalRole('moderator'));
+        $this->assertTrue($user->hasRole('moderator'));
+    }
+
+    public function test_has_global_role_matches_global_assignments()
+    {
+        $user = User::factory()->create();
+
+        $user->roleAssignments()->create(['role' => 'moderator', 'area_id' => null]);
+
+        $this->assertTrue($user->hasGlobalRole('moderator'));
+        $this->assertTrue($user->hasGlobalRole(['admin', 'moderator']));
+        $this->assertFalse($user->hasGlobalRole('admin'));
+    }
 }


### PR DESCRIPTION
Resolves the remaining TODO from https://github.com/Vatsim-Scandinavia/controlcenter/issues/1419: RoleAssignment now rejects an
area_id on roles configured with a global-only scope, mirroring the
existing area-scope validation.

- Grant director all admin permissions except system-level.

- Restrict admin to CLI-only, directors manage roles within scope.

  Addresses comment in https://github.com/Vatsim-Scandinavia/controlcenter/issues/1474.

- Directors can configure a work e-mail.

- add hasGlobalRole helper for area-less role checks.

- Assign global admin with user:makeadmin instead of area admin.

- Tweak and allow the global role row to be assignable in the user
  settings UI.

- Seed director user, and let directors manage their work e-mail.

## Summary by Sourcery

Introduce a director role with near-admin permissions while restricting the admin role to global, CLI-managed assignments and tightening role scope validation.

New Features:
- Add a director role with area and global scope and map it to most existing admin permissions except system-level operations.
- Allow directors (including global directors) to manage user roles within their permitted scope and retain workmail addresses when holding the director role.
- Add a hasGlobalRole helper on User for checking area-less role assignments.

Bug Fixes:
- Enforce that globally scoped roles cannot be assigned or updated with an area_id, rejecting invalid role assignments.

Enhancements:
- Refine user role update policy so admin assignments are UI-disabled, directors manage scoped roles, and moderators cannot grant elevated roles.
- Extend the workmail cleanup command to consider the new director role when deciding which users retain workmail addresses.

Tests:
- Expand and adjust feature and unit tests to cover director role behavior, admin assignment restrictions, global-scope enforcement, permission mappings, and workmail update behavior.