### PR TITLE
refactor(bookings): create shared booking service with sweatbox

### DIFF
--- a/app/Console/Commands/CleanSweatbooks.php
+++ b/app/Console/Commands/CleanSweatbooks.php
@@ -38,7 +38,7 @@ class CleanSweatbooks extends Command
      */
     public function handle()
     {
-        DB::table('sweatbooks')->where('date', '<', date('Y-m-d'))->delete();
+        DB::table('sweatbooks')->whereDate('time_start', '<', date('Y-m-d'))->delete();
         $this->info('All old sweatbooks have been cleaned.');
     }
 }

--- a/app/Contracts/VatsimBookingApiContract.php
+++ b/app/Contracts/VatsimBookingApiContract.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Contracts;
+
+use App\Models\Booking;
+
+interface VatsimBookingApiContract
+{
+    /**
+     * Publish a new booking to the VATSIM booking API.
+     *
+     * @return int|null The VATSIM booking id, or null if nothing was published
+     */
+    public function createBooking(Booking $booking, string $type): ?int;
+
+    /**
+     * Update an existing booking on the VATSIM booking API.
+     *
+     * @return int|null The VATSIM booking id, or null if nothing was published
+     */
+    public function updateBooking(Booking $booking, string $type): ?int;
+
+    /**
+     * Remove a booking from the VATSIM booking API.
+     */
+    public function deleteBooking(Booking $booking): void;
+}

--- a/app/Facades/VatsimBookingApi.php
+++ b/app/Facades/VatsimBookingApi.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Facades;
+
+use App\Contracts\VatsimBookingApiContract;
+use App\Services\VatsimBooking\Api;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static int|null createBooking(\App\Models\Booking $booking, string $type)
+ * @method static int|null updateBooking(\App\Models\Booking $booking, string $type)
+ * @method static void deleteBooking(\App\Models\Booking $booking)
+ *
+ * @see Api
+ */
+class VatsimBookingApi extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return VatsimBookingApiContract::class;
+    }
+}

--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -2,19 +2,13 @@
 
 namespace App\Http\Controllers;
 
-use anlutro\LaravelSettings\Facade as Setting;
-use App;
 use App\Exceptions\VatsimAPIException;
-use App\Helpers\TrainingStatus;
-use App\Helpers\VatsimRating;
+use App\Facades\VatsimBookingApi;
 use App\Models\Booking;
 use App\Models\Position;
 use App\Models\User;
-use Carbon\Carbon;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
+use App\Services\BookingService;
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -28,40 +22,7 @@ class BookingController extends Controller
 {
     use AuthorizesRequests;
 
-    /**
-     * Get the bookable positions for a user.
-     *
-     * @return \Illuminate\Support\Collection<Position> Bookable positions
-     */
-    private function getBookablePositions(User $user)
-    {
-        // Moderators and above can book any position
-        if ($user->hasPermission('bypass-booking-restrictions')) {
-            return Position::all();
-        }
-
-        // Users with a rating of S1 or above can book positions up to their rating
-        $positions = new Collection();
-
-        if ($user->rating >= VatsimRating::S1->value) {
-            if (Setting::get('atcActivityBasedOnTotalHours')) {
-                $positions = Position::where('rating', '<=', $user->rating)->get();
-            } else {
-
-                $activeAreas = $user->atcActivity->pluck('area_id');
-                $positionsInAreas = Position::whereIn('area_id', $activeAreas)->where('rating', '<=', $user->rating)->get();
-                $positions = $positions->merge($positionsInAreas);
-            }
-        }
-
-        if ($user->getActiveTraining(TrainingStatus::PRE_TRAINING->value)) {
-            $positions = $positions->merge(
-                $user->getActiveTraining()->area->positions->where('rating', '<=', $user->getActiveTraining()->getHighestVatsimRating()?->vatsim_rating)
-            );
-        }
-
-        return $positions;
-    }
+    public function __construct(private BookingService $bookingService) {}
 
     /**
      * Display a listing of the resource.
@@ -72,8 +33,8 @@ class BookingController extends Controller
     {
         $user = Auth::user();
         $this->authorize('view', Booking::class);
-        $bookings = Booking::where('deleted', false)->with('user', 'position')->get()->sortBy('time_start');
-        $positions = $this->getBookablePositions($user);
+        $bookings = $this->bookingService->getActiveBookings();
+        $positions = $this->bookingService->getBookablePositions($user);
 
         return view('booking.index', compact('bookings', 'user', 'positions'));
     }
@@ -88,7 +49,7 @@ class BookingController extends Controller
         $user = Auth::user();
         $this->authorize('create', Booking::class);
 
-        $positions = $this->getBookablePositions($user);
+        $positions = $this->bookingService->getBookablePositions($user);
 
         return view('booking.bulk', compact('user', 'positions'));
     }
@@ -96,14 +57,14 @@ class BookingController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param  Booking  $booking
+     * @param  int  $id
      * @return View
      */
     public function show($id)
     {
         $booking = Booking::findOrFail($id);
         $user = Auth::user();
-        $positions = $this->getBookablePositions($user);
+        $positions = $this->bookingService->getBookablePositions($user);
         $this->authorize('update', $booking);
 
         return view('booking.show', compact('booking', 'user', 'positions'));
@@ -129,115 +90,21 @@ class BookingController extends Controller
         ]);
 
         $user = Auth::user();
-        $booking = new Booking();
         $position = Position::firstWhere('callsign', $data['position']);
 
-        $date = Carbon::createFromFormat('d/m/Y', $data['date']);
-        $booking->time_start = Carbon::createFromFormat('H:i', $data['start_at'])->setDateFrom($date);
-        $booking->time_end = Carbon::createFromFormat('H:i', $data['end_at'])->setDateFrom($date);
-
+        $booking = new Booking();
+        $this->fillBookingPeriod($booking, $data);
         $booking->callsign = strtoupper($data['position']);
         $booking->position_id = $position->id;
         $booking->name = $user->name;
         $booking->user_id = $user->id;
 
-        $this->authorize('position', $booking);
-
-        if ($booking->time_start->eq($booking->time_end)) {
-            return back()->withErrors(['duration' => 'Booking needs to have a valid duration!'])->withInput();
-        }
-        if ($booking->time_start->diffInMinutes($booking->time_end, false) < 0) {
-            $booking->time_end->addDay();
-        }
-        if ($booking->time_start->diffInMinutes(Carbon::now(), false) > 0) {
-            return back()->withErrors('You cannot create a booking in the past.')->withInput();
+        $result = $this->persistBooking($booking, $position, $data['tag'] ?? null);
+        if ($result instanceof RedirectResponse) {
+            return $result;
         }
 
-        if (! Booking::whereBetween('time_start', [$booking->time_start, $booking->time_end])
-            ->where('time_end', '!=', $booking->time_start)
-            ->where('time_start', '!=', $booking->time_end)
-            ->where('position_id', $booking->position_id)
-            ->where('deleted', false)
-            ->orWhereBetween('time_end', [$booking->time_start, $booking->time_end])
-            ->where('time_end', '!=', $booking->time_start)
-            ->where('time_start', '!=', $booking->time_end)
-            ->where('position_id', $booking->position_id)
-            ->where('deleted', false)
-            ->get()->isEmpty()) {
-            return back()->withErrors('The position is already booked for that time!')->withInput();
-        }
-
-        $forcedTrainingTag = false;
-
-        if (($booking->position->rating->value > $user->rating) && ! $user->hasPermission('bypass-booking-restrictions')) {
-            $booking->training = 1;
-            $forcedTrainingTag = true;
-        } elseif ($position->requiredRating && ! $user->hasEndorsementRating($position->requiredRating) && ! $user->hasPermission('bypass-booking-restrictions')) {
-            $booking->training = 1;
-            $forcedTrainingTag = true;
-        } else {
-            $booking->training = 0;
-        }
-
-        $type = null;
-
-        if (isset($data['tag'])) {
-            $this->authorize('bookTags', $booking);
-            switch ($data['tag']) {
-                case 1:
-                    $booking->exam = 0;
-                    $booking->event = 0;
-                    $booking->training = 1;
-                    $type = 'training';
-                    break;
-                case 2:
-                    $booking->training = 0;
-                    $booking->exam = 1;
-                    $booking->event = 0;
-                    $type = 'exam';
-                    break;
-                case 3:
-                    $booking->training = 0;
-                    $booking->exam = 0;
-                    $booking->event = 1;
-                    $type = 'event';
-                    break;
-            }
-        } else {
-            $booking->exam = 0;
-            $booking->event = 0;
-            $type = 'booking';
-        }
-
-        if (App::environment('production')) {
-            $client = new Client();
-            $url = $this->getVatsimBookingUrl('post');
-
-            try {
-                $response = $this->makeHttpRequest($client, $url, 'post', [
-                    'callsign' => (string) $booking->callsign,
-                    'cid' => $booking->user_id,
-                    'type' => $type,
-                    'start' => $booking->time_start->format('Y-m-d H:i:s'),
-                    'end' => $booking->time_end->format('Y-m-d H:i:s'),
-                ]);
-            } catch (VatsimAPIException $e) {
-                return redirect(route('booking'))->withErrors('Booking failed with error: ' . $e->getMessage() . '. Please contact staff if this issue persists.');
-            }
-
-            $vatsim_booking = json_decode($response->getBody()->getContents());
-
-            $booking->vatsim_booking = $vatsim_booking->id;
-        }
-
-        $booking->save();
-
-        ActivityLogController::info('BOOKING', 'Created booking booking ' . $booking->id .
-        ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
-        ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
-        ' ― Position: ' . Position::find($booking->position_id)->callsign);
-
-        if ($forcedTrainingTag) {
+        if ($result) {
             return redirect(route('booking'))->withSuccess('Booking successfully added, but training tag was forced due to booking a restricted position.');
         }
 
@@ -266,108 +133,23 @@ class BookingController extends Controller
         $user = Auth::user();
 
         $positions = explode(',', $data['positions']);
-        foreach ($positions as $position) {
-            $booking = new Booking();
-
-            $date = Carbon::createFromFormat('d/m/Y', $data['date']);
-            $booking->time_start = Carbon::createFromFormat('H:i', $data['start_at'])->setDateFrom($date);
-            $booking->time_end = Carbon::createFromFormat('H:i', $data['end_at'])->setDateFrom($date);
-
-            $booking->callsign = strtoupper($position);
-
-            $positionModel = Position::firstWhere('callsign', $position);
-            if (isset($positionModel)) {
-                $booking->position_id = Position::firstWhere('callsign', $position)->id;
-            } else {
-                return redirect(route('booking'))->withErrors('The position ' . $position . ' does not exist. The bulk booking stopped here, but previous positions in the list have been booked.')->withInput();
+        foreach ($positions as $positionCallsign) {
+            $position = Position::firstWhere('callsign', $positionCallsign);
+            if (! isset($position)) {
+                return redirect(route('booking'))->withErrors('The position ' . $positionCallsign . ' does not exist. The bulk booking stopped here, but previous positions in the list have been booked.')->withInput();
             }
 
+            $booking = new Booking();
+            $this->fillBookingPeriod($booking, $data);
+            $booking->callsign = strtoupper($positionCallsign);
+            $booking->position_id = $position->id;
             $booking->name = $user->name;
             $booking->user_id = $user->id;
 
-            $this->authorize('position', $booking);
-
-            if ($booking->time_start->eq($booking->time_end)) {
-                return back()->withErrors(['duration' => 'Booking needs to have a valid duration!'])->withInput();
+            $result = $this->persistBooking($booking, $position, $data['tag'] ?? null, bulk: true);
+            if ($result instanceof RedirectResponse) {
+                return $result;
             }
-            if ($booking->time_start->diffInMinutes($booking->time_end, false) < 0) {
-                $booking->time_end->addDay();
-            }
-            if ($booking->time_start->diffInMinutes(Carbon::now(), false) > 0) {
-                return back()->withErrors('You cannot create a booking in the past.')->withInput();
-            }
-
-            if (! Booking::whereBetween('time_start', [$booking->time_start, $booking->time_end])
-                ->where('time_end', '!=', $booking->time_start)
-                ->where('time_start', '!=', $booking->time_end)
-                ->where('position_id', $booking->position_id)
-                ->where('deleted', false)
-                ->orWhereBetween('time_end', [$booking->time_start, $booking->time_end])
-                ->where('time_end', '!=', $booking->time_start)
-                ->where('time_start', '!=', $booking->time_end)
-                ->where('position_id', $booking->position_id)
-                ->where('deleted', false)
-                ->get()->isEmpty()) {
-                return back()->withErrors('The position is already booked for that time!')->withInput();
-            }
-
-            $type = null;
-
-            if (isset($data['tag'])) {
-                $this->authorize('bookTags', $booking);
-                switch ($data['tag']) {
-                    case 1:
-                        $booking->exam = 0;
-                        $booking->event = 0;
-                        $booking->training = 1;
-                        $type = 'training';
-                        break;
-                    case 2:
-                        $booking->training = 0;
-                        $booking->exam = 1;
-                        $booking->event = 0;
-                        $type = 'exam';
-                        break;
-                    case 3:
-                        $booking->training = 0;
-                        $booking->exam = 0;
-                        $booking->event = 1;
-                        $type = 'event';
-                        break;
-                }
-            } else {
-                $booking->exam = 0;
-                $booking->event = 0;
-                $type = 'booking';
-            }
-
-            if (App::environment('production')) {
-                $client = new Client();
-                $url = $this->getVatsimBookingUrl('post');
-
-                try {
-                    $response = $this->makeHttpRequest($client, $url, 'post', [
-                        'callsign' => (string) $booking->callsign,
-                        'cid' => $booking->user_id,
-                        'type' => $type,
-                        'start' => $booking->time_start->format('Y-m-d H:i:s'),
-                        'end' => $booking->time_end->format('Y-m-d H:i:s'),
-                    ]);
-                } catch (VatsimAPIException $e) {
-                    return redirect(route('booking'))->withErrors('Booking failed with error: ' . $e->getMessage() . '. Please contact staff if this issue persists.');
-                }
-
-                $vatsim_booking = json_decode($response->getBody()->getContents());
-
-                $booking->vatsim_booking = $vatsim_booking->id;
-            }
-
-            $booking->save();
-
-            ActivityLogController::info('BOOKING', 'Created booking BULK booking ' . $booking->id .
-            ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
-            ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
-            ' ― Position: ' . Position::find($booking->position_id)->callsign);
         }
 
         return redirect(route('booking'))->withSuccess('Bulk bookings successfully added!');
@@ -388,118 +170,20 @@ class BookingController extends Controller
             'tag' => 'nullable|integer|between:1,3',
         ]);
 
-        $user = Auth::user();
         $booking = Booking::findOrFail($request->id);
         $position = Position::firstWhere('callsign', $data['position']);
         $this->authorize('update', $booking);
 
-        $date = Carbon::createFromFormat('d/m/Y', $data['date']);
-        $booking->time_start = Carbon::createFromFormat('H:i', $data['start_at'])->setDateFrom($date);
-        $booking->time_end = Carbon::createFromFormat('H:i', $data['end_at'])->setDateFrom($date);
-
+        $this->fillBookingPeriod($booking, $data);
         $booking->callsign = strtoupper($data['position']);
         $booking->position_id = $position->id;
 
-        $this->authorize('position', $booking);
-
-        if ($booking->time_start->eq($booking->time_end)) {
-            return back()->withErrors('Booking needs to have a valid duration!')->withInput();
-        }
-        if ($booking->time_start->diffInMinutes($booking->time_end, false) < 0) {
-            $booking->time_end->addDay();
-        }
-        if ($booking->time_start->diffInMinutes(Carbon::now(), false) > 0) {
-            return back()->withErrors('You cannot create a booking in the past.')->withInput();
+        $result = $this->persistBooking($booking, $position, $data['tag'] ?? null);
+        if ($result instanceof RedirectResponse) {
+            return $result;
         }
 
-        if (! Booking::whereBetween('time_start', [$booking->time_start, $booking->time_end])
-            ->where('time_end', '!=', $booking->time_start)
-            ->where('time_start', '!=', $booking->time_end)
-            ->where('position_id', $booking->position_id)
-            ->where('deleted', false)
-            ->where('id', '!=', $booking->id)
-            ->orWhereBetween('time_end', [$booking->time_start, $booking->time_end])
-            ->where('time_end', '!=', $booking->time_start)
-            ->where('time_start', '!=', $booking->time_end)
-            ->where('position_id', $booking->position_id)
-            ->where('deleted', false)
-            ->where('id', '!=', $booking->id)
-            ->get()->isEmpty()) {
-            return back()->withErrors('The position is already booked for that time!')->withInput();
-        }
-
-        $forcedTrainingTag = false;
-        $bookingUser = User::find($booking->user_id);
-
-        if (($booking->position->rating > $bookingUser->rating) && ! $bookingUser->hasPermission('bypass-booking-restrictions')) {
-            $booking->training = 1;
-            $forcedTrainingTag = true;
-        } elseif ($position->requiredRating && ! $user->hasEndorsementRating($position->requiredRating) && ! $user->hasPermission('bypass-booking-restrictions')) {
-            $booking->training = 1;
-            $forcedTrainingTag = true;
-        } else {
-            $booking->training = 0;
-        }
-
-        $type = null;
-
-        if (isset($data['tag'])) {
-            $this->authorize('bookTags', $booking);
-            switch ($data['tag']) {
-                case 1:
-                    $booking->exam = 0;
-                    $booking->event = 0;
-                    $booking->training = 1;
-                    $type = 'training';
-                    break;
-                case 2:
-                    $booking->training = 0;
-                    $booking->exam = 1;
-                    $booking->event = 0;
-                    $type = 'exam';
-                    break;
-                case 3:
-                    $booking->training = 0;
-                    $booking->exam = 0;
-                    $booking->event = 1;
-                    $type = 'event';
-                    break;
-            }
-        } else {
-            $booking->exam = 0;
-            $booking->event = 0;
-            $type = 'booking';
-        }
-
-        if (App::environment('production')) {
-            $client = new Client();
-            $url = $this->getVatsimBookingUrl('put', $booking->vatsim_booking);
-
-            try {
-                $response = $this->makeHttpRequest($client, $url, 'put', [
-                    'callsign' => (string) $booking->callsign,
-                    'cid' => $booking->user_id,
-                    'type' => $type,
-                    'start' => $booking->time_start->format('Y-m-d H:i:s'),
-                    'end' => $booking->time_end->format('Y-m-d H:i:s'),
-                ]);
-            } catch (VatsimAPIException $e) {
-                return redirect(route('booking'))->withErrors('Booking failed with error: ' . $e->getMessage() . '. Please contact staff if this issue persists.');
-            }
-
-            $vatsim_booking = json_decode($response->getBody()->getContents());
-
-            $booking->vatsim_booking = $vatsim_booking->id;
-        }
-
-        $booking->save();
-
-        ActivityLogController::info('BOOKING', 'Updated booking booking ' . $booking->id .
-        ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
-        ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
-        ' ― Position: ' . Position::find($booking->position_id)->callsign);
-
-        if ($forcedTrainingTag) {
+        if ($result) {
             return redirect(route('booking'))->withSuccess('Booking successfully added, but training tag was forced due to booking a restricted position.');
         }
 
@@ -507,9 +191,78 @@ class BookingController extends Controller
     }
 
     /**
+     * Set the booking period from the validated request data.
+     *
+     * @param  array{date: string, start_at: string, end_at: string}  $data
+     */
+    private function fillBookingPeriod(Booking $booking, array $data): void
+    {
+        [$startAt, $endAt] = $this->bookingService->parsePeriod($data['date'], $data['start_at'], $data['end_at']);
+
+        $booking->time_start = $startAt;
+        $booking->time_end = $endAt;
+    }
+
+    /**
+     * Validate, publish to the VATSIM booking API and persist the filled booking.
+     *
+     * @return RedirectResponse|bool An error response, or whether the training tag was forced
+     *
+     * @throws AuthorizationException
+     */
+    private function persistBooking(Booking $booking, Position $position, ?int $tag, bool $bulk = false): RedirectResponse|bool
+    {
+        $this->authorize('position', $booking);
+
+        if ($booking->time_start->eq($booking->time_end)) {
+            return back()->withErrors(['duration' => 'Booking needs to have a valid duration!'])->withInput();
+        }
+        $this->bookingService->adjustForOvernight($booking->time_start, $booking->time_end);
+        if ($this->bookingService->isStartInPast($booking->time_start)) {
+            return back()->withErrors('You cannot create a booking in the past.')->withInput();
+        }
+
+        if ($this->bookingService->bookingConflictExists($booking)) {
+            return back()->withErrors('The position is already booked for that time!')->withInput();
+        }
+
+        $isNewBooking = ! $booking->exists;
+
+        $forcedTrainingTag = $this->bookingService->shouldForceTrainingTag($booking, $position, $booking->user);
+        $booking->training = $forcedTrainingTag ? 1 : 0;
+
+        if ($tag !== null) {
+            $this->authorize('bookTags', $booking);
+        }
+        $type = $this->bookingService->applyTagToBooking($booking, $tag);
+
+        try {
+            $vatsimBookingId = $isNewBooking
+                ? VatsimBookingApi::createBooking($booking, $type)
+                : VatsimBookingApi::updateBooking($booking, $type);
+        } catch (VatsimAPIException $e) {
+            return redirect(route('booking'))->withErrors('Booking failed with error: ' . $e->getMessage() . '. Please contact staff if this issue persists.');
+        }
+
+        if ($vatsimBookingId !== null) {
+            $booking->vatsim_booking = $vatsimBookingId;
+        }
+
+        $booking->save();
+
+        if ($isNewBooking) {
+            $this->bookingService->logBookingCreated($booking, $bulk);
+        } else {
+            $this->bookingService->logBookingUpdated($booking);
+        }
+
+        return $forcedTrainingTag;
+    }
+
+    /**
      * Remove the specified resource from storage.
      *
-     * @param  Booking  $booking
+     * @param  int  $id
      * @return RedirectResponse
      */
     public function delete($id)
@@ -519,63 +272,16 @@ class BookingController extends Controller
 
         $booking->deleted = true;
 
-        if (App::environment('production')) {
-            $client = new Client();
-            $url = $this->getVatsimBookingUrl('delete', $booking->vatsim_booking);
-
-            try {
-                $response = $this->makeHttpRequest($client, $url, 'delete');
-            } catch (VatsimAPIException $e) {
-                return redirect(route('booking'))->withErrors('Booking deletion failed with error: ' . $e->getMessage() . '. Please contact staff if this issue persists.');
-            }
+        try {
+            VatsimBookingApi::deleteBooking($booking);
+        } catch (VatsimAPIException $e) {
+            return redirect(route('booking'))->withErrors('Booking deletion failed with error: ' . $e->getMessage() . '. Please contact staff if this issue persists.');
         }
 
         $booking->save();
 
-        ActivityLogController::warning('BOOKING', 'Deleted booking booking ' . $booking->id .
-        ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
-        ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
-        ' ― Position: ' . Position::find($booking->position_id)->callsign);
+        $this->bookingService->logBookingDeleted($booking);
 
         return redirect(route('booking'));
-    }
-
-    private function getVatsimBookingUrl(string $type, ?int $id = null)
-    {
-        if ($type == 'get' || $type == 'post') {
-            $url = config('vatsim.booking_api_url') . '/booking';
-        } elseif ($type == 'put' || $type == 'delete') {
-            $url = config('vatsim.booking_api_url') . '/booking/' . $id;
-        } else {
-            return null;
-        }
-
-        return $url;
-    }
-
-    private function makeHttpRequest(Client $client, string $url, string $type, ?array $data = null)
-    {
-        try {
-            $headers = [
-                'Authorization' => 'Bearer ' . config('vatsim.booking_api_token'),
-                'Accept' => 'application/json',
-            ];
-
-            if ($type == 'get') {
-                return $client->request('GET', $url, [
-                    'headers' => $headers,
-                ]);
-            } elseif ($type == 'post') {
-                return $client->request('POST', $url, ['headers' => $headers, 'form_params' => $data]);
-            } elseif ($type == 'put') {
-                return $client->request('PUT', $url, ['headers' => $headers, 'form_params' => $data]);
-            } elseif ($type == 'delete') {
-                return $client->request('DELETE', $url, ['headers' => $headers]);
-            }
-
-            return null;
-        } catch (ClientException $e) {
-            throw new VatsimAPIException($e);
-        }
     }
 }

--- a/app/Http/Controllers/SweatbookController.php
+++ b/app/Http/Controllers/SweatbookController.php
@@ -4,12 +4,11 @@ namespace App\Http\Controllers;
 
 use App\Models\Position;
 use App\Models\Sweatbook;
-use Carbon\Carbon;
+use App\Services\BookingService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
 
@@ -19,6 +18,8 @@ use Illuminate\View\View;
 class SweatbookController extends Controller
 {
     use AuthorizesRequests;
+
+    public function __construct(private BookingService $bookingService) {}
 
     /**
      * Display a listing of the resource.
@@ -31,7 +32,7 @@ class SweatbookController extends Controller
     {
         $user = Auth::user();
         $this->authorize('view', Sweatbook::class);
-        $bookings = Sweatbook::with('user', 'position')->get()->sortBy('date')->sortBy('start_at');
+        $bookings = $this->bookingService->getActiveBookings(Sweatbook::class);
         $positions = Position::all();
 
         return view('sweatbook.index', compact('bookings', 'user', 'positions'));
@@ -49,7 +50,6 @@ class SweatbookController extends Controller
     {
         $booking = Sweatbook::findOrFail($id);
         $positions = Position::all();
-        $user = Auth::user();
         $this->authorize('update', $booking);
 
         return view('sweatbook.show', compact('booking', 'positions'));
@@ -74,49 +74,10 @@ class SweatbookController extends Controller
             'mentor_notes' => 'nullable|string|max:255',
         ]);
 
-        $user = Auth::user();
-
-        $date = Carbon::createFromFormat('d/m/Y', $data['date']);
         $booking = new Sweatbook();
+        $booking->user_id = Auth::id();
 
-        $booking->user_id = $user->id;
-        $booking->date = $date->format('Y-m-d');
-        $booking->start_at = Carbon::createFromFormat('H:i', $data['start_at'])->setDateFrom($booking->date);
-        $booking->end_at = Carbon::createFromFormat('H:i', $data['end_at'])->setDateFrom($booking->date);
-        $booking->position_id = Position::firstWhere('callsign', $data['position'])->id;
-        $booking->mentor_notes = $data['mentor_notes'];
-
-        if ($booking->start_at === $booking->end_at) {
-            return back()->withInput()->withErrors('Booking need to have a valid duration!');
-        }
-        if ($booking->start_at->diffInMinutes(Carbon::now(), false) > 0) {
-            return back()->withErrors('You cannot create a booking in the past.')->withInput();
-        }
-
-        if (! Sweatbook::whereBetween('start_at', [$booking->start_at, $booking->end_at])
-            ->where('date', $booking->date)
-            ->where('end_at', '!=', $booking->start_at)
-            ->where('start_at', '!=', $booking->end_at)
-            ->where('position_id', $booking->position_id)
-            ->where('id', '!=', $booking->id)
-            ->orWhereBetween('end_at', [$booking->start_at, $booking->end_at])
-            ->where('date', $booking->date)
-            ->where('end_at', '!=', $booking->start_at)
-            ->where('start_at', '!=', $booking->end_at)
-            ->where('position_id', $booking->position_id)
-            ->where('id', '!=', $booking->id)
-            ->get()->isEmpty()) {
-            return back()->withErrors('The position is already booked for that time!')->withInput();
-        }
-
-        $booking->save();
-
-        ActivityLogController::info('BOOKING', 'Created sweatbox booking ' . $booking->id .
-        ' ― from ' . Carbon::parse($booking->start_at)->toEuropeanDateTime() .
-        ' → ' . Carbon::parse($booking->end_at)->toEuropeanDateTime() .
-        ' ― Position: ' . Position::find($booking->position_id)->callsign);
-
-        return redirect('/sweatbook')->withSuccess('Booking successfully saved.');
+        return $this->saveBooking($booking, $data);
     }
 
     /**
@@ -139,47 +100,45 @@ class SweatbookController extends Controller
         $booking = Sweatbook::findOrFail($request->id);
         $this->authorize('update', $booking);
 
-        $date = Carbon::createFromFormat('d/m/Y', $data['date']);
+        return $this->saveBooking($booking, $data);
+    }
 
-        $booking->user_id = $booking->user_id;
-        $booking->date = $date->format('Y-m-d');
-        $booking->start_at = Carbon::createFromFormat('H:i', $data['start_at'])->setDateFrom($booking->date);
-        $booking->end_at = Carbon::createFromFormat('H:i', $data['end_at'])->setDateFrom($booking->date);
+    /**
+     * Fill, validate and persist the booking from the validated request data.
+     *
+     * @param  array{date: string, start_at: string, end_at: string, position: string, mentor_notes?: ?string}  $data
+     */
+    private function saveBooking(Sweatbook $booking, array $data): RedirectResponse
+    {
+        $isNewBooking = ! $booking->exists;
+
+        [$startAt, $endAt] = $this->bookingService->parsePeriod($data['date'], $data['start_at'], $data['end_at']);
+
+        $booking->time_start = $startAt;
+        $booking->time_end = $endAt;
         $booking->position_id = Position::firstWhere('callsign', $data['position'])->id;
-        $booking->mentor_notes = $data['mentor_notes'];
+        $booking->mentor_notes = $data['mentor_notes'] ?? null;
 
-        if ($booking->start_at->diffInMinutes($booking->end_at, false) <= 0) {
+        if ($startAt->diffInMinutes($endAt, false) <= 0) {
             return back()->withInput()->withErrors('Booking need to have a valid duration!');
         }
-        if ($booking->start_at->diffInMinutes(Carbon::now(), false) > 0) {
+        if ($this->bookingService->isStartInPast($startAt)) {
             return back()->withErrors('You cannot create a booking in the past.')->withInput();
         }
 
-        $fullStartDate = Carbon::create($booking->date)->setTime($booking->start_at->format('H'), $booking->start_at->format('i'));
-        $fullEndDate = Carbon::create($booking->date)->setTime($booking->end_at->format('H'), $booking->end_at->format('i'));
-
-        if (! Sweatbook::whereBetween('start_at', [$fullStartDate, $fullEndDate])
-            ->where('date', $booking->date)
-            ->where('end_at', '!=', $booking->start_at)
-            ->where('start_at', '!=', $booking->end_at)
-            ->where('position_id', $booking->position_id)
-            ->where('id', '!=', $booking->id)
-            ->orWhereBetween('end_at', [$booking->start_at, $booking->end_at])
-            ->where('date', $booking->date)
-            ->where('end_at', '!=', $booking->start_at)
-            ->where('start_at', '!=', $booking->end_at)
-            ->where('position_id', $booking->position_id)
-            ->where('id', '!=', $booking->id)
-            ->get()->isEmpty()) {
+        if ($this->bookingService->sweatbookConflictExists($booking)) {
             return back()->withErrors('The position is already booked for that time!')->withInput();
         }
 
         $booking->save();
 
-        ActivityLogController::info('BOOKING', 'Updated sweatbox booking ' . $booking->id .
-        ' ― from ' . Carbon::parse($booking->start_at)->toEuropeanDateTime() .
-        ' → ' . Carbon::parse($booking->end_at)->toEuropeanDateTime() .
-        ' ― Position: ' . Position::find($booking->position_id)->callsign);
+        if ($isNewBooking) {
+            $this->bookingService->logBookingCreated($booking);
+
+            return redirect('/sweatbook')->withSuccess('Booking successfully saved.');
+        }
+
+        $this->bookingService->logBookingUpdated($booking);
 
         return redirect('/sweatbook')->withSuccess('Booking successfully edited.');
     }
@@ -188,20 +147,16 @@ class SweatbookController extends Controller
      * Remove the specified resource from storage.
      *
      * @param  int  $id
-     * @return Response
+     * @return RedirectResponse
      *
      * @throws AuthorizationException
      */
     public function delete($id)
     {
-        $user = Auth::user();
         $booking = Sweatbook::findOrFail($id);
         $this->authorize('update', $booking);
 
-        ActivityLogController::warning('BOOKING', 'Deleted sweatbox booking ' . $booking->id .
-        ' ― from ' . Carbon::parse($booking->start_at)->toEuropeanDateTime() .
-        ' → ' . Carbon::parse($booking->end_at)->toEuropeanDateTime() .
-        ' ― Position: ' . Position::find($booking->position_id)->callsign);
+        $this->bookingService->logBookingDeleted($booking);
 
         $booking->delete();
 

--- a/app/Models/Sweatbook.php
+++ b/app/Models/Sweatbook.php
@@ -6,6 +6,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class Sweatbook extends Model
 {
+    protected $casts = [
+        'time_start' => 'datetime',
+        'time_end' => 'datetime',
+    ];
+
     public function position()
     {
         return $this->hasOne(Position::class, 'id', 'position_id');

--- a/app/Providers/VatsimBookingApiServiceProvider.php
+++ b/app/Providers/VatsimBookingApiServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Providers;
+
+use App\Contracts\VatsimBookingApiContract;
+use App\Services\VatsimBooking\Api;
+use App\Services\VatsimBooking\NoOpApi;
+use Illuminate\Support\ServiceProvider;
+
+class VatsimBookingApiServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        $this->app->bind(VatsimBookingApiContract::class, function ($app) {
+            if ($app->environment('production')) {
+                return new Api();
+            }
+
+            return new NoOpApi();
+        });
+    }
+}

--- a/app/Services/BookingService.php
+++ b/app/Services/BookingService.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace App\Services;
+
+use anlutro\LaravelSettings\Facade as Setting;
+use App\Helpers\TrainingStatus;
+use App\Helpers\VatsimRating;
+use App\Http\Controllers\ActivityLogController;
+use App\Models\Booking;
+use App\Models\Position;
+use App\Models\Sweatbook;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Shared domain logic for ATC and sweatbox bookings.
+ */
+class BookingService
+{
+    /**
+     * Get all active bookings of the given model, sorted by start time.
+     *
+     * @param  class-string<Booking|Sweatbook>  $model
+     * @return \Illuminate\Support\Collection<int, Booking|Sweatbook> Active bookings
+     */
+    public function getActiveBookings(string $model = Booking::class)
+    {
+        return $model::query()
+            ->when($model === Booking::class, fn ($query) => $query->where('deleted', false))
+            ->with('user', 'position')
+            ->orderBy('time_start')
+            ->get();
+    }
+
+    /**
+     * Get the bookable positions for a user.
+     *
+     * @return \Illuminate\Support\Collection<int, Position> Bookable positions
+     */
+    public function getBookablePositions(User $user)
+    {
+        // Moderators and above can book any position
+        if ($user->hasPermission('bypass-booking-restrictions')) {
+            return Position::all();
+        }
+
+        // Users with a rating of S1 or above can book positions up to their rating
+        $positions = new Collection();
+
+        if ($user->rating >= VatsimRating::S1->value) {
+            if (Setting::get('atcActivityBasedOnTotalHours')) {
+                $positions = Position::where('rating', '<=', $user->rating)->get();
+            } else {
+                $activeAreas = $user->atcActivity->pluck('area_id');
+                $positionsInAreas = Position::whereIn('area_id', $activeAreas)->where('rating', '<=', $user->rating)->get();
+                $positions = $positions->merge($positionsInAreas);
+            }
+        }
+
+        if ($user->getActiveTraining(TrainingStatus::PRE_TRAINING->value)) {
+            $positions = $positions->merge(
+                $user->getActiveTraining()->area->positions->where('rating', '<=', $user->getActiveTraining()->getHighestVatsimRating()?->vatsim_rating)
+            );
+        }
+
+        return $positions;
+    }
+
+    /**
+     * Parse the validated date and time inputs into the booking period.
+     *
+     * @return array{0: Carbon, 1: Carbon} Start and end of the booking
+     */
+    public function parsePeriod(string $date, string $startAt, string $endAt): array
+    {
+        $bookingDate = Carbon::createFromFormat('d/m/Y', $date);
+
+        return [
+            Carbon::createFromFormat('H:i', $startAt)->setDateFrom($bookingDate),
+            Carbon::createFromFormat('H:i', $endAt)->setDateFrom($bookingDate),
+        ];
+    }
+
+    /**
+     * Roll the end time to the next day for bookings crossing midnight.
+     */
+    public function adjustForOvernight(Carbon $startAt, Carbon $endAt): void
+    {
+        if ($startAt->diffInMinutes($endAt, false) < 0) {
+            $endAt->addDay();
+        }
+    }
+
+    public function isStartInPast(Carbon $startAt): bool
+    {
+        return $startAt->diffInMinutes(Carbon::now(), false) > 0;
+    }
+
+    /**
+     * Check if another booking overlaps the given booking's position and period.
+     */
+    public function bookingConflictExists(Booking $booking): bool
+    {
+        return Booking::where('deleted', false)->where($this->overlapConstraints($booking))->exists();
+    }
+
+    /**
+     * Check if another sweatbox booking overlaps the given booking's position and period.
+     */
+    public function sweatbookConflictExists(Sweatbook $booking): bool
+    {
+        return Sweatbook::where($this->overlapConstraints($booking))->exists();
+    }
+
+    /**
+     * Query constraints matching bookings that overlap the given booking's
+     * position and period, excluding adjacent bookings and the booking itself.
+     */
+    private function overlapConstraints(Booking|Sweatbook $booking): \Closure
+    {
+        return function ($query) use ($booking) {
+            $query->where(function ($query) use ($booking) {
+                $query->whereBetween('time_start', [$booking->time_start, $booking->time_end])
+                    ->where('time_end', '!=', $booking->time_start)
+                    ->where('time_start', '!=', $booking->time_end)
+                    ->where('position_id', $booking->position_id)
+                    ->where('id', '!=', $booking->id);
+            })->orWhere(function ($query) use ($booking) {
+                $query->whereBetween('time_end', [$booking->time_start, $booking->time_end])
+                    ->where('time_end', '!=', $booking->time_start)
+                    ->where('time_start', '!=', $booking->time_end)
+                    ->where('position_id', $booking->position_id)
+                    ->where('id', '!=', $booking->id);
+            });
+        };
+    }
+
+    /**
+     * Check if the booking must carry a training tag because the booking user
+     * lacks the rating or endorsement required for the position.
+     */
+    public function shouldForceTrainingTag(Booking $booking, Position $position, User $bookingUser): bool
+    {
+        if ($bookingUser->hasPermission('bypass-booking-restrictions')) {
+            return false;
+        }
+
+        if ($booking->position->rating->value > $bookingUser->rating) {
+            return true;
+        }
+
+        return $position->requiredRating && ! $bookingUser->hasEndorsementRating($position->requiredRating);
+    }
+
+    /**
+     * Apply the requested tag to the booking's flags.
+     *
+     * @return string The booking type to report to the VATSIM booking API
+     */
+    public function applyTagToBooking(Booking $booking, ?int $tag): string
+    {
+        switch ($tag) {
+            case 1:
+                $booking->training = 1;
+                $booking->exam = 0;
+                $booking->event = 0;
+
+                return 'training';
+            case 2:
+                $booking->training = 0;
+                $booking->exam = 1;
+                $booking->event = 0;
+
+                return 'exam';
+            case 3:
+                $booking->training = 0;
+                $booking->exam = 0;
+                $booking->event = 1;
+
+                return 'event';
+            default:
+                $booking->exam = 0;
+                $booking->event = 0;
+
+                return 'booking';
+        }
+    }
+
+    public function logBookingCreated(Booking|Sweatbook $booking, bool $bulk = false): void
+    {
+        $kind = $bulk ? 'booking BULK' : $this->bookingKind($booking);
+        ActivityLogController::info('BOOKING', 'Created ' . $kind . ' ' . $this->describeBooking($booking));
+    }
+
+    public function logBookingUpdated(Booking|Sweatbook $booking): void
+    {
+        ActivityLogController::info('BOOKING', 'Updated ' . $this->bookingKind($booking) . ' ' . $this->describeBooking($booking));
+    }
+
+    public function logBookingDeleted(Booking|Sweatbook $booking): void
+    {
+        ActivityLogController::warning('BOOKING', 'Deleted ' . $this->bookingKind($booking) . ' ' . $this->describeBooking($booking));
+    }
+
+    private function bookingKind(Booking|Sweatbook $booking): string
+    {
+        return $booking instanceof Sweatbook ? 'sweatbox' : 'booking';
+    }
+
+    private function describeBooking(Booking|Sweatbook $booking): string
+    {
+        return 'booking ' . $booking->id .
+            ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
+            ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
+            ' ― Position: ' . $booking->position->callsign;
+    }
+}

--- a/app/Services/VatsimBooking/Api.php
+++ b/app/Services/VatsimBooking/Api.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Services\VatsimBooking;
+
+use App\Contracts\VatsimBookingApiContract;
+use App\Exceptions\VatsimAPIException;
+use App\Models\Booking;
+use Carbon\Carbon;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Publishes bookings to the central VATSIM booking API.
+ */
+class Api implements VatsimBookingApiContract
+{
+    public function createBooking(Booking $booking, string $type): ?int
+    {
+        $response = $this->callApi('post', $this->bookingUrl(), $this->bookingPayload($booking, $type));
+
+        return (int) $response->json('id');
+    }
+
+    public function updateBooking(Booking $booking, string $type): ?int
+    {
+        $response = $this->callApi('put', $this->bookingUrl($booking->vatsim_booking), $this->bookingPayload($booking, $type));
+
+        return (int) $response->json('id');
+    }
+
+    public function deleteBooking(Booking $booking): void
+    {
+        $this->callApi('delete', $this->bookingUrl($booking->vatsim_booking));
+    }
+
+    /**
+     * @return array{callsign: string, cid: int, type: string, start: string, end: string}
+     */
+    private function bookingPayload(Booking $booking, string $type): array
+    {
+        return [
+            'callsign' => (string) $booking->callsign,
+            'cid' => $booking->user_id,
+            'type' => $type,
+            'start' => Carbon::parse($booking->time_start)->format('Y-m-d H:i:s'),
+            'end' => Carbon::parse($booking->time_end)->format('Y-m-d H:i:s'),
+        ];
+    }
+
+    private function bookingUrl(?int $vatsimBookingId = null): string
+    {
+        return config('vatsim.booking_api_url') . '/booking' . ($vatsimBookingId !== null ? '/' . $vatsimBookingId : '');
+    }
+
+    /**
+     * @throws VatsimAPIException
+     */
+    private function callApi(string $method, string $url, ?array $data = null): Response
+    {
+        $response = Http::withToken(config('vatsim.booking_api_token'))
+            ->acceptJson()
+            ->asForm()
+            ->$method($url, $data ?? []);
+
+        if ($response->failed()) {
+            throw new VatsimAPIException('VATSIM booking API responded with status ' . $response->status(), $response->status());
+        }
+
+        return $response;
+    }
+}

--- a/app/Services/VatsimBooking/NoOpApi.php
+++ b/app/Services/VatsimBooking/NoOpApi.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Services\VatsimBooking;
+
+use App\Contracts\VatsimBookingApiContract;
+use App\Models\Booking;
+
+/**
+ * No-op implementation used outside production, where bookings
+ * are not published to the central VATSIM booking API.
+ */
+class NoOpApi implements VatsimBookingApiContract
+{
+    public function createBooking(Booking $booking, string $type): ?int
+    {
+        return null;
+    }
+
+    public function updateBooking(Booking $booking, string $type): ?int
+    {
+        return null;
+    }
+
+    public function deleteBooking(Booking $booking): void
+    {
+        // Intentionally left blank
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -6,6 +6,7 @@ use App\Providers\CarbonServiceProvider;
 use App\Providers\DivisionApiServiceProvider;
 use App\Providers\EventServiceProvider;
 use App\Providers\RouteServiceProvider;
+use App\Providers\VatsimBookingApiServiceProvider;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\ServiceProvider;
 
@@ -256,6 +257,7 @@ return [
 
         CarbonServiceProvider::class,
         DivisionApiServiceProvider::class,
+        VatsimBookingApiServiceProvider::class,
 
     ])->toArray(),
 

--- a/database/migrations/2026_06_12_014338_convert_sweatbooks_to_datetime_columns.php
+++ b/database/migrations/2026_06_12_014338_convert_sweatbooks_to_datetime_columns.php
@@ -1,0 +1,65 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sweatbooks', function (Blueprint $table) {
+            $table->dateTime('time_start')->nullable()->after('user_id');
+            $table->dateTime('time_end')->nullable()->after('time_start');
+        });
+
+        DB::table('sweatbooks')->orderBy('id')->chunkById(500, function ($bookings) {
+            foreach ($bookings as $booking) {
+                DB::table('sweatbooks')->where('id', $booking->id)->update([
+                    'time_start' => Carbon::parse($booking->date)->setTimeFromTimeString($booking->start_at),
+                    'time_end' => Carbon::parse($booking->date)->setTimeFromTimeString($booking->end_at),
+                ]);
+            }
+        });
+
+        Schema::table('sweatbooks', function (Blueprint $table) {
+            $table->dateTime('time_start')->nullable(false)->change();
+            $table->dateTime('time_end')->nullable(false)->change();
+            $table->dropColumn(['date', 'start_at', 'end_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sweatbooks', function (Blueprint $table) {
+            $table->date('date')->nullable()->after('user_id');
+            $table->time('start_at')->nullable()->after('date');
+            $table->time('end_at')->nullable()->after('start_at');
+        });
+
+        DB::table('sweatbooks')->orderBy('id')->chunkById(500, function ($bookings) {
+            foreach ($bookings as $booking) {
+                DB::table('sweatbooks')->where('id', $booking->id)->update([
+                    'date' => Carbon::parse($booking->time_start)->format('Y-m-d'),
+                    'start_at' => Carbon::parse($booking->time_start)->format('H:i:s'),
+                    'end_at' => Carbon::parse($booking->time_end)->format('H:i:s'),
+                ]);
+            }
+        });
+
+        Schema::table('sweatbooks', function (Blueprint $table) {
+            $table->date('date')->nullable(false)->change();
+            $table->time('start_at')->nullable(false)->change();
+            $table->time('end_at')->nullable(false)->change();
+            $table->dropColumn(['time_start', 'time_end']);
+        });
+    }
+};

--- a/resources/views/sweatbook/index.blade.php
+++ b/resources/views/sweatbook/index.blade.php
@@ -40,18 +40,18 @@
                             <tr>
                                 <td>
                                     @can('update', $booking)
-                                        <a href="/sweatbook/{{ $booking->id }}">{{ Carbon\Carbon::create($booking->date)->toEuropeanDate(true) }}
+                                        <a href="/sweatbook/{{ $booking->id }}">{{ $booking->time_start->toEuropeanDate(true) }}
                                         &nbsp;&nbsp;<i class="fa fa-pencil-alt w3-tiny" aria-hidden="true"></i></a>
                                     @endcan
                                     @cannot('update', $booking)
-                                        {{ Carbon\Carbon::create($booking->date)->toEuropeanDate(true) }}
+                                        {{ $booking->time_start->toEuropeanDate(true) }}
                                     @endcannot
                                 </td>
                                 <td>
-                                    {{ Carbon\Carbon::create($booking->start_at)->toEuropeanTime() }}
+                                    {{ $booking->time_start->toEuropeanTime() }}
                                 </td>
                                 <td>
-                                    {{ Carbon\Carbon::create($booking->end_at)->toEuropeanTime() }}
+                                    {{ $booking->time_end->toEuropeanTime() }}
                                 </td>
                                 <td>
                                     {{ $booking->position->callsign }} ({{ $booking->position->name }})

--- a/resources/views/sweatbook/show.blade.php
+++ b/resources/views/sweatbook/show.blade.php
@@ -21,7 +21,7 @@
 
                     <div class="mb-3">
                         <label class="form-label" for="start_at">Start (Zulu)</label>
-                        <input id="start_at" class="form-control @error('start_at') is-invalid @enderror" type="time" name="start_at" placeholder="12:00" value="{{ empty(old('start_at')) ? \Carbon\Carbon::createFromFormat('H:i:s', $booking->start_at)->format('H:i') : old('start_at') }}" required>
+                        <input id="start_at" class="form-control @error('start_at') is-invalid @enderror" type="time" name="start_at" placeholder="12:00" value="{{ empty(old('start_at')) ? $booking->time_start->format('H:i') : old('start_at') }}" required>
                         @error('start_at')
                             <span class="text-danger">{{ $errors->first('start_at') }}</span>
                         @enderror
@@ -29,7 +29,7 @@
 
                     <div class="mb-3">
                         <label class="form-label" for="end_at">End (Zulu)</label>
-                        <input id="end_at" class="form-control @error('end_at') is-invalid @enderror" type="time" name="end_at" placeholder="12:00" value="{{ empty(old('end_at')) ? \Carbon\Carbon::createFromFormat('H:i:s', $booking->end_at)->format('H:i') : old('end_at') }}" required>
+                        <input id="end_at" class="form-control @error('end_at') is-invalid @enderror" type="time" name="end_at" placeholder="12:00" value="{{ empty(old('end_at')) ? $booking->time_end->format('H:i') : old('end_at') }}" required>
                         @error('end_at')
                             <span class="text-danger">{{ $errors->first('end_at') }}</span>
                         @enderror
@@ -82,7 +82,7 @@
 @vite(['resources/js/flatpickr.js', 'resources/sass/flatpickr.scss'])
 <script>
     document.addEventListener("DOMContentLoaded", function () {
-        var defaultDate = "{{ empty(old('date')) ? \Carbon\Carbon::createFromFormat('Y-m-d', $booking->date)->format('d/m/Y') : old('date') }}"
+        var defaultDate = "{{ empty(old('date')) ? $booking->time_start->format('d/m/Y') : old('date') }}"
         document.querySelector('.datepicker').flatpickr({ disableMobile: true, minDate: "{!! date('Y-m-d') !!}", dateFormat: "d/m/Y", defaultDate: defaultDate, locale: {firstDayOfWeek: 1 }});
     })
 </script>

--- a/tests/Feature/SweatbookTest.php
+++ b/tests/Feature/SweatbookTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Area;
+use App\Models\Position;
+use App\Models\Sweatbook;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SweatbookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createMentor(): User
+    {
+        $mentor = User::factory()->create();
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => Area::factory()->create()->id]);
+
+        return $mentor;
+    }
+
+    #[Test]
+    public function mentor_can_create_sweatbook_booking(): void
+    {
+        $mentor = $this->createMentor();
+        $position = Position::factory()->create();
+        $startDate = Carbon::tomorrow()->setHour(10);
+
+        $response = $this->actingAs($mentor)->post('/sweatbook/store', [
+            'date' => $startDate->format('d/m/Y'),
+            'start_at' => $startDate->format('H:i'),
+            'end_at' => $startDate->copy()->addHours(2)->format('H:i'),
+            'position' => $position->callsign,
+        ]);
+
+        $response->assertRedirect('/sweatbook');
+        $response->assertSessionHasNoErrors();
+        $this->assertEquals(1, Sweatbook::count());
+    }
+
+    #[Test]
+    public function sweatbook_booking_requires_a_valid_duration(): void
+    {
+        $mentor = $this->createMentor();
+        $position = Position::factory()->create();
+        $startDate = Carbon::tomorrow()->setHour(10);
+
+        $response = $this->actingAs($mentor)->from('/sweatbook')->post('/sweatbook/store', [
+            'date' => $startDate->format('d/m/Y'),
+            'start_at' => $startDate->format('H:i'),
+            'end_at' => $startDate->format('H:i'),
+            'position' => $position->callsign,
+        ]);
+
+        $response->assertInvalid();
+        $this->assertEquals(0, Sweatbook::count());
+    }
+
+    private function createSweatbook(Position $position, Carbon $startAt, Carbon $endAt): Sweatbook
+    {
+        $booking = new Sweatbook();
+        $booking->user_id = User::factory()->create()->id;
+        $booking->position_id = $position->id;
+        $booking->time_start = $startAt;
+        $booking->time_end = $endAt;
+        $booking->save();
+
+        return $booking;
+    }
+
+    #[Test]
+    public function index_and_show_display_the_booking_date_and_times(): void
+    {
+        $mentor = $this->createMentor();
+        $position = Position::factory()->create();
+        $booking = $this->createSweatbook($position, Carbon::tomorrow()->setHour(9)->setMinute(30), Carbon::tomorrow()->setHour(11));
+        $booking->user_id = $mentor->id;
+        $booking->save();
+
+        $this->actingAs($mentor)->get('/sweatbook')
+            ->assertSuccessful()
+            ->assertSee(Carbon::tomorrow()->format('D. d/m/Y'))
+            ->assertSee('09:30z')
+            ->assertSee('11:00z')
+            ->assertSee($position->callsign);
+
+        $this->actingAs($mentor)->get('/sweatbook/' . $booking->id)
+            ->assertSuccessful()
+            ->assertSee('value="09:30"', false)
+            ->assertSee('value="11:00"', false)
+            ->assertSee(Carbon::tomorrow()->format('d/m/Y'));
+    }
+
+    #[Test]
+    public function clean_command_removes_only_past_sweatbook_bookings(): void
+    {
+        $position = Position::factory()->create();
+
+        $this->createSweatbook($position, Carbon::yesterday()->setHour(10), Carbon::yesterday()->setHour(12));
+        $upcoming = $this->createSweatbook($position, Carbon::tomorrow()->setHour(10), Carbon::tomorrow()->setHour(12));
+
+        $this->artisan('clean:sweatbooks')->assertSuccessful();
+
+        $this->assertEquals([$upcoming->id], Sweatbook::pluck('id')->all());
+    }
+
+    #[Test]
+    public function overlapping_sweatbook_booking_is_rejected(): void
+    {
+        $mentor = $this->createMentor();
+        $position = Position::factory()->create();
+        $startDate = Carbon::tomorrow()->setHour(10);
+
+        $bookingRequest = [
+            'date' => $startDate->format('d/m/Y'),
+            'start_at' => $startDate->format('H:i'),
+            'end_at' => $startDate->copy()->addHours(2)->format('H:i'),
+            'position' => $position->callsign,
+        ];
+
+        $this->actingAs($mentor)->post('/sweatbook/store', $bookingRequest)->assertSessionHasNoErrors();
+        $response = $this->actingAs($mentor)->from('/sweatbook')->post('/sweatbook/store', $bookingRequest);
+
+        $response->assertInvalid();
+        $this->assertEquals(1, Sweatbook::count());
+    }
+}

--- a/tests/Unit/BookingServiceTest.php
+++ b/tests/Unit/BookingServiceTest.php
@@ -1,0 +1,418 @@
+<?php
+
+namespace Tests\Unit;
+
+use anlutro\LaravelSettings\Facade as Setting;
+use App\Helpers\TrainingStatus;
+use App\Helpers\VatsimRating;
+use App\Models\Area;
+use App\Models\Booking;
+use App\Models\Position;
+use App\Models\Rating;
+use App\Models\Sweatbook;
+use App\Models\Training;
+use App\Models\User;
+use App\Services\BookingService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class BookingServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private BookingService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new BookingService();
+    }
+
+    private function makeBooking(Position $position, Carbon $startAt, Carbon $endAt): Booking
+    {
+        $user = User::factory()->create();
+
+        $booking = new Booking();
+        $booking->callsign = $position->callsign;
+        $booking->position_id = $position->id;
+        $booking->name = $user->name;
+        $booking->user_id = $user->id;
+        $booking->time_start = $startAt;
+        $booking->time_end = $endAt;
+
+        return $booking;
+    }
+
+    private function makeSweatbook(Position $position, Carbon $startAt, Carbon $endAt): Sweatbook
+    {
+        $booking = new Sweatbook();
+        $booking->user_id = User::factory()->create()->id;
+        $booking->position_id = $position->id;
+        $booking->time_start = $startAt;
+        $booking->time_end = $endAt;
+
+        return $booking;
+    }
+
+    #[Test]
+    public function parse_period_returns_start_and_end_on_the_given_date(): void
+    {
+        [$startAt, $endAt] = $this->service->parsePeriod('25/12/2026', '10:00', '12:30');
+
+        $this->assertSame('2026-12-25 10:00', $startAt->format('Y-m-d H:i'));
+        $this->assertSame('2026-12-25 12:30', $endAt->format('Y-m-d H:i'));
+    }
+
+    #[Test]
+    public function adjust_for_overnight_adds_a_day_when_end_is_before_start(): void
+    {
+        [$startAt, $endAt] = $this->service->parsePeriod('25/12/2026', '23:00', '01:00');
+
+        $this->service->adjustForOvernight($startAt, $endAt);
+
+        $this->assertSame('2026-12-26 01:00', $endAt->format('Y-m-d H:i'));
+    }
+
+    #[Test]
+    public function adjust_for_overnight_keeps_end_when_after_start(): void
+    {
+        [$startAt, $endAt] = $this->service->parsePeriod('25/12/2026', '10:00', '12:00');
+
+        $this->service->adjustForOvernight($startAt, $endAt);
+
+        $this->assertSame('2026-12-25 12:00', $endAt->format('Y-m-d H:i'));
+    }
+
+    #[Test]
+    public function start_in_the_past_is_detected(): void
+    {
+        $this->assertTrue($this->service->isStartInPast(Carbon::now()->subHour()));
+        $this->assertFalse($this->service->isStartInPast(Carbon::now()->addHour()));
+    }
+
+    #[Test]
+    public function booking_conflict_is_detected_for_overlapping_times(): void
+    {
+        $position = Position::factory()->create();
+        $start = Carbon::tomorrow()->setHour(10);
+        $this->makeBooking($position, $start, $start->copy()->addHours(2))->save();
+
+        $overlapping = $this->makeBooking($position, $start->copy()->addHour(), $start->copy()->addHours(3));
+
+        $this->assertTrue($this->service->bookingConflictExists($overlapping));
+    }
+
+    #[Test]
+    public function booking_conflict_ignores_adjacent_bookings(): void
+    {
+        $position = Position::factory()->create();
+        $start = Carbon::tomorrow()->setHour(10);
+        $this->makeBooking($position, $start, $start->copy()->addHours(2))->save();
+
+        $adjacent = $this->makeBooking($position, $start->copy()->addHours(2), $start->copy()->addHours(4));
+
+        $this->assertFalse($this->service->bookingConflictExists($adjacent));
+    }
+
+    #[Test]
+    public function booking_conflict_ignores_other_positions(): void
+    {
+        $position = Position::factory()->create();
+        $otherPosition = Position::factory()->create();
+        $start = Carbon::tomorrow()->setHour(10);
+        $this->makeBooking($position, $start, $start->copy()->addHours(2))->save();
+
+        $otherPositionBooking = $this->makeBooking($otherPosition, $start->copy()->addHour(), $start->copy()->addHours(3));
+
+        $this->assertFalse($this->service->bookingConflictExists($otherPositionBooking));
+    }
+
+    #[Test]
+    public function booking_conflict_ignores_deleted_bookings(): void
+    {
+        $position = Position::factory()->create();
+        $start = Carbon::tomorrow()->setHour(10);
+        $deleted = $this->makeBooking($position, $start, $start->copy()->addHours(2));
+        $deleted->deleted = true;
+        $deleted->save();
+
+        $overlapping = $this->makeBooking($position, $start->copy()->addHour(), $start->copy()->addHours(3));
+
+        $this->assertFalse($this->service->bookingConflictExists($overlapping));
+    }
+
+    #[Test]
+    public function booking_conflict_ignores_the_booking_itself_on_update(): void
+    {
+        $position = Position::factory()->create();
+        $start = Carbon::tomorrow()->setHour(10);
+        $booking = $this->makeBooking($position, $start, $start->copy()->addHours(2));
+        $booking->save();
+
+        $booking->time_start = $start->copy()->addHour();
+        $booking->time_end = $start->copy()->addHours(3);
+
+        $this->assertFalse($this->service->bookingConflictExists($booking));
+    }
+
+    #[Test]
+    public function sweatbook_conflict_is_detected_for_overlapping_times(): void
+    {
+        $position = Position::factory()->create();
+        $start = Carbon::tomorrow()->setHour(10);
+        $this->makeSweatbook($position, $start, $start->copy()->addHours(2))->save();
+
+        $overlapping = $this->makeSweatbook($position, $start->copy()->addHour(), $start->copy()->addHours(3));
+
+        $this->assertTrue($this->service->sweatbookConflictExists($overlapping));
+    }
+
+    #[Test]
+    public function sweatbook_conflict_ignores_other_positions(): void
+    {
+        $position = Position::factory()->create();
+        $otherPosition = Position::factory()->create();
+        $start = Carbon::tomorrow()->setHour(10);
+        $this->makeSweatbook($position, $start, $start->copy()->addHours(2))->save();
+
+        $otherPositionBooking = $this->makeSweatbook($otherPosition, $start->copy()->addHour(), $start->copy()->addHours(3));
+
+        $this->assertFalse($this->service->sweatbookConflictExists($otherPositionBooking));
+    }
+
+    #[Test]
+    public function sweatbook_conflict_ignores_the_booking_itself_on_update(): void
+    {
+        $position = Position::factory()->create();
+        $start = Carbon::tomorrow()->setHour(10);
+        $booking = $this->makeSweatbook($position, $start, $start->copy()->addHours(2));
+        $booking->save();
+
+        $booking->time_start = $start->copy()->addHour();
+        $booking->time_end = $start->copy()->addHours(3);
+
+        $this->assertFalse($this->service->sweatbookConflictExists($booking));
+    }
+
+    #[Test]
+    public function applying_training_tag_sets_flags_and_returns_type(): void
+    {
+        $booking = new Booking();
+
+        $this->assertSame('training', $this->service->applyTagToBooking($booking, 1));
+        $this->assertEquals(1, $booking->training);
+        $this->assertEquals(0, $booking->exam);
+        $this->assertEquals(0, $booking->event);
+    }
+
+    #[Test]
+    public function applying_exam_tag_sets_flags_and_returns_type(): void
+    {
+        $booking = new Booking();
+
+        $this->assertSame('exam', $this->service->applyTagToBooking($booking, 2));
+        $this->assertEquals(0, $booking->training);
+        $this->assertEquals(1, $booking->exam);
+        $this->assertEquals(0, $booking->event);
+    }
+
+    #[Test]
+    public function applying_event_tag_sets_flags_and_returns_type(): void
+    {
+        $booking = new Booking();
+
+        $this->assertSame('event', $this->service->applyTagToBooking($booking, 3));
+        $this->assertEquals(0, $booking->training);
+        $this->assertEquals(0, $booking->exam);
+        $this->assertEquals(1, $booking->event);
+    }
+
+    #[Test]
+    public function applying_no_tag_keeps_training_flag_untouched(): void
+    {
+        $booking = new Booking();
+        $booking->training = 1;
+
+        $this->assertSame('booking', $this->service->applyTagToBooking($booking, null));
+        $this->assertEquals(1, $booking->training);
+        $this->assertEquals(0, $booking->exam);
+        $this->assertEquals(0, $booking->event);
+    }
+
+    #[Test]
+    public function training_tag_is_forced_when_position_is_above_user_rating(): void
+    {
+        $position = Position::factory()->create(['rating' => VatsimRating::C1->value]);
+        $user = User::factory()->create(['rating' => VatsimRating::S2->value]);
+        $booking = $this->makeBooking($position, Carbon::tomorrow()->setHour(10), Carbon::tomorrow()->setHour(12));
+
+        $this->assertTrue($this->service->shouldForceTrainingTag($booking, $position, $user));
+    }
+
+    #[Test]
+    public function training_tag_is_not_forced_when_user_rating_is_sufficient(): void
+    {
+        $position = Position::factory()->create(['rating' => VatsimRating::S2->value]);
+        $user = User::factory()->create(['rating' => VatsimRating::C1->value]);
+        $booking = $this->makeBooking($position, Carbon::tomorrow()->setHour(10), Carbon::tomorrow()->setHour(12));
+
+        $this->assertFalse($this->service->shouldForceTrainingTag($booking, $position, $user));
+    }
+
+    #[Test]
+    public function active_bookings_exclude_deleted_and_are_sorted_by_start_time(): void
+    {
+        $position = Position::factory()->create();
+        $start = Carbon::tomorrow()->setHour(10);
+
+        $later = $this->makeBooking($position, $start->copy()->addHours(4), $start->copy()->addHours(6));
+        $later->save();
+        $earlier = $this->makeBooking($position, $start, $start->copy()->addHours(2));
+        $earlier->save();
+        $deleted = $this->makeBooking($position, $start->copy()->addHours(8), $start->copy()->addHours(10));
+        $deleted->deleted = true;
+        $deleted->save();
+
+        $bookings = $this->service->getActiveBookings();
+
+        $this->assertEquals([$earlier->id, $later->id], $bookings->pluck('id')->values()->all());
+        $this->assertTrue($bookings->first()->relationLoaded('position'));
+        $this->assertTrue($bookings->first()->relationLoaded('user'));
+    }
+
+    #[Test]
+    public function sweatbook_bookings_are_sorted_by_start_time_across_dates(): void
+    {
+        $position = Position::factory()->create();
+
+        $nextDayMorning = $this->makeSweatbook($position, Carbon::tomorrow()->addDay()->setHour(9), Carbon::tomorrow()->addDay()->setHour(11));
+        $nextDayMorning->save();
+
+        $evening = $this->makeSweatbook($position, Carbon::tomorrow()->setHour(18), Carbon::tomorrow()->setHour(20));
+        $evening->save();
+
+        $morning = $this->makeSweatbook($position, Carbon::tomorrow()->setHour(8), Carbon::tomorrow()->setHour(10));
+        $morning->save();
+
+        $bookings = $this->service->getActiveBookings(Sweatbook::class);
+
+        $this->assertEquals(
+            [$morning->id, $evening->id, $nextDayMorning->id],
+            $bookings->pluck('id')->values()->all()
+        );
+        $this->assertTrue($bookings->first()->relationLoaded('position'));
+        $this->assertTrue($bookings->first()->relationLoaded('user'));
+    }
+
+    #[Test]
+    public function user_with_bypass_permission_can_book_all_positions(): void
+    {
+        Position::factory()->count(2)->create();
+        $mentor = User::factory()->create(['rating' => VatsimRating::S1->value]);
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => Area::factory()->create()->id]);
+
+        $this->assertEquals(Position::count(), $this->service->getBookablePositions($mentor)->count());
+    }
+
+    #[Test]
+    public function rated_user_can_book_positions_in_active_areas_up_to_their_rating(): void
+    {
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $area = Area::factory()->create();
+        $tower = Position::factory()->create(['area_id' => $area->id, 'rating' => VatsimRating::S2->value]);
+        $center = Position::factory()->create(['area_id' => $area->id, 'rating' => VatsimRating::C1->value]);
+        $otherAreaTower = Position::factory()->create(['rating' => VatsimRating::S2->value]);
+
+        $user = User::factory()->create(['rating' => VatsimRating::S2->value]);
+        $user->atcActivity()->create(['user_id' => $user->id, 'area_id' => $area->id, 'hours' => 100, 'atc_active' => true]);
+
+        $positions = $this->service->getBookablePositions($user);
+
+        $this->assertTrue($positions->contains('id', $tower->id));
+        $this->assertFalse($positions->contains('id', $center->id));
+        $this->assertFalse($positions->contains('id', $otherAreaTower->id));
+    }
+
+    #[Test]
+    public function rated_user_can_book_positions_in_all_areas_when_activity_is_based_on_total_hours(): void
+    {
+        Setting::set('atcActivityBasedOnTotalHours', true);
+
+        $tower = Position::factory()->create(['rating' => VatsimRating::S2->value]);
+        $user = User::factory()->create(['rating' => VatsimRating::S2->value]);
+
+        $positions = $this->service->getBookablePositions($user);
+
+        $this->assertTrue($positions->contains('id', $tower->id));
+    }
+
+    #[Test]
+    public function user_below_s1_without_training_cannot_book_any_positions(): void
+    {
+        Position::factory()->create();
+        $user = User::factory()->create(['rating' => VatsimRating::OBS->value]);
+
+        $this->assertTrue($this->service->getBookablePositions($user)->isEmpty());
+    }
+
+    #[Test]
+    public function student_in_training_can_book_training_area_positions_up_to_the_training_rating(): void
+    {
+        $area = Area::factory()->create();
+        $tower = Position::factory()->create(['area_id' => $area->id, 'rating' => VatsimRating::S2->value]);
+        $center = Position::factory()->create(['area_id' => $area->id, 'rating' => VatsimRating::C1->value]);
+
+        $student = User::factory()->create(['rating' => VatsimRating::S1->value]);
+        Training::factory()
+            ->has(Rating::factory(['vatsim_rating' => VatsimRating::S2]))
+            ->create(['user_id' => $student->id, 'type' => 1, 'status' => TrainingStatus::ACTIVE_TRAINING->value, 'area_id' => $area->id]);
+
+        $positions = $this->service->getBookablePositions($student);
+
+        $this->assertTrue($positions->contains('id', $tower->id));
+        $this->assertFalse($positions->contains('id', $center->id));
+    }
+
+    #[Test]
+    public function booking_activity_is_logged(): void
+    {
+        $position = Position::factory()->create();
+        $start = Carbon::tomorrow()->setHour(10);
+        $booking = $this->makeBooking($position, $start, $start->copy()->addHours(2));
+        $booking->save();
+
+        $this->service->logBookingCreated($booking);
+
+        $this->assertDatabaseHas('activity_logs', [
+            'type' => 'INFO',
+            'category' => 'BOOKING',
+            'message' => 'Created booking booking ' . $booking->id .
+                ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
+                ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
+                ' ― Position: ' . $position->callsign,
+        ]);
+    }
+
+    #[Test]
+    public function sweatbook_activity_is_logged(): void
+    {
+        $position = Position::factory()->create();
+        $start = Carbon::tomorrow()->setHour(10);
+        $booking = $this->makeSweatbook($position, $start, $start->copy()->addHours(2));
+        $booking->save();
+
+        $this->service->logBookingDeleted($booking);
+
+        $this->assertDatabaseHas('activity_logs', [
+            'type' => 'WARNING',
+            'category' => 'BOOKING',
+            'message' => 'Deleted sweatbox booking ' . $booking->id .
+                ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
+                ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
+                ' ― Position: ' . $position->callsign,
+        ]);
+    }
+}

--- a/tests/Unit/VatsimBookingApiTest.php
+++ b/tests/Unit/VatsimBookingApiTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Contracts\VatsimBookingApiContract;
+use App\Exceptions\VatsimAPIException;
+use App\Facades\VatsimBookingApi;
+use App\Models\Booking;
+use App\Models\Position;
+use App\Models\User;
+use App\Services\VatsimBooking\Api;
+use App\Services\VatsimBooking\NoOpApi;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class VatsimBookingApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config([
+            'vatsim.booking_api_url' => 'https://booking-api.test',
+            'vatsim.booking_api_token' => 'test-token',
+        ]);
+    }
+
+    private function makeBooking(): Booking
+    {
+        $position = Position::factory()->create();
+        $user = User::factory()->create();
+        $start = Carbon::tomorrow()->setHour(10);
+
+        $booking = new Booking();
+        $booking->callsign = $position->callsign;
+        $booking->position_id = $position->id;
+        $booking->name = $user->name;
+        $booking->user_id = $user->id;
+        $booking->time_start = $start;
+        $booking->time_end = $start->copy()->addHours(2);
+
+        return $booking;
+    }
+
+    #[Test]
+    public function noop_service_is_bound_outside_production(): void
+    {
+        $this->assertInstanceOf(NoOpApi::class, app(VatsimBookingApiContract::class));
+    }
+
+    #[Test]
+    public function noop_service_sends_no_requests_and_returns_null(): void
+    {
+        Http::fake();
+
+        $this->assertNull(VatsimBookingApi::createBooking($this->makeBooking(), 'booking'));
+
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function create_booking_posts_to_the_vatsim_api_and_returns_the_booking_id(): void
+    {
+        Http::fake([
+            'booking-api.test/booking' => Http::response(['id' => 1337]),
+        ]);
+
+        $booking = $this->makeBooking();
+        $vatsimBookingId = (new Api())->createBooking($booking, 'training');
+
+        $this->assertSame(1337, $vatsimBookingId);
+        Http::assertSent(function ($request) use ($booking) {
+            return $request->url() === 'https://booking-api.test/booking'
+                && $request->method() === 'POST'
+                && $request->hasHeader('Authorization', 'Bearer test-token')
+                && $request['callsign'] === $booking->callsign
+                && $request['cid'] == $booking->user_id
+                && $request['type'] === 'training'
+                && $request['start'] === $booking->time_start->format('Y-m-d H:i:s')
+                && $request['end'] === $booking->time_end->format('Y-m-d H:i:s');
+        });
+    }
+
+    #[Test]
+    public function update_booking_puts_to_the_vatsim_api_and_returns_the_booking_id(): void
+    {
+        Http::fake([
+            'booking-api.test/booking/42' => Http::response(['id' => 42]),
+        ]);
+
+        $booking = $this->makeBooking();
+        $booking->vatsim_booking = 42;
+        $vatsimBookingId = (new Api())->updateBooking($booking, 'booking');
+
+        $this->assertSame(42, $vatsimBookingId);
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://booking-api.test/booking/42'
+                && $request->method() === 'PUT';
+        });
+    }
+
+    #[Test]
+    public function delete_booking_sends_a_delete_request(): void
+    {
+        Http::fake([
+            'booking-api.test/booking/42' => Http::response(),
+        ]);
+
+        $booking = $this->makeBooking();
+        $booking->vatsim_booking = 42;
+        (new Api())->deleteBooking($booking);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://booking-api.test/booking/42'
+                && $request->method() === 'DELETE';
+        });
+    }
+
+    #[Test]
+    public function failed_request_throws_a_vatsim_api_exception(): void
+    {
+        Http::fake([
+            'booking-api.test/*' => Http::response(['error' => 'nope'], 422),
+        ]);
+
+        $this->expectException(VatsimAPIException::class);
+
+        (new Api())->createBooking($this->makeBooking(), 'booking');
+    }
+}


### PR DESCRIPTION
Includes some shared booking components, along with a set of VatsimBookingApi resources: a facade, the primary service for prod, and a no-op service for local use. Not something for you to choose between, but helps split out the one behaviour from the other.

While making these changes we also share the same sort method as the BookingController. Thus, SweatBox bookings are now sorted correctly. 

Fixes #1495.

BEGIN_COMMIT_OVERRIDE
fix(bookings): create shared booking service with sweatbook (#1498)
END_COMMIT_OVERRIDE


## Summary by Sourcery

Extract shared booking domain logic into a reusable service and VATSIM booking API abstraction, and apply it to both controller-driven and sweatbox bookings while unifying time handling.

Enhancements:
- Introduce a BookingService to encapsulate booking period parsing, conflict detection, tag handling, logging, and bookable-position selection for both regular and sweatbox bookings.
- Refactor BookingController and SweatbookController to delegate booking lifecycle operations and sorting to the shared BookingService.
- Normalize sweatbox booking date/time handling by replacing separate date/time columns with unified datetime fields and updating related console command logic.
- Introduce a VatsimBookingApi abstraction with production and no-op implementations, bound via a service provider and accessed through a facade, to handle all VATSIM booking API interactions.

Tests:
- Add unit tests for BookingService covering period parsing, conflict detection, tag logic, sortable active bookings, bookable-position rules, and activity logging.
- Add unit tests for the VATSIM booking API abstraction, including HTTP integration behavior and error handling.
- Add feature tests for sweatbox bookings to validate mentor permissions, duration and overlap validation, display of date/times, and clean-up behavior.