### PR TITLE
refactor(roles): replace hard-coded role checks with permissions

### DIFF
--- a/app/Console/Commands/UpdateWorkmails.php
+++ b/app/Console/Commands/UpdateWorkmails.php
@@ -42,9 +42,9 @@ class UpdateWorkmails extends Command
         // Check for expired workmails
         DB::table('users')->where('setting_workmail_expire', '<=', date('Y-m-d H:i:s'))->update(['setting_workmail_address' => null, 'setting_workmail_expire' => null]);
 
-        // Check for users that no longer hold a moderator, admin or director rank
+        // Check for users that no longer hold a role granting workmail
         foreach (User::whereNotNull('setting_workmail_address')->get() as $user) {
-            if ($user->roleAssignments()->count() == 0 || ! $user->hasRole(['moderator', 'admin', 'director'])) {
+            if (! $user->hasPermission('use-workmail')) {
                 $user->setting_workmail_address = null;
                 $user->setting_workmail_expire = null;
                 $user->save();

--- a/app/Http/Controllers/Admin/PositionController.php
+++ b/app/Http/Controllers/Admin/PositionController.php
@@ -75,7 +75,7 @@ class PositionController extends Controller
 
     private function redirectAfterMutation(Request $request, int $areaId): RedirectResponse
     {
-        $route = $request->user()->hasRole('admin')
+        $route = $request->user()->accessibleAreasForPermission('manage-positions')->isGlobal
             ? route('positions.index.area', $areaId)
             : route('positions.index');
 

--- a/app/Http/Controllers/MentorController.php
+++ b/app/Http/Controllers/MentorController.php
@@ -21,7 +21,7 @@ class MentorController extends Controller
         $trainings = $user->mentoringTrainings();
         $statuses = TrainingController::$statuses;
         $types = TrainingController::$types;
-        if ($user->hasRole(['admin', 'moderator', 'mentor'])) {
+        if ($user->hasPermission('view-mentor-dashboard')) {
             return view('mentor.index', compact('trainings', 'user', 'statuses', 'types'));
         }
 

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -218,17 +218,19 @@ class ReportController extends Controller
     {
         $this->authorize('viewMentors', ManagementReport::class);
 
-        if (auth()->user()->hasRole('admin')) {
-            $mentors = User::whereHas('roleAssignments', function ($q) {
-                $q->where('role', 'mentor');
-            })->with('trainingReports', 'teaches', 'teaches.reports', 'teaches.user')->get();
-        } else {
-            $mentors = User::whereHas('roleAssignments', function ($q) {
-                $q->where('role', 'mentor');
-            })->with('trainingReports', 'teaches', 'teaches.reports', 'teaches.user')->whereHas('roleAssignments', function (Builder $query) {
-                $query->whereIn('area_id', auth()->user()->roleAssignments()->pluck('area_id'));
-            })->get();
+        $scope = auth()->user()->accessibleAreasForPermission('view-management-reports');
+
+        $query = User::whereHas('roleAssignments', function ($q) {
+            $q->where('role', 'mentor');
+        })->with('trainingReports', 'teaches', 'teaches.reports', 'teaches.user');
+
+        if (! $scope->isGlobal) {
+            $query->whereHas('roleAssignments', function (Builder $areaQuery) use ($scope) {
+                $areaQuery->whereIn('area_id', $scope->areas->pluck('id'));
+            });
         }
+
+        $mentors = $query->get();
 
         $mentors = $mentors->sortBy('name')->unique();
         $statuses = TrainingController::$statuses;

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -162,7 +162,7 @@ class TaskController extends Controller
 
         // Filter out users who no longer can receive tasks and end up with 3
         $users = $users->filter(function ($user) {
-            return $user->can('receive', Task::class) && $user->hasRole('moderator');
+            return $user->hasPermission('suggested-task-recipient');
         })->take(3);
 
         return $users;

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -475,7 +475,7 @@ class TrainingController extends Controller
         $notifyOfNewMentor = false;
         if (array_key_exists('mentors', $attributes)) {
             foreach ((array) $attributes['mentors'] as $mentor) {
-                if (! $training->mentors->contains($mentor) && User::find($mentor) != null && User::find($mentor)->hasRole(['admin', 'moderator', 'mentor'], $training->area)) {
+                if (! $training->mentors->contains($mentor) && User::find($mentor) != null && User::find($mentor)->hasPermission('mentor-trainings', $training->area)) {
                     $training->mentors()->attach($mentor, ['expire_at' => now()->addMonths(12)]);
 
                     // Notify student of their new mentor

--- a/app/Notifications/TrainingClosedNotification.php
+++ b/app/Notifications/TrainingClosedNotification.php
@@ -80,13 +80,8 @@ class TrainingClosedNotification extends Notification implements ShouldQueue
         }
 
         // Find staff who wants notification of new training request
-        $bcc = User::allWithRole(['admin', 'moderator'])->where('setting_notify_closedreq', true);
-
-        foreach ($bcc as $key => $user) {
-            if (! $user->hasRole(['admin', 'moderator'], $this->training->area)) {
-                $bcc->pull($key);
-            }
-        }
+        $bcc = User::allWithPermission('receive-training-notifications', $this->training->area)
+            ->where('setting_notify_closedreq', true);
 
         return (new TrainingMail('Training Request Closed', $this->training, $textLines, $contactMail))
             ->to($this->training->user->personalNotificationEmail, $this->training->user->name)

--- a/app/Notifications/TrainingCreatedNotification.php
+++ b/app/Notifications/TrainingCreatedNotification.php
@@ -60,13 +60,8 @@ class TrainingCreatedNotification extends Notification implements ShouldQueue
         }
 
         // Find staff who wants notification of new training request
-        $bcc = User::allWithRole(['admin', 'moderator'])->where('setting_notify_newreq', true);
-
-        foreach ($bcc as $key => $user) {
-            if (! $user->hasRole(['admin', 'moderator'], $this->training->area)) {
-                $bcc->pull($key);
-            }
-        }
+        $bcc = User::allWithPermission('receive-training-notifications', $this->training->area)
+            ->where('setting_notify_newreq', true);
 
         $contactMail = $area->contact;
 

--- a/app/Notifications/TrainingExamNotification.php
+++ b/app/Notifications/TrainingExamNotification.php
@@ -58,13 +58,8 @@ class TrainingExamNotification extends Notification implements ShouldQueue
         ];
 
         // Find staff who wants notification of new training request
-        $bcc = User::allWithRole(['admin', 'moderator'])->where('setting_notify_newexamreport', true);
-
-        foreach ($bcc as $key => $user) {
-            if (! $user->hasRole(['admin', 'moderator'], $this->training->area)) {
-                $bcc->pull($key);
-            }
-        }
+        $bcc = User::allWithPermission('receive-training-notifications', $this->training->area)
+            ->where('setting_notify_newexamreport', true);
 
         return (new TrainingMail('Training Examination Result', $this->training, $textLines, null, route('training.show', $this->training->id), 'Read Report'))
             ->to($this->training->user->personalNotificationEmail, $this->training->user->name)

--- a/app/Policies/ActivityLogPolicy.php
+++ b/app/Policies/ActivityLogPolicy.php
@@ -16,6 +16,6 @@ class ActivityLogPolicy
      */
     public function index(User $user)
     {
-        return $user->hasRole('admin');
+        return $user->hasPermission('view-activity-log');
     }
 }

--- a/app/Policies/BookingPolicy.php
+++ b/app/Policies/BookingPolicy.php
@@ -34,7 +34,7 @@ class BookingPolicy
             $user->isAtcActive() && $user->rating >= VatsimRating::S1->value
             || $user->hasActiveEndorsement('VISITING')
             || $user->getActiveTraining(TrainingStatus::PRE_TRAINING->value) != null
-            || $user->hasRole(['admin', 'moderator']);
+            || $user->hasPermission('manage-bookings');
     }
 
     /**
@@ -55,7 +55,7 @@ class BookingPolicy
         }
 
         // The booking is not Discord but the user is moderator or above
-        if ($booking->source != 'DISCORD' && $user->hasRole(['admin', 'moderator'])) {
+        if ($booking->source != 'DISCORD' && $user->hasPermission('manage-bookings')) {
             return Response::allow();
         }
 
@@ -75,7 +75,7 @@ class BookingPolicy
      */
     public function bookTrainingTag(User $user): bool
     {
-        if ($user->hasRole('moderator')) {
+        if ($user->hasPermission('manage-bookings')) {
             return true;
         }
 
@@ -98,7 +98,7 @@ class BookingPolicy
     public function bookExamTag(User $user): bool
     {
 
-        return $user->isMember() && ($user->rating >= VatsimRating::C1->value || $user->hasRole('moderator'));
+        return $user->isMember() && ($user->rating >= VatsimRating::C1->value || $user->hasPermission('manage-bookings'));
     }
 
     /**
@@ -109,7 +109,7 @@ class BookingPolicy
     public function position(User $user, Booking $booking)
     {
         // TODO: Make it easier to read the order of checks
-        if (($booking->position->rating->value > $user->rating || $user->rating < VatsimRating::S1->value) && ! $user->hasRole('moderator')) {
+        if (($booking->position->rating->value > $user->rating || $user->rating < VatsimRating::S1->value) && ! $user->hasPermission('manage-bookings')) {
             if (
                 $user->getActiveTraining(TrainingStatus::PRE_TRAINING->value) &&
                 $user->getActiveTraining()->getHighestVatsimRating()?->vatsim_rating >= $booking->position->rating->value &&

--- a/app/Policies/FilePolicy.php
+++ b/app/Policies/FilePolicy.php
@@ -17,7 +17,7 @@ class FilePolicy
      */
     public function view(User $user, File $file)
     {
-        return $user->hasRole(['admin', 'moderator']) ||
+        return $user->hasPermission('manage-files') ||
                 $user->is($file->owner) ||
                 ($file->trainingReportAttachment != null ? $user->can('view', $file->trainingReportAttachment) : false);
     }
@@ -29,7 +29,7 @@ class FilePolicy
      */
     public function create(User $user)
     {
-        return $user->hasRole(['admin', 'moderator', 'mentor']);
+        return $user->hasPermission('upload-files');
     }
 
     /**
@@ -39,7 +39,7 @@ class FilePolicy
      */
     public function update(User $user, File $file)
     {
-        return $user->hasRole(['admin', 'moderator']) || $user->is($file->owner);
+        return $user->hasPermission('manage-files') || $user->is($file->owner);
     }
 
     /**
@@ -49,6 +49,6 @@ class FilePolicy
      */
     public function delete(User $user, File $file)
     {
-        return $user->hasRole(['admin', 'moderator']) || $user->is($file->owner);
+        return $user->hasPermission('manage-files') || $user->is($file->owner);
     }
 }

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -11,13 +11,13 @@ class NotificationPolicy
     use HandlesAuthorization;
 
     /**
-     * Determine if the user can modify notification templates
+     * Determine if the user can view notification templates
      *
      * @return bool
      */
     public function viewTemplates(User $user)
     {
-        return $user->hasRole(['admin', 'moderator']);
+        return $user->hasPermission('manage-notification-templates');
     }
 
     /**
@@ -27,6 +27,6 @@ class NotificationPolicy
      */
     public function modifyAreaTemplate(User $user, Area $area)
     {
-        return $user->hasRole('admin') || $user->hasRole('moderator', $area);
+        return $user->hasPermission('manage-notification-templates', $area);
     }
 }

--- a/app/Policies/OneTimeLinkPolicy.php
+++ b/app/Policies/OneTimeLinkPolicy.php
@@ -22,10 +22,10 @@ class OneTimeLinkPolicy
     {
         // Only allow examination link generation if the training is awaiting exam
         if ($type == OneTimeLink::TRAINING_EXAMINATION_TYPE) {
-            return $training->status == TrainingStatus::AWAITING_EXAM->value && ($training->mentors->contains($user) || $user->hasRole(['admin', 'moderator'], $training->area));
+            return $training->status == TrainingStatus::AWAITING_EXAM->value && ($training->mentors->contains($user) || $user->hasPermission('update-training', $training->area));
         }
 
-        return $training->mentors->contains($user) || $user->hasRole(['admin', 'moderator'], $training->area);
+        return $training->mentors->contains($user) || $user->hasPermission('update-training', $training->area);
     }
 
     /**
@@ -41,8 +41,8 @@ class OneTimeLinkPolicy
             return Response::denyAsNotFound('The one-time link provided has expired');
         }
 
-        return ($link->reportType() && ($user->hasRole('mentor') || $user->hasRole('buddy'))
-            || ($link->examinationType() && $user->isExaminer()))
+        return ($link->reportType() && $user->hasPermission('use-report-one-time-link'))
+            || ($link->examinationType() && $user->isExaminer())
             ? Response::allow()
             : Response::deny('You are not allowed to access the one-time link');
     }

--- a/app/Policies/SettingPolicy.php
+++ b/app/Policies/SettingPolicy.php
@@ -11,13 +11,13 @@ class SettingPolicy
     use HandlesAuthorization;
 
     /**
-     * Determine whether the user view global settings.
+     * Determine whether the user can view global settings.
      *
      * @return bool
      */
     public function index(User $user, Setting $setting)
     {
-        return $user->hasRole('admin');
+        return $user->hasPermission('manage-settings');
     }
 
     /**
@@ -27,6 +27,6 @@ class SettingPolicy
      */
     public function edit(User $user, Setting $setting)
     {
-        return $user->hasRole('admin');
+        return $user->hasPermission('manage-settings');
     }
 }

--- a/app/Policies/SweatbookPolicy.php
+++ b/app/Policies/SweatbookPolicy.php
@@ -2,7 +2,7 @@
 
 namespace App\Policies;
 
-use App\Models\SweatBook;
+use App\Models\Sweatbook;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
@@ -17,7 +17,7 @@ class SweatbookPolicy
      */
     public function view(User $user)
     {
-        return $user->hasRole(['admin', 'moderator', 'mentor']);
+        return $user->hasPermission('use-sweatbook');
     }
 
     /**
@@ -27,7 +27,7 @@ class SweatbookPolicy
      */
     public function create(User $user)
     {
-        return $user->hasRole(['admin', 'moderator', 'mentor']);
+        return $user->hasPermission('use-sweatbook');
     }
 
     /**
@@ -35,8 +35,8 @@ class SweatbookPolicy
      *
      * @return bool
      */
-    public function update(User $user, SweatBook $booking)
+    public function update(User $user, Sweatbook $booking)
     {
-        return $booking->user_id == $user->id || $user->hasRole(['admin', 'moderator']);
+        return $booking->user_id == $user->id || $user->hasPermission('manage-sweatbook');
     }
 }

--- a/app/Policies/TaskPolicy.php
+++ b/app/Policies/TaskPolicy.php
@@ -16,7 +16,7 @@ class TaskPolicy
      */
     public function create(User $user)
     {
-        return $user->hasRole(['admin', 'moderator', 'mentor']) || $user->isExaminer();
+        return $user->hasPermission('manage-tasks') || $user->isExaminer();
     }
 
     /**
@@ -26,7 +26,7 @@ class TaskPolicy
      */
     public function update(User $user)
     {
-        return $user->hasRole(['admin', 'moderator', 'mentor']) || $user->isExaminer();
+        return $user->hasPermission('manage-tasks') || $user->isExaminer();
     }
 
     /**
@@ -36,6 +36,6 @@ class TaskPolicy
      */
     public function receive(User $user)
     {
-        return $user->hasRole(['admin', 'moderator', 'mentor']) || $user->isExaminer();
+        return $user->hasPermission('manage-tasks') || $user->isExaminer();
     }
 }

--- a/app/Policies/TrainingActivityPolicy.php
+++ b/app/Policies/TrainingActivityPolicy.php
@@ -29,7 +29,7 @@ class TrainingActivityPolicy
     public function view(User $user, Training $training, string $type)
     {
         if ($type == 'COMMENT') {
-            return $training->mentors->contains($user) || $user->hasRole(['admin', 'moderator'], $training->area);
+            return $training->mentors->contains($user) || $user->hasPermission('view-training-activities', $training->area);
         }
 
         return true;

--- a/app/Policies/TrainingExaminationPolicy.php
+++ b/app/Policies/TrainingExaminationPolicy.php
@@ -19,7 +19,7 @@ class TrainingExaminationPolicy
      */
     public function view(User $user, TrainingExamination $examination)
     {
-        return $user->hasRole(['admin', 'moderator']) || ($examination->training->mentors->contains($user) || $user->is($examination->training->user) || $user->isExaminer());
+        return $user->hasPermission('manage-examinations', $examination->training->area) || ($examination->training->mentors->contains($user) || $user->is($examination->training->user) || $user->isExaminer());
     }
 
     /**
@@ -30,7 +30,7 @@ class TrainingExaminationPolicy
     public function create(User $user, Training $training)
     {
 
-        if ($user->hasRole('admin')) {
+        if ($user->hasPermission('create-examinations')) {
             return true;
         }
 
@@ -51,11 +51,7 @@ class TrainingExaminationPolicy
      */
     public function update(User $user, TrainingExamination $examination)
     {
-        if ($user->hasRole('admin')) {
-            return true;
-        }
-
-        return $examination->draft ? ($user->hasRole(['admin', 'moderator'], $examination->training->area) || $user->isExaminer()) : $user->hasRole(['admin', 'moderator'], $examination->training->area);
+        return $examination->draft ? ($user->hasPermission('manage-examinations', $examination->training->area) || $user->isExaminer()) : $user->hasPermission('manage-examinations', $examination->training->area);
     }
 
     /**
@@ -65,6 +61,6 @@ class TrainingExaminationPolicy
      */
     public function delete(User $user, TrainingExamination $trainingExamination)
     {
-        return $user->hasRole(['admin', 'moderator'], $trainingExamination->training->area) || $user->hasRole('admin');
+        return $user->hasPermission('manage-examinations', $trainingExamination->training->area);
     }
 }

--- a/app/Policies/TrainingObjectAttachmentPolicy.php
+++ b/app/Policies/TrainingObjectAttachmentPolicy.php
@@ -19,7 +19,7 @@ class TrainingObjectAttachmentPolicy
     {
         $attachmentArea = $attachment->object->training->area;
 
-        return ($user->can('view', $attachment->object) && $attachment->hidden != true) || $user->hasRole('mentor', $attachmentArea);
+        return ($user->can('view', $attachment->object) && $attachment->hidden != true) || $user->hasPermission('view-hidden-training-attachments', $attachmentArea);
     }
 
     /**
@@ -29,7 +29,7 @@ class TrainingObjectAttachmentPolicy
      */
     public function create(User $user)
     {
-        return $user->hasRole(['admin', 'moderator', 'mentor']);
+        return $user->hasPermission('upload-files');
     }
 
     /**
@@ -39,6 +39,6 @@ class TrainingObjectAttachmentPolicy
      */
     public function delete(User $user, TrainingObjectAttachment $attachment)
     {
-        return $user->hasRole(['admin', 'moderator'], $attachment->object->training->area) || $user->is($attachment->file->owner);
+        return $user->hasPermission('manage-files', $attachment->object->training->area) || $user->is($attachment->file->owner);
     }
 }

--- a/app/Policies/TrainingReportPolicy.php
+++ b/app/Policies/TrainingReportPolicy.php
@@ -20,8 +20,7 @@ class TrainingReportPolicy
     {
         return $training->mentors->contains($user) ||
                 $user->is($training->user) ||
-                $user->hasRole(['admin', 'moderator'], $training->area) ||
-                $user->hasRole('admin');
+                $user->hasPermission('view-training-reports', $training->area);
     }
 
     /**
@@ -37,8 +36,7 @@ class TrainingReportPolicy
             && ! ($isTrainee && $trainingReport->draft)
         )
             || $trainingReport->author->is($user) // If the user is the author of the report
-            || $user->hasRole('admin')
-            || $user->hasRole('moderator', $trainingReport->training->area)
+            || $user->hasPermission('view-training-reports', $trainingReport->training->area)
             || ($isTrainee && ! $trainingReport->draft);
     }
 
@@ -52,14 +50,14 @@ class TrainingReportPolicy
             return false;
         }
 
-        // Training mentors and area moderators can create a report
-        if ($user->hasRole('moderator', $training->area) || $training->mentors->contains($user)) {
+        // Training mentors and report-managing staff can create a report
+        if ($user->hasPermission('create-training-reports', $training->area) || $training->mentors->contains($user)) {
             return true;
         }
 
         // Otherwise, let's see if a one-time link is used
         if (($link = OneTimeLink::getFromSession($training)) != null) {
-            return $user->hasRole('mentor', $link->training->area) || $user->hasRole('buddy', $link->training->area);
+            return $user->hasPermission('use-report-one-time-link', $link->training->area);
         }
 
         return false;
@@ -83,8 +81,7 @@ class TrainingReportPolicy
     public function update(User $user, TrainingReport $trainingReport): bool
     {
         return $trainingReport->training->mentors->contains($user) ||
-                $user->hasRole('admin') ||
-                $user->hasRole('moderator', $trainingReport->training->area);
+                $user->hasPermission('update-training-reports', $trainingReport->training->area);
     }
 
     /**
@@ -92,7 +89,7 @@ class TrainingReportPolicy
      */
     public function delete(User $user, TrainingReport $trainingReport): Response
     {
-        return ($user->hasRole('admin') || $user->hasRole('moderator', $trainingReport->training->area) || ($user->is($trainingReport->author) && $user->hasRole('mentor', $trainingReport->training->area)))
+        return ($user->hasPermission('delete-training-reports', $trainingReport->training->area) || ($user->is($trainingReport->author) && $user->hasRole('mentor', $trainingReport->training->area)))
             ? Response::allow()
             : Response::deny('Only moderators and the author of the training report can delete it.');
     }

--- a/app/Policies/VotePolicy.php
+++ b/app/Policies/VotePolicy.php
@@ -19,7 +19,7 @@ class VotePolicy
      */
     public function index(User $user)
     {
-        return $user->hasRole('admin');
+        return $user->hasPermission('manage-votes');
     }
 
     /**
@@ -29,7 +29,7 @@ class VotePolicy
      */
     public function create(User $user)
     {
-        return $user->hasRole('admin');
+        return $user->hasPermission('manage-votes');
     }
 
     /**
@@ -39,7 +39,7 @@ class VotePolicy
      */
     public function store(User $user)
     {
-        return $user->hasRole('admin');
+        return $user->hasPermission('manage-votes');
     }
 
     /**

--- a/config/roles.php
+++ b/config/roles.php
@@ -91,5 +91,8 @@ return [
 
         // Alerts
         'receive-inactivity-alerts' => ['admin', 'director', 'moderator'],
+
+        // Workmail
+        'use-workmail' => ['admin', 'director', 'moderator'],
     ],
 ];

--- a/config/roles.php
+++ b/config/roles.php
@@ -105,7 +105,6 @@ return [
         'view-management-reports' => ['admin', 'director', 'moderator'],
         'view-training-activities' => ['admin', 'director', 'moderator'],
         'view-training-statistics' => ['admin', 'director', 'moderator'],
-        'view-mentor-reports' => ['admin', 'director', 'moderator', 'mentor'],
 
         // Feedback
         'view-correlated-feedback' => ['admin', 'director', 'moderator'],

--- a/config/roles.php
+++ b/config/roles.php
@@ -57,12 +57,29 @@ return [
         'create-training' => ['admin', 'director', 'moderator', 'mentor'],
         'update-training' => ['admin', 'director', 'moderator'],
         'delete-training' => ['admin', 'director'],
+        'mentor-trainings' => ['admin', 'director', 'moderator', 'mentor'],
+        'view-mentor-dashboard' => ['admin', 'director', 'moderator', 'mentor'],
+
+        // Training reports
+        'view-training-reports' => ['admin', 'director', 'moderator'],
+        'create-training-reports' => ['admin', 'director', 'moderator'],
+        'update-training-reports' => ['admin', 'director', 'moderator'],
+        'delete-training-reports' => ['admin', 'director', 'moderator'],
+        'use-report-one-time-link' => ['mentor', 'buddy'],
+        'view-hidden-training-attachments' => ['mentor'],
+
+        // Examinations
+        'manage-examinations' => ['admin', 'director', 'moderator'],
+        'create-examinations' => ['admin'],
 
         // Area management
         'manage-area' => ['admin'],
 
         // System
         'view-system-health' => ['admin'],
+        'manage-settings' => ['admin'],
+        'manage-votes' => ['admin'],
+        'view-activity-log' => ['admin'],
 
         // Users & Access
         'manage-users' => ['admin', 'director', 'moderator'],
@@ -76,6 +93,14 @@ return [
         'manage-visiting-endorsements' => ['admin', 'director'],
         'manage-examiner-endorsements' => ['admin', 'director'],
 
+        // Tasks
+        'manage-tasks' => ['admin', 'director', 'moderator', 'mentor'],
+        'suggested-task-recipient' => ['admin', 'director', 'moderator'],
+
+        // Files
+        'manage-files' => ['admin', 'director', 'moderator'],
+        'upload-files' => ['admin', 'director', 'moderator', 'mentor'],
+
         // Reports
         'view-management-reports' => ['admin', 'director', 'moderator'],
         'view-training-activities' => ['admin', 'director', 'moderator'],
@@ -88,9 +113,16 @@ return [
 
         // Bookings
         'bypass-booking-restrictions' => ['admin', 'director', 'moderator', 'mentor'],
+        'manage-bookings' => ['admin', 'director', 'moderator'],
+        'use-sweatbook' => ['admin', 'director', 'moderator', 'mentor'],
+        'manage-sweatbook' => ['admin', 'director', 'moderator'],
 
-        // Alerts
+        // Alerts & notifications
         'receive-inactivity-alerts' => ['admin', 'director', 'moderator'],
+        'receive-training-notifications' => ['admin', 'director', 'moderator'],
+
+        // Notification templates
+        'manage-notification-templates' => ['admin', 'director', 'moderator'],
 
         // Workmail
         'use-workmail' => ['admin', 'director', 'moderator'],

--- a/resources/views/booking/index.blade.php
+++ b/resources/views/booking/index.blade.php
@@ -63,7 +63,7 @@
                                             {{ \Carbon\Carbon::create($booking->time_start)->toEuropeanDate(true) }}
                                         @endif 
                                         
-                                        @if(Auth::user()->id == $booking->user_id || $user->hasRole(['admin', 'moderator']))
+                                        @if(Auth::user()->id == $booking->user_id || Auth::user()->hasPermission('manage-bookings'))
 
                                             @if($booking->source == "DISCORD")
                                                 <i class="fab fa-discord text-primary" data-bs-toggle="tooltip" data-bs-placement="top" aria-hidden="true" title="{{ Gate::inspect('update', $booking, \App\Models\Booking::class)->message() }}"></i>

--- a/resources/views/endorsements/examiners.blade.php
+++ b/resources/views/endorsements/examiners.blade.php
@@ -3,9 +3,9 @@
 @section('title', 'Examiners')
 @section('title-flex')
     <div>
-        @if (\Auth::user()->hasRole(['admin', 'moderator']))
+        @can('manage-examiner-endorsements')
             <a href="{{ route('endorsements.create') }}" class="btn btn-outline-success"><i class="fas fa-plus"></i> Add new endorsement</a>
-        @endif
+        @endcan
     </div>
 @endsection
 

--- a/resources/views/endorsements/mascs.blade.php
+++ b/resources/views/endorsements/mascs.blade.php
@@ -3,9 +3,9 @@
 @section('title', 'Facility Endorsements')
 @section('title-flex')
     <div>
-        @if (\Auth::user()->hasRole(['admin', 'moderator']))
+        @can('manage-endorsements')
             <a href="{{ route('endorsements.create') }}" class="btn btn-outline-success"><i class="fas fa-plus"></i> Add new endorsement</a>
-        @endif
+        @endcan
     </div>
 @endsection
 

--- a/resources/views/endorsements/solos.blade.php
+++ b/resources/views/endorsements/solos.blade.php
@@ -3,9 +3,9 @@
 @section('title', 'Solo Endorsements')
 @section('title-flex')
     <div>
-        @if (\Auth::user()->hasRole(['admin', 'moderator']))
+        @can('manage-endorsements')
             <a href="{{ route('endorsements.create') }}" class="btn btn-outline-success"><i class="fas fa-plus"></i> Add new endorsement</a>
-        @endif
+        @endcan
     </div>
 @endsection
 

--- a/resources/views/endorsements/visiting.blade.php
+++ b/resources/views/endorsements/visiting.blade.php
@@ -3,9 +3,9 @@
 @section('title', 'Visiting')
 @section('title-flex')
     <div>
-        @if (\Auth::user()->hasRole(['admin', 'moderator']))
+        @can('manage-visiting-endorsements')
             <a href="{{ route('endorsements.create') }}" class="btn btn-outline-success"><i class="fas fa-plus"></i> Add new endorsement</a>
-        @endif
+        @endcan
     </div>
 @endsection
 

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -52,7 +52,7 @@
             </li>
         @endif
 
-        @can('view-mentor-reports')
+        @canany(['view-mentor-dashboard', 'use-sweatbook', 'view-management-reports'])
 
             {{-- Divider --}}
             <div class="sidebar-divider"></div>
@@ -62,37 +62,41 @@
             Training
             </div>
 
-            <li class="nav-item {{ Route::is('mentor') ? 'active' : '' }}">
-            <a class="nav-link" href="{{ route('mentor') }}">
-                <i class="fas fa-fw fa-chalkboard-teacher"></i>
-                <span>My students</span></a>
-            </li>
+            @can('view-mentor-dashboard')
+                <li class="nav-item {{ Route::is('mentor') ? 'active' : '' }}">
+                <a class="nav-link" href="{{ route('mentor') }}">
+                    <i class="fas fa-fw fa-chalkboard-teacher"></i>
+                    <span>My students</span></a>
+                </li>
+            @endcan
 
-            <li class="nav-item {{ Route::is('sweatbook') ? 'active' : '' }}">
-                <a class="nav-link" href="{{ route('sweatbook') }}">
-                    <i class="fas fa-fw fa-calendar-alt"></i>
-                    <span>Sweatbox Calendar</span>
+            @can('use-sweatbook')
+                <li class="nav-item {{ Route::is('sweatbook') ? 'active' : '' }}">
+                    <a class="nav-link" href="{{ route('sweatbook') }}">
+                        <i class="fas fa-fw fa-calendar-alt"></i>
+                        <span>Sweatbox Calendar</span>
+                    </a>
+                </li>
+            @endcan
+
+            @can('view-management-reports')
+
+                {{-- Nav Item - Pages Collapse Menu --}}
+                <li class="nav-item {{ Route::is('requests') || Route::is('requests.history') ? 'active' : '' }}">
+                <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseReq" aria-expanded="true" aria-controls="collapseReq">
+                    <i class="fas fa-fw fa-flag"></i>
+                    <span>Requests</span>
                 </a>
-            </li>
-
-        @endif
-        @can('manage-users')
-
-            {{-- Nav Item - Pages Collapse Menu --}}
-            <li class="nav-item {{ Route::is('requests') || Route::is('requests.history') ? 'active' : '' }}">
-            <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseReq" aria-expanded="true" aria-controls="collapseReq">
-                <i class="fas fa-fw fa-flag"></i>
-                <span>Requests</span>
-            </a>
-            <div id="collapseReq" class="collapse" data-bs-parent="#sidebar">
-                <div class="bg-white py-2 collapse-inner rounded">
-                <a class="collapse-item" href="{{ route('requests') }}">Open Requests</a>
-                <a class="collapse-item" href="{{ route('requests.history') }}">Closed Requests</a>
+                <div id="collapseReq" class="collapse" data-bs-parent="#sidebar">
+                    <div class="bg-white py-2 collapse-inner rounded">
+                    <a class="collapse-item" href="{{ route('requests') }}">Open Requests</a>
+                    <a class="collapse-item" href="{{ route('requests.history') }}">Closed Requests</a>
+                    </div>
                 </div>
-            </div>
-            </li>
+                </li>
+            @endcan
 
-        @endif
+        @endcanany
 
         {{-- Divider --}}
         <div class="sidebar-divider"></div>

--- a/resources/views/layouts/topbar.blade.php
+++ b/resources/views/layouts/topbar.blade.php
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand bg-white topbar {{ (\Auth::user()->hasRole(['admin', 'moderator'])) ? 'topbar-justify-moderator' : 'topbar-justify-user' }} mb-4 ps-4 pe-4 static-top shadow">
+<nav class="navbar navbar-expand bg-white topbar {{ (\Auth::user()->can('manage-users')) ? 'topbar-justify-moderator' : 'topbar-justify-user' }} mb-4 ps-4 pe-4 static-top shadow">
 
     <a class="sidebar-brand sidebar-brand-topbar align-items-center" href="{{ route('dashboard') }}">
         <div class="sidebar-brand-icon">
@@ -9,7 +9,7 @@
     </a>
 
     {{-- Topbar Desktop Search --}}
-    @if(\Auth::user()->hasRole(['admin', 'moderator']))
+    @can('manage-users')
         <form class="d-none d-md-inline-block my-2 my-md-0 mw-100 navbar-search" id="user-search-form-desktop">
             <div class="input-group">
                 <div class="search input-group input-lg">
@@ -25,12 +25,12 @@
                 </div>
             </div>
         </form>
-    @endif
+    @endcan
 
     {{-- Topbar Navbar --}}
     <ul class="navbar-nav">
 
-        @if(\Auth::user()->hasRole(['admin', 'moderator']))
+        @can('manage-users')
 
             {{-- Search Dropdown (Visible Only XS) --}}
             <li class="nav-item dropdown no-arrow d-md-none">
@@ -55,7 +55,7 @@
                 </div>
             </li>
 
-        @endif
+        @endcan
 
         <div class="topbar-divider d-none d-lg-block"></div>
 

--- a/resources/views/mentor/index.blade.php
+++ b/resources/views/mentor/index.blade.php
@@ -42,13 +42,13 @@
                                 <td>
                                     <i class="{{ $statuses[$training->status]["icon"] }} text-{{ $statuses[$training->status]["color"] }}"></i>&ensp;<a href="/training/{{ $training->id }}">{{ $statuses[$training->status]["text"] }}</a>{{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
                                 </td>
-                                @if ($user->hasRole(['admin', 'moderator']))                            
+                                @can('manage-users')
                                     <td><a href="{{ route('user.show', $training->user->id) }}">{{ $training->user->id }}</a></td>
                                     <td><a href="{{ route('user.show', $training->user->id) }}">{{ $training->user->name }}</a></td>
-                                @else 
+                                @else
                                     <td>{{ $training->user->id }}</td>
                                     <td>{{ $training->user->name }}</td>
-                                @endif
+                                @endcan
                                 <td>
                                     @if ( is_iterable($ratings = $training->ratings->toArray()) )
                                         @for( $i = 0; $i < sizeof($ratings); $i++ )

--- a/resources/views/reports/activities.blade.php
+++ b/resources/views/reports/activities.blade.php
@@ -4,14 +4,14 @@
 @section('title-flex')
     <div>
         <i class="fas fa-filter text-secondary"></i>&nbsp;Filter&nbsp;
-        @if(\Auth::user()->hasRole('admin'))
+        @if(\Auth::user()->accessibleAreasForPermission('view-training-activities')->isGlobal)
             <a class="btn btn-sm {{ $filterName == "All Areas" ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('reports.activities') }}">All Areas</a>
         @endif
         @foreach($areas as $area)
-            @if(\Auth::user()->hasRole(['admin', 'moderator'], $area))
+            @can('view-training-activities', $area)
                 <a class="btn btn-sm {{ $filterName == $area->name ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('reports.activities.area', $area->id) }}">{{ $area->name }}</a>
-            @endif
-        @endforeach 
+            @endcan
+        @endforeach
     </div>
 @endsection
 

--- a/resources/views/reports/trainings.blade.php
+++ b/resources/views/reports/trainings.blade.php
@@ -19,13 +19,13 @@
 
         <div class="input-group input-group-sm w-auto">
             <span class="input-group-text"><i class="fas fa-filter me-1"></i>Filter</span>
-            @if(\Auth::user()->hasRole('admin'))
+            @if(\Auth::user()->accessibleAreasForPermission('view-training-statistics')->isGlobal)
                 <a class="btn btn-sm {{ $filterName == "All Areas" ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('reports.trainings', ['start_date' => request('start_date'), 'end_date' => request('end_date')]) }}">All Areas</a>
             @endif
             @foreach($areas as $area)
-                @if(\Auth::user()->hasRole(['admin', 'moderator'], $area))
+                @can('view-training-statistics', $area)
                     <a class="btn btn-sm {{ $filterName == $area->name ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('reports.training.area', ['id' => $area->id, 'start_date' => request('start_date'), 'end_date' => request('end_date')]) }}">{{ $area->name }}</a>
-                @endif
+                @endcan
             @endforeach
         </div>
     </div>

--- a/resources/views/training/history.blade.php
+++ b/resources/views/training/history.blade.php
@@ -3,9 +3,9 @@
 @section('title', 'Closed Training Requests')
 @section('title-flex')
     <div>
-        @if (\Auth::user()->hasRole(['admin', 'moderator']))
+        @can('create', \App\Models\Training::class)
             <a href="{{ route('training.create') }}" class="btn btn-outline-success"><i class="fas fa-plus"></i> Add new request</a>
-        @endif
+        @endcan
     </div>
 @endsection
 

--- a/resources/views/training/index.blade.php
+++ b/resources/views/training/index.blade.php
@@ -3,9 +3,9 @@
 @section('title', 'Training Requests')
 @section('title-flex')
     <div>
-        @if (\Auth::user()->hasRole(['admin', 'moderator']))
+        @can('create', \App\Models\Training::class)
             <a href="{{ route('training.create') }}" class="btn btn-outline-success"><i class="fas fa-plus"></i> Add new request</a>
-        @endif
+        @endcan
     </div>
 @endsection
 

--- a/resources/views/training/show.blade.php
+++ b/resources/views/training/show.blade.php
@@ -174,7 +174,7 @@
                             @endif
 
                             <label class="form-label" for="trainingStateSelect">Select training state</label>
-                            <select class="form-select" name="status" id="trainingStateSelect" @if(!Auth::user()->hasRole(['admin', 'moderator'])) disabled @endif>
+                            <select class="form-select" name="status" id="trainingStateSelect" @if(Auth::user()->cannot('update', $training)) disabled @endif>
                                 @foreach($statuses as $id => $data)
                                     @if($data["assignableByStaff"])
                                         @if($id == $training->status)
@@ -193,7 +193,7 @@
                         </div>
 
                         <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="check1" name="paused_at" {{ $training->paused_at ? "checked" : "" }} @if(!Auth::user()->hasRole(['admin', 'moderator'])) disabled @endif>
+                            <input class="form-check-input" type="checkbox" id="check1" name="paused_at" {{ $training->paused_at ? "checked" : "" }} @if(Auth::user()->cannot('update', $training)) disabled @endif>
                             <label class="form-check-label" for="check1">
                                 Paused
                                 @if(isset($training->paused_at))
@@ -204,7 +204,7 @@
 
                         <hr>
 
-                        @if (\Auth::user()->hasRole(['admin', 'moderator']))
+                        @can('update', $training)
                         <div class="mb-3">
                             <label class="form-label" for="assignMentors">Assigned mentors: <span class="badge bg-secondary">Ctrl/Cmd+Click</span> to select multiple</label>
                             <select multiple class="form-select" name="mentors[]" id="assignMentors">
@@ -213,7 +213,7 @@
                                 @endforeach
                             </select>
                         </div>
-                        @endif
+                        @endcan
 
                         <button type="submit" id="training-submit-btn" class="btn btn-primary" onclick="handleSubmit(event)">Save
                             <div class="submit-spinner spinner-border spinner-border-sm" role="status" style="display: none;">&nbsp;</div>

--- a/resources/views/user/reports.blade.php
+++ b/resources/views/user/reports.blade.php
@@ -22,7 +22,7 @@
                         @foreach($reportsAndExams as $reportModel)
                             @if(is_a($reportModel, '\App\Models\TrainingReport'))
 
-                                @if(!$reportModel->draft || $reportModel->draft && \Auth::user()->hasRole(['admin', 'moderator', 'mentor']))
+                                @if(!$reportModel->draft || Auth::user()->can('view', $reportModel))
 
                                     @php
                                         $uuid = "instance-".Ramsey\Uuid\Uuid::uuid4();

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -24,7 +24,7 @@
                         {{ $user->id }}
                         <button type="button" onclick="navigator.clipboard.writeText('{{ $user->id }}')"><i class="fas fa-copy"></i></button>
                         <a href="https://stats.vatsim.net/stats/{{ $user->id }}" target="_blank" title="VATSIM Stats" class="link-btn me-1"><i class="fas fa-chart-simple"></i></button></a>
-                        @if($user->division == 'EUD' && Auth::user()->hasRole(['admin', 'moderator']))
+                        @if($user->division == 'EUD' && Auth::user()->can('manage-users'))
                             <a href="https://core.vateud.net/manage/controller/{{ $user->id }}/view" target="_blank" title="VATEUD Core Profile" class="link-btn"><i class="fa-solid fa-earth-europe"></i></button></a>
                         @endif
                     </dd>
@@ -83,10 +83,10 @@
                     <dt class="pt-2">Last login</dt>
                     <dd>{{ $user->last_login->toEuropeanDateTime() }}</dd>
 
-                    @if(\Auth::user()->hasRole(['admin', 'moderator']))
+                    @can('manage-users')
                         <dt class="pt-2">Last activity</dt>
                         <dd>{{ isset($user->last_activity) ? $user->last_activity->toEuropeanDateTime() : 'N/A' }}</dd>
-                    @endif
+                    @endcan
 
                 </dl>
             </div>

--- a/resources/views/usersettings.blade.php
+++ b/resources/views/usersettings.blade.php
@@ -47,7 +47,7 @@
                                 @endif
                             </div>
 
-                            @if($user->hasRole(['admin', 'moderator', 'mentor']))
+                            @can('manage-tasks')
                                 <hr>
 
                                 <h5>Mentor Notifications</h5>
@@ -58,8 +58,8 @@
                                         Send notification of new tasks
                                     </label>
                                 </div>
-                                
-                            @endif
+
+                            @endcan
 
                             @if($user->hasRole(['admin', 'director', 'moderator']))
                                 <hr>

--- a/resources/views/usersettings.blade.php
+++ b/resources/views/usersettings.blade.php
@@ -61,7 +61,7 @@
 
                             @endcan
 
-                            @if($user->hasRole(['admin', 'director', 'moderator']))
+                            @can('receive-training-notifications')
                                 <hr>
 
                                 <h5>Moderator Notifications</h5>
@@ -93,8 +93,8 @@
                                         <span class="text-danger">{{ $errors->first('setting_workmail_address') }}</span>
                                     @enderror
                                 </div>
-                                
-                            @endif
+
+                            @endcan
 
                             <button class="btn btn-success mt-3" type="submit">Save</button>
                         </form>

--- a/tests/Feature/AdminPermissionPoliciesTest.php
+++ b/tests/Feature/AdminPermissionPoliciesTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use anlutro\LaravelSettings\Facade as Setting;
+use App\Models\ActivityLog;
+use App\Models\Area;
+use App\Models\User;
+use App\Models\Vote;
+use App\Policies\SettingPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminPermissionPoliciesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_passes_admin_only_policies(): void
+    {
+        $admin = User::factory()->create();
+        $admin->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        $this->assertTrue($admin->can('index', Vote::class));
+        $this->assertTrue($admin->can('index', ActivityLog::class));
+        $this->assertTrue((new SettingPolicy)->index($admin, new Setting));
+        $this->assertTrue((new SettingPolicy)->edit($admin, new Setting));
+    }
+
+    public function test_moderator_fails_admin_only_policies(): void
+    {
+        $area = Area::factory()->create();
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $this->assertFalse($moderator->can('index', Vote::class));
+        $this->assertFalse($moderator->can('index', ActivityLog::class));
+        $this->assertFalse((new SettingPolicy)->index($moderator, new Setting));
+        $this->assertFalse((new SettingPolicy)->edit($moderator, new Setting));
+        $this->assertFalse($moderator->can('create', Vote::class));
+        $this->assertFalse($moderator->can('store', Vote::class));
+    }
+}

--- a/tests/Feature/BookingTest.php
+++ b/tests/Feature/BookingTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Helpers\VatsimRating;
+use App\Models\Area;
 use App\Models\Booking;
 use App\Models\Endorsement;
 use App\Models\Position;
@@ -284,6 +285,27 @@ class BookingTest extends TestCase
 
         $this->actingAs($user)->followingRedirects()->postJson(route('booking.store', ['id' => $booking->id]), $booking->getAttributes())
             ->assertStatus(403);
+    }
+
+    #[Test]
+    public function test_director_can_update_other_users_booking(): void
+    {
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
+        $booking = Booking::factory()->create(['user_id' => User::factory()->create()->id, 'source' => 'CC']);
+
+        $this->assertTrue($director->can('update', $booking));
+    }
+
+    #[Test]
+    public function test_mentor_cannot_update_other_users_booking(): void
+    {
+        $area = Area::factory()->create();
+        $mentor = User::factory()->create();
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+        $booking = Booking::factory()->create(['user_id' => User::factory()->create()->id, 'source' => 'CC']);
+
+        $this->assertFalse($mentor->can('update', $booking));
     }
 
     #[Test]

--- a/tests/Feature/FilesTest.php
+++ b/tests/Feature/FilesTest.php
@@ -124,4 +124,22 @@ class FilesTest extends TestCase
 
         $this->actingAs($otherUser)->delete(route('file.delete', ['file' => $file_id]))->assertStatus(403)->assertSessionMissing('message');
     }
+
+    #[Test]
+    public function test_director_has_full_file_access(): void
+    {
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
+        $file = File::create([
+            'id' => 'test-file-id',
+            'name' => 'test.jpg',
+            'path' => 'test.jpg',
+            'uploaded_by' => null,
+        ]);
+
+        $this->assertTrue($director->can('update', $file));
+        $this->assertTrue($director->can('delete', $file));
+        $this->assertTrue($director->can('view', $file));
+        $this->assertTrue($director->can('create', File::class));
+    }
 }

--- a/tests/Feature/FrontpageTest.php
+++ b/tests/Feature/FrontpageTest.php
@@ -41,4 +41,26 @@ class FrontpageTest extends TestCase
         $response = $this->get('/logout');
         $response->assertRedirect('/login');
     }
+
+    #[Test]
+    public function test_director_sees_user_search_in_topbar(): void
+    {
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
+
+        $response = $this->actingAs($director)->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertSee('Search for user');
+    }
+
+    public function test_regular_user_does_not_see_user_search_in_topbar(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertDontSee('Search for user');
+    }
 }

--- a/tests/Feature/FrontpageTest.php
+++ b/tests/Feature/FrontpageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Area;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use PHPUnit\Framework\Attributes\Test;
@@ -62,5 +63,28 @@ class FrontpageTest extends TestCase
 
         $response->assertOk();
         $response->assertDontSee('Search for user');
+    }
+
+    public function test_mentor_sees_training_section_in_sidebar(): void
+    {
+        $mentor = User::factory()->create();
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => Area::factory()->create()->id]);
+
+        $response = $this->actingAs($mentor)->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertSee('My students');
+        $response->assertSee('Sweatbox Calendar');
+    }
+
+    public function test_regular_user_does_not_see_training_section_in_sidebar(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertDontSee('My students');
+        $response->assertDontSee('Sweatbox Calendar');
     }
 }

--- a/tests/Feature/NotificationEmailTest.php
+++ b/tests/Feature/NotificationEmailTest.php
@@ -144,4 +144,39 @@ class NotificationEmailTest extends TestCase
         Notification::assertNotSentTo($staffWrongArea, TrainingCreatedNotification::class);
         Notification::assertNotSentTo($staffNoNotify, TrainingCreatedNotification::class);
     }
+
+    #[Test]
+    public function bccs_directors_who_opted_in_to_new_request_notifications(): void
+    {
+        $director = User::factory()->create([
+            'setting_workmail_address' => 'director@example.com',
+        ]);
+        $director->setting_notify_newreq = true;
+        $director->save();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $this->area->id]);
+
+        $outsider = User::factory()->create([
+            'setting_workmail_address' => 'outsider@example.com',
+        ]);
+        $outsider->setting_notify_newreq = true;
+        $outsider->save();
+        $outsider->roleAssignments()->create(['role' => 'moderator', 'area_id' => Area::factory()->create()->id]);
+
+        $training = Training::factory()->for($this->user)->for($this->area)->create();
+
+        $this->user->notify(new TrainingCreatedNotification($training));
+
+        Notification::assertSentTo(
+            $this->user,
+            TrainingCreatedNotification::class,
+            function ($notification, $channels, $notifiable) {
+                $bccAddresses = collect($notification->toMail($notifiable)->bcc)->pluck('address');
+
+                $this->assertContains('director@example.com', $bccAddresses);
+                $this->assertNotContains('outsider@example.com', $bccAddresses);
+
+                return true;
+            }
+        );
+    }
 }

--- a/tests/Feature/NotificationTemplatePermissionsTest.php
+++ b/tests/Feature/NotificationTemplatePermissionsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Area;
+use App\Models\User;
+use App\Policies\NotificationPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class NotificationTemplatePermissionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_director_can_view_and_modify_templates_in_their_area(): void
+    {
+        $area = Area::factory()->create();
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $area->id]);
+
+        $policy = new NotificationPolicy;
+        $this->assertTrue($policy->viewTemplates($director));
+        $this->assertTrue($policy->modifyAreaTemplate($director, $area));
+    }
+
+    public function test_admin_can_modify_any_areas_templates(): void
+    {
+        $area = Area::factory()->create();
+        $admin = User::factory()->create();
+        $admin->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        $policy = new NotificationPolicy;
+        $this->assertTrue($policy->viewTemplates($admin));
+        $this->assertTrue($policy->modifyAreaTemplate($admin, $area));
+    }
+
+    public function test_area_moderator_cannot_modify_other_areas_templates(): void
+    {
+        $area = Area::factory()->create();
+        $otherArea = Area::factory()->create();
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $policy = new NotificationPolicy;
+        $this->assertTrue($policy->modifyAreaTemplate($moderator, $area));
+        $this->assertFalse($policy->modifyAreaTemplate($moderator, $otherArea));
+    }
+}

--- a/tests/Feature/OneTimeLinkPermissionsTest.php
+++ b/tests/Feature/OneTimeLinkPermissionsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Area;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OneTimeLinkPermissionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_buddy_holds_report_link_permission_and_moderator_does_not(): void
+    {
+        $area = Area::factory()->create();
+
+        $buddy = User::factory()->create();
+        $buddy->roleAssignments()->create(['role' => 'buddy', 'area_id' => $area->id]);
+
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $this->assertTrue($buddy->hasPermission('use-report-one-time-link'));
+        $this->assertFalse($moderator->hasPermission('use-report-one-time-link'));
+    }
+
+    public function test_director_holds_update_training_in_their_area(): void
+    {
+        $area = Area::factory()->create();
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $area->id]);
+
+        $this->assertTrue($director->hasPermission('update-training', $area));
+    }
+}

--- a/tests/Feature/ReportControllerTest.php
+++ b/tests/Feature/ReportControllerTest.php
@@ -91,6 +91,17 @@ class ReportControllerTest extends TestCase
     }
 
     #[Test]
+    public function global_director_sees_mentor_report(): void
+    {
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
+
+        $response = $this->actingAs($director)->get(route('reports.mentors'));
+
+        $response->assertOk();
+    }
+
+    #[Test]
     public function admin_sees_global_training_report(): void
     {
         $response = $this->actingAs($this->adminUser)->get(route('reports.trainings'));

--- a/tests/Feature/SweatbookPermissionsTest.php
+++ b/tests/Feature/SweatbookPermissionsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Area;
+use App\Models\Sweatbook;
+use App\Models\User;
+use App\Policies\SweatbookPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SweatbookPermissionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_director_can_view_create_and_update_sweatbook(): void
+    {
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
+        $otherUsersBooking = new Sweatbook;
+        $otherUsersBooking->user_id = User::factory()->create()->id;
+
+        $policy = new SweatbookPolicy;
+        $this->assertTrue($policy->view($director));
+        $this->assertTrue($policy->create($director));
+        $this->assertTrue($policy->update($director, $otherUsersBooking));
+    }
+
+    public function test_mentor_can_view_but_not_update_others_bookings(): void
+    {
+        $area = Area::factory()->create();
+        $mentor = User::factory()->create();
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+        $otherUsersBooking = new Sweatbook;
+        $otherUsersBooking->user_id = User::factory()->create()->id;
+
+        $policy = new SweatbookPolicy;
+        $this->assertTrue($policy->view($mentor));
+        $this->assertFalse($policy->update($mentor, $otherUsersBooking));
+    }
+}

--- a/tests/Feature/TaskPermissionsTest.php
+++ b/tests/Feature/TaskPermissionsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Area;
+use App\Models\Endorsement;
+use App\Models\Task;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TaskPermissionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_director_can_create_update_and_receive_tasks(): void
+    {
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
+
+        $this->assertTrue($director->can('create', Task::class));
+        $this->assertTrue($director->can('update', Task::class));
+        $this->assertTrue($director->can('receive', Task::class));
+    }
+
+    public function test_regular_user_cannot_create_tasks(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertFalse($user->can('create', Task::class));
+    }
+
+    public function test_mentor_can_create_update_and_receive_tasks(): void
+    {
+        $area = Area::factory()->create();
+        $mentor = User::factory()->create();
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+
+        $this->assertTrue($mentor->can('create', Task::class));
+        $this->assertTrue($mentor->can('update', Task::class));
+        $this->assertTrue($mentor->can('receive', Task::class));
+    }
+
+    public function test_examiner_without_staff_role_can_receive_tasks(): void
+    {
+        $examiner = User::factory()->create();
+        Endorsement::factory()->create([
+            'user_id' => $examiner->id,
+            'type' => 'EXAMINER',
+            'valid_from' => Carbon::now(),
+            'expired' => false,
+            'revoked' => false,
+        ]);
+
+        $this->assertTrue($examiner->can('receive', Task::class));
+    }
+
+    public function test_mentor_is_not_a_suggested_task_recipient(): void
+    {
+        $area = Area::factory()->create();
+        $mentor = User::factory()->create();
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $this->assertFalse($mentor->hasPermission('suggested-task-recipient'));
+        $this->assertTrue($moderator->hasPermission('suggested-task-recipient'));
+    }
+}

--- a/tests/Feature/TrainingExaminationsTest.php
+++ b/tests/Feature/TrainingExaminationsTest.php
@@ -396,4 +396,30 @@ class TrainingExaminationsTest extends TestCase
 
         $response->assertStatus(403);
     }
+
+    #[Test]
+    public function test_director_can_update_and_delete_examination_in_their_area(): void
+    {
+        $examination = TrainingExamination::create($this->examination->getAttributes());
+        $area = $this->training->area;
+
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $area->id]);
+
+        $this->assertTrue($director->can('update', $examination));
+        $this->assertTrue($director->can('delete', $examination));
+        $this->assertTrue($director->can('view', $examination));
+    }
+
+    #[Test]
+    public function test_moderator_of_other_area_cannot_view_examination(): void
+    {
+        $examination = TrainingExamination::create($this->examination->getAttributes());
+
+        $otherArea = Area::factory()->create();
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $otherArea->id]);
+
+        $this->assertFalse($moderator->can('view', $examination));
+    }
 }

--- a/tests/Feature/TrainingObjectAttachmentTest.php
+++ b/tests/Feature/TrainingObjectAttachmentTest.php
@@ -127,4 +127,23 @@ class TrainingObjectAttachmentTest extends TestCase
             ->get(route('training.object.attachment.show', ['attachment' => $id]))
             ->assertStatus(200);
     }
+
+    #[Test]
+    public function test_director_can_delete_attachment(): void
+    {
+        $mentor = $this->report->author;
+        $file = UploadedFile::fake()->image($this->faker->word . '.jpg');
+
+        $id = $this->actingAs($mentor)
+            ->postJson(route('training.object.attachment.store', ['trainingObjectType' => 'report', 'trainingObject' => $this->report]), ['file' => $file])
+            ->json('id')[0];
+
+        $attachment = TrainingObjectAttachment::findOrFail($id);
+
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
+
+        $this->assertTrue($director->can('delete', $attachment));
+        $this->assertTrue($director->can('create', TrainingObjectAttachment::class));
+    }
 }

--- a/tests/Feature/TrainingReportsTest.php
+++ b/tests/Feature/TrainingReportsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Area;
 use App\Models\OneTimeLink;
 use App\Models\Training;
 use App\Models\TrainingReport;
@@ -471,5 +472,54 @@ class TrainingReportsTest extends TestCase
         // Ensure reports still exist in database
         $this->assertDatabaseHas('training_reports', ['id' => $reportByMentor->id]);
         $this->assertDatabaseHas('training_reports', ['id' => $reportByBuddy->id]);
+    }
+
+    #[Test]
+    public function test_director_can_view_update_and_delete_reports_in_their_area(): void
+    {
+        $training = Training::factory()->create([
+            'user_id' => User::factory()->create()->id,
+        ]);
+        $area = $training->area;
+
+        $mentor = User::factory()->create();
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+
+        $report = TrainingReport::factory()->create([
+            'training_id' => $training->id,
+            'written_by_id' => $mentor->id,
+            'draft' => false,
+        ]);
+
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $area->id]);
+
+        $this->assertTrue($director->can('view', $report));
+        $this->assertTrue($director->can('update', $report));
+        $this->assertTrue($director->can('delete', $report));
+        $this->assertTrue($director->can('create', [TrainingReport::class, $training]));
+    }
+
+    #[Test]
+    public function test_director_of_other_area_cannot_update_report(): void
+    {
+        $training = Training::factory()->create([
+            'user_id' => User::factory()->create()->id,
+        ]);
+
+        $mentor = User::factory()->create();
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $training->area->id]);
+
+        $report = TrainingReport::factory()->create([
+            'training_id' => $training->id,
+            'written_by_id' => $mentor->id,
+            'draft' => false,
+        ]);
+
+        $otherArea = Area::factory()->create();
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $otherArea->id]);
+
+        $this->assertFalse($director->can('update', $report));
     }
 }

--- a/tests/Feature/TrainingsTest.php
+++ b/tests/Feature/TrainingsTest.php
@@ -80,6 +80,17 @@ class TrainingsTest extends TestCase
     }
 
     #[Test]
+    public function test_director_is_eligible_as_training_mentor_in_their_area(): void
+    {
+        $area = Area::factory()->create();
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => $area->id]);
+
+        $this->assertTrue($director->hasPermission('mentor-trainings', $area));
+        $this->assertTrue($director->hasPermission('view-mentor-dashboard'));
+    }
+
+    #[Test]
     public function moderator_can_update_training_request()
     {
         $moderator = User::factory()->create();

--- a/tests/Feature/TrainingsTest.php
+++ b/tests/Feature/TrainingsTest.php
@@ -202,6 +202,16 @@ class TrainingsTest extends TestCase
     //    }
 
     #[Test]
+    public function test_director_can_create_training_requests_for_others(): void
+    {
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
+
+        $this->assertTrue($director->can('create', Training::class));
+        $this->assertTrue($director->hasPermission('view-training-activities', Area::factory()->create()));
+    }
+
+    #[Test]
     public function a_mentor_cant_be_added_if_they_are_not_a_mentor_in_the_right_area()
     {
         $training = Training::factory()->create([

--- a/tests/Feature/UpdateWorkmailsTest.php
+++ b/tests/Feature/UpdateWorkmailsTest.php
@@ -41,4 +41,22 @@ class UpdateWorkmailsTest extends TestCase
         $this->assertNull($roleless->fresh()->setting_workmail_address);
         $this->assertNull($mentor->fresh()->setting_workmail_address);
     }
+
+    public function test_workmail_eligibility_follows_configured_permission(): void
+    {
+        config(['roles.matrix.use-workmail' => ['mentor']]);
+
+        $area = Area::factory()->create();
+
+        $mentor = User::factory()->create(['setting_workmail_address' => 'mentor@example.test']);
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+
+        $moderator = User::factory()->create(['setting_workmail_address' => 'moderator@example.test']);
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $this->artisan('update:workmails')->assertExitCode(0);
+
+        $this->assertEquals('mentor@example.test', $mentor->fresh()->setting_workmail_address);
+        $this->assertNull($moderator->fresh()->setting_workmail_address);
+    }
 }

--- a/tests/Unit/RolesConfigTest.php
+++ b/tests/Unit/RolesConfigTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+class RolesConfigTest extends TestCase
+{
+    public function test_every_matrix_role_is_a_defined_role(): void
+    {
+        $definedRoles = array_keys(config('roles.roles'));
+
+        foreach (config('roles.matrix') as $permission => $roles) {
+            foreach ($roles as $role) {
+                $this->assertContains($role, $definedRoles, "Permission {$permission} references undefined role {$role}");
+            }
+        }
+    }
+
+    public function test_permissions_for_migrated_hasrole_checks_exist(): void
+    {
+        $matrix = config('roles.matrix');
+
+        $expected = [
+            'manage-tasks', 'suggested-task-recipient',
+            'manage-files', 'upload-files',
+            'manage-bookings', 'use-sweatbook', 'manage-sweatbook',
+            'manage-notification-templates',
+            'view-training-reports', 'create-training-reports', 'update-training-reports', 'delete-training-reports',
+            'use-report-one-time-link', 'view-hidden-training-attachments',
+            'manage-examinations', 'create-examinations',
+            'view-mentor-dashboard', 'mentor-trainings',
+            'receive-training-notifications',
+            'manage-settings', 'manage-votes', 'view-activity-log',
+        ];
+
+        foreach ($expected as $permission) {
+            $this->assertArrayHasKey($permission, $matrix);
+        }
+    }
+
+    public function test_every_matrix_permission_has_at_least_one_role(): void
+    {
+        foreach (config('roles.matrix') as $permission => $roles) {
+            $this->assertNotEmpty($roles, "Permission '{$permission}' has no roles assigned.");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1470.

## Summary by Sourcery

Replace role-based access checks with permission-based checks across training, booking, files, notifications, tasks, and reporting, and expand the roles-permissions matrix to support the new model.

New Features:
- Introduce fine-grained permissions for mentor dashboard, training reports, examinations, bookings, tasks, files, notifications, sweatbox, and workmail in the roles matrix.
- Gate sidebar, topbar, reports, training pages, and endorsements UI elements via named permissions instead of hard-coded roles.

Enhancements:
- Refactor authorization policies and controllers to use permission checks and area-aware access scopes instead of direct role checks.
- Align email notification BCC selection and workmail eligibility with the new permission model.
- Improve mentor and training reports visibility logic to respect area-scoped management-report permissions.

Tests:
- Add comprehensive feature and unit tests to cover director, mentor, moderator, examiner, and buddy permissions for trainings, reports, examinations, bookings, tasks, files, notification templates, sweatbook, and one-time links.
- Add a roles configuration test suite to validate that all matrix permissions and roles are consistently defined.