### PR TITLE
docs: document director role and post-upgrade access review

### DIFF
--- a/docs/reference/permissions.md
+++ b/docs/reference/permissions.md
@@ -10,11 +10,17 @@ The catalogue of roles, permissions, and configuration knobs that ship with Cont
 
 | Role | Scope | Description |
 | --- | --- | --- |
-| `admin` | `global` | System-wide administrator. Bypasses area checks (via the per-policy `before` hook) and is expected to be listed against every permission you want unrestricted. |
+| `admin` | `global` | System-wide administrator. Assignable **only** via the `user:makeadmin` CLI command — never through the UI. Bypasses area checks (via the per-policy `before` hook) and is expected to be listed against every permission you want unrestricted. |
+| `director` | `both` | Director of an area, or of the whole organisation when assigned globally. Holds every admin permission except the system-level ones (`manage-area`, `view-system-health`). Only global admins and global directors may grant or revoke it. |
 | `moderator` | `both` | Area moderator. Manages users, reports, positions, and endorsements within the assigned area, or system-wide if assigned globally. |
 | `nav-editor` | `area` | Navigational editor. May edit operationally relevant sector data such as positions within the assigned area. |
 | `mentor` | `area` | Training mentor. Can manage and view training within the assigned area. |
 | `buddy` | `area` | Training buddy. Limited training visibility within the assigned area. |
+
+!!! note "Removing an admin"
+    There is currently no CLI command to revoke the `admin` role; removal requires
+    deleting the row from the `role_user` table directly.
+    <!-- TODO: replace with `user:removeadmin` once available. -->
 
 ### Role Scope
 
@@ -26,42 +32,9 @@ The `scope` field on a role restricts where assignments are allowed:
 
 ## Default Permission Matrix
 
-The matrix in `config/roles.php`:
-
-```php
-'matrix' => [
-    // Training
-    'view-training' => ['admin', 'moderator', 'mentor', 'buddy'],
-    'create-training' => ['admin', 'moderator', 'mentor'],
-    'update-training' => ['admin', 'moderator'],
-    'delete-training' => ['admin'],
-
-    // Area & system
-    'manage-area' => ['admin'],
-    'view-system-health' => ['admin'],
-
-    // Users & access
-    'manage-users' => ['admin', 'moderator'],
-    'view-user-access' => ['admin', 'moderator'],
-
-    // Operations
-    'manage-positions' => ['admin', 'moderator', 'nav-editor'],
-
-    // Endorsements
-    'manage-endorsements' => ['admin', 'moderator'],
-    'manage-visiting-endorsements' => ['admin'],
-    'manage-examiner-endorsements' => ['admin'],
-
-    // Reports
-    'view-management-reports' => ['admin', 'moderator'],
-    'view-training-activities' => ['admin', 'moderator'],
-    'view-training-statistics' => ['admin', 'moderator'],
-    'view-mentor-reports' => ['admin', 'moderator', 'mentor'],
-
-    // Bookings
-    'bypass-booking-restrictions' => ['admin', 'moderator', 'mentor'],
-],
-```
+??? abstract "Default matrix in `config/roles.php`"
+    The default permission-to-role mapping lives in the `matrix` block of
+    [`config/roles.php` on `main`](https://github.com/Vatsim-Scandinavia/controlcenter/blob/main/config/roles.php).
 
 A permission that is not listed in the matrix grants no role — `admin` included. The "administrators can do anything" behaviour is a per-policy convention (a `before` hook), not a property of the matrix.
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -27,6 +27,34 @@ This is due to a change in the StatSim API offering which we didn't get around t
 
 The new API requires the use of a dedicated API key, which has a corresponding [required new environment variable for authenticating to StatSim](configuration/index.md#vatsim).
 
+### Access Management: CLI-only Admin and the new Director role
+
+The `admin` role is now strictly system-wide and can no longer be granted, scoped
+to an area, or revoked through the web UI. It is assigned exclusively via:
+
+```sh
+php artisan user:makeadmin
+```
+
+A new `director` [role takes over the "full access to an area" use-case](reference/permissions.md).
+It can be assigned per area or globally through the user access page, and holds every admin permission except the system-level ones (`manage-area`, `view-system-health`).
+Only global admins and global directors can grant or revoke directorships.
+
+#### Manual step after upgrading
+
+Members of the previous administrator group are migrated as **global admins** and
+retain full access. After upgrading, review who actually needs system-wide admin
+rights:
+
+1. Grant `director` (per-area or global) through the UI to those who only need
+   area- or organisation-level management access.
+2. Remove their admin assignment from the `role_user` table directly
+   (`DELETE FROM role_user WHERE user_id = <cid> AND role = 'admin';`).
+   There is no CLI command for revoking admin yet.
+   <!-- TODO: replace with `user:removeadmin` once available. -->
+
+Until this review is done, previously migrated admins keep unrestricted access.
+
 ### Theme System Migration
 
 The theme system has been completely redesigned to support light/dark themes and user preferences.


### PR DESCRIPTION
Removes the default permission matrix in the same swoop.

## Summary by Sourcery

Document the new director role, clarify CLI-only assignment and manual removal of admin privileges, and update references to the default permission matrix location.

Documentation:
- Describe the director role, its scope, and who can grant or revoke it in the permissions reference.
- Clarify that the admin role is assignable only via the user:makeadmin CLI command and currently must be revoked via a direct database change.
- Replace the inline default permission matrix with a link to the matrix definition in config/roles.php on the main branch.
- Add upgrade instructions for reviewing and migrating existing admins to director roles and adjusting admin assignments after the upgrade.