### PR TITLE
refactor(alerts): drive inactive-controller staff alerts from permission

### DIFF
--- a/app/Console/Commands/CheckOnlineControllers.php
+++ b/app/Console/Commands/CheckOnlineControllers.php
@@ -89,21 +89,8 @@ class CheckOnlineControllers extends Command
                             $user->last_inactivity_warning = now();
                             $user->save();
 
-                            // Send warning to all admins, and moderators in selected area
-                            $sendToStaff = User::allWithRole('admin');
-
-                            if (isset($area)) {
-                                $moderators = User::allWithRole('moderator');
-                                foreach ($moderators as $m) {
-                                    if ($sendToStaff->where('id', $m->id)->count()) {
-                                        continue;
-                                    }
-
-                                    if ($m->hasRole('moderator', $area)) {
-                                        $sendToStaff->push($m);
-                                    }
-                                }
-                            }
+                            // Send warning to staff holding the alert permission, limited to the position's area when known
+                            $sendToStaff = User::allWithPermission('receive-inactivity-alerts', $area);
 
                             $user->notify(new InactiveOnlineStaffNotification($sendToStaff, $user, $d['callsign'], $d['logon_time']));
                         } else {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use App\Exceptions\PolicyMethodMissingException;
 use App\Exceptions\PolicyMissingException;
 use App\Support\AreaScope;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -54,6 +55,33 @@ class User extends Authenticatable
 
         return User::whereHas('roleAssignments', function ($query) use ($roles) {
             $query->whereIn('role', $roles);
+        })->get();
+    }
+
+    /**
+     * Find all users granted the given permission, mirroring hasPermission():
+     * without an area, holding the permission anywhere is sufficient; with an
+     * area, the assignment must be global or in that area.
+     *
+     * @return Collection<int, User>
+     */
+    public static function allWithPermission(string $permission, ?Area $area = null): Collection
+    {
+        $allowedRoles = config("roles.matrix.{$permission}", []);
+
+        if (empty($allowedRoles)) {
+            return (new User)->newCollection();
+        }
+
+        return User::whereHas('roleAssignments', function ($query) use ($allowedRoles, $area) {
+            $query->whereIn('role', $allowedRoles);
+
+            if ($area !== null) {
+                $query->where(function ($areaQuery) use ($area) {
+                    $areaQuery->whereNull('area_id')
+                        ->orWhere('area_id', $area->id);
+                });
+            }
         })->get();
     }
 

--- a/config/roles.php
+++ b/config/roles.php
@@ -88,5 +88,8 @@ return [
 
         // Bookings
         'bypass-booking-restrictions' => ['admin', 'director', 'moderator', 'mentor'],
+
+        // Alerts
+        'receive-inactivity-alerts' => ['admin', 'director', 'moderator'],
     ],
 ];

--- a/tests/Unit/RolePermissionTest.php
+++ b/tests/Unit/RolePermissionTest.php
@@ -117,4 +117,92 @@ class RolePermissionTest extends TestCase
         $this->assertTrue($user->hasGlobalRole(['admin', 'moderator']));
         $this->assertFalse($user->hasGlobalRole('admin'));
     }
+
+    public function test_all_with_permission_scoped_to_area_includes_global_and_area_holders()
+    {
+        config(['roles.matrix.test-permission' => ['admin', 'moderator']]);
+
+        $area = Area::factory()->create();
+        $otherArea = Area::factory()->create();
+
+        $globalAdmin = User::factory()->create();
+        $globalAdmin->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        $areaModerator = User::factory()->create();
+        $areaModerator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $otherAreaModerator = User::factory()->create();
+        $otherAreaModerator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $otherArea->id]);
+
+        $areaMentor = User::factory()->create();
+        $areaMentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+
+        $recipients = User::allWithPermission('test-permission', $area);
+
+        $this->assertTrue($recipients->contains($globalAdmin));
+        $this->assertTrue($recipients->contains($areaModerator));
+        $this->assertFalse($recipients->contains($otherAreaModerator));
+        $this->assertFalse($recipients->contains($areaMentor));
+    }
+
+    public function test_all_with_permission_without_area_includes_holders_anywhere()
+    {
+        config(['roles.matrix.test-permission' => ['admin', 'moderator']]);
+
+        $area = Area::factory()->create();
+
+        $globalAdmin = User::factory()->create();
+        $globalAdmin->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        $areaModerator = User::factory()->create();
+        $areaModerator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $areaMentor = User::factory()->create();
+        $areaMentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+
+        $recipients = User::allWithPermission('test-permission');
+
+        $this->assertTrue($recipients->contains($globalAdmin));
+        $this->assertTrue($recipients->contains($areaModerator));
+        $this->assertFalse($recipients->contains($areaMentor));
+    }
+
+    public function test_all_with_permission_matches_has_permission_semantics()
+    {
+        config(['roles.matrix.test-permission' => ['moderator']]);
+
+        $area = Area::factory()->create();
+        $otherArea = Area::factory()->create();
+
+        $areaModerator = User::factory()->create();
+        $areaModerator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        foreach ([null, $area, $otherArea] as $queriedArea) {
+            $this->assertEquals(
+                $areaModerator->hasPermission('test-permission', $queriedArea),
+                User::allWithPermission('test-permission', $queriedArea)->contains($areaModerator)
+            );
+        }
+    }
+
+    public function test_all_with_permission_returns_no_users_for_unknown_permission()
+    {
+        $user = User::factory()->create();
+        $user->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        $this->assertTrue(User::allWithPermission('does-not-exist')->isEmpty());
+    }
+
+    public function test_all_with_permission_returns_each_user_once_despite_multiple_assignments()
+    {
+        config(['roles.matrix.test-permission' => ['admin', 'moderator']]);
+
+        $area = Area::factory()->create();
+
+        $user = User::factory()->create();
+        $user->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+        $user->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $this->assertCount(1, User::allWithPermission('test-permission', $area));
+    }
 }


### PR DESCRIPTION
Staff recipients of InactiveOnlineStaffNotification are resolved via the new receive-inactivity-alerts permission and User::allWithPermission() instead of hardcoded admin/director/moderator role lookups.

## Summary by Sourcery

Drive inactive online staff alert recipients from a permission-based lookup instead of hardcoded staff roles and add support for querying users by permission.

New Features:
- Introduce User::allWithPermission() to retrieve users granted a specific permission, optionally scoped to an area.
- Configure a receive-inactivity-alerts permission mapping to admin, director, and moderator roles for staff alerts.

Enhancements:
- Refactor inactive controller alert command to resolve staff recipients using permission-based lookups rather than explicit role checks.

Tests:
- Add unit tests covering User::allWithPermission() behavior, including area scoping, unknown permissions, de-duplication, and alignment with hasPermission() semantics.