### PR TITLE
fix(logs): introduce role assignment logs & new logging system

### DIFF
--- a/app/Console/Commands/CleanLogs.php
+++ b/app/Console/Commands/CleanLogs.php
@@ -3,9 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Models\ActivityLog;
-use Carbon\Carbon;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
 
 class CleanLogs extends Command
 {
@@ -21,34 +19,19 @@ class CleanLogs extends Command
      *
      * @var string
      */
-    protected $description = 'Clean and purge old logs';
-
-    /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
+    protected $description = 'Scrub IP and user agent details from old activity log entries';
 
     /**
      * Execute the console command.
      *
-     * @return void
+     * Deletion of old entries is handled separately by the activitylog:clean
+     * command (see config/activitylog.php).
      */
-    public function handle()
+    public function handle(): void
     {
-        $entries = ActivityLog::where('created_at', '<', Carbon::now()->subWeeks(2))->get();
-        foreach ($entries as $entry) {
-            $entry->ip_address = null;
-            $entry->user_agent = null;
-            $entry->save();
-        }
+        $scrubbed = ActivityLog::where('created_at', '<', now()->subWeeks(2))
+            ->update(['ip_address' => null, 'user_agent' => null]);
 
-        DB::table('activity_logs')->where('created_at', '<', Carbon::now()->subMonths(3)->format('Y-m-d H:i:s'))->delete();
-
-        $this->info('All logs older than two weeks has been purged for IP and user agent details. Logs older than three months have been deleted.');
+        $this->info("Scrubbed IP and user agent details from {$scrubbed} activity log entries older than two weeks.");
     }
 }

--- a/app/Console/Commands/UpdateMemberDetails.php
+++ b/app/Console/Commands/UpdateMemberDetails.php
@@ -90,10 +90,14 @@ class UpdateMemberDetails extends Command
             // Detach mentors before closing the training
             $training->mentors()->detach();
 
-            // Close the training
-            $training->updateStatus(-4);
-            $training->closed_reason = 'The student has left or is no longer part of our division.';
-            $training->save();
+            // Close the training. Suppress automatic model-event logging here:
+            // the closure is recorded explicitly below, so the LogsActivity trait
+            // would only add a duplicate entry for this bulk maintenance write.
+            activity()->withoutLogging(function () use ($training) {
+                $training->updateStatus(-4);
+                $training->closed_reason = 'The student has left or is no longer part of our division.';
+                $training->save();
+            });
 
             // Notify student of closure
             $training->user->notify(new TrainingClosedNotification($training, -4, 'Student has left the division.'));

--- a/app/Console/Commands/UpdateMemberDetails.php
+++ b/app/Console/Commands/UpdateMemberDetails.php
@@ -3,11 +3,11 @@
 namespace App\Console\Commands;
 
 use anlutro\LaravelSettings\Facade as Setting;
-use App\Http\Controllers\ActivityLogController;
 use App\Models\AtcActivity;
 use App\Models\Training;
 use App\Models\User;
 use App\Notifications\TrainingClosedNotification;
+use App\Services\ActivityLogService;
 use Illuminate\Console\Command;
 
 class UpdateMemberDetails extends Command
@@ -103,7 +103,7 @@ class UpdateMemberDetails extends Command
             $training->user->notify(new TrainingClosedNotification($training, -4, 'Student has left the division.'));
 
             // Log the closure
-            ActivityLogController::warning('TRAINING', 'Closed training request ' . $training->id . ' due to student leaving division');
+            ActivityLogService::warning('TRAINING', 'Closed training request ' . $training->id . ' due to student leaving division');
 
             $count++;
         }

--- a/app/Console/Commands/UpdateMemberDetails.php
+++ b/app/Console/Commands/UpdateMemberDetails.php
@@ -65,8 +65,8 @@ class UpdateMemberDetails extends Command
             // Remove any active trainings and training roles
             $mentor->teaches()->detach();
 
-            // Remove training role assignments
-            $mentor->roleAssignments()->delete();
+            // Remove training role assignments (delete per-model so each revocation is logged)
+            $mentor->roleAssignments()->get()->each->delete();
             $mentor->save();
 
             $count++;

--- a/app/Console/Commands/UserDelete.php
+++ b/app/Console/Commands/UserDelete.php
@@ -83,7 +83,7 @@ class UserDelete extends Command
                 if ($confirmed) {
                     // Remove things from Control Center
                     $this->closeUserTrainings($user);
-                    $user->roleAssignments()->delete();
+                    $user->roleAssignments()->get()->each->delete();
 
                     $user->email = 'void@void.void';
                     $user->first_name = 'Anonymous';

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -49,8 +49,12 @@ class Kernel extends ConsoleKernel
         $schedule->command('clean:votes')
             ->everyMinute();
 
-        // Clean IP addresses and user agent information from old logs and very old logs
+        // Scrub IP addresses and user agent information from old activity logs
         $schedule->command('clean:logs')
+            ->daily();
+
+        // Delete activity log entries older than the configured retention period
+        $schedule->command('activitylog:clean')
             ->daily();
 
         // Daily fetch updated member data from OAuth provider

--- a/app/Helpers/ActivityLevel.php
+++ b/app/Helpers/ActivityLevel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Helpers;
+
+/**
+ * Severity of an activity log entry. Values are lowercase so they double as the
+ * CSS modifier used by the admin view (e.g. text-warning).
+ */
+enum ActivityLevel: string
+{
+    case Debug = 'debug';
+    case Info = 'info';
+    case Warning = 'warning';
+    case Danger = 'danger';
+}

--- a/app/Http/Controllers/API/BookingController.php
+++ b/app/Http/Controllers/API/BookingController.php
@@ -4,11 +4,11 @@ namespace App\Http\Controllers\API;
 
 use App;
 use App\Helpers\TrainingStatus;
-use App\Http\Controllers\ActivityLogController;
 use App\Http\Controllers\Controller;
 use App\Models\Booking;
 use App\Models\Position;
 use App\Models\User;
+use App\Services\ActivityLogService;
 use Carbon\Carbon;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
@@ -164,7 +164,7 @@ class BookingController extends Controller
 
         $booking->save();
 
-        ActivityLogController::info('BOOKING', 'Created booking booking' . $booking->id . ' via API' .
+        ActivityLogService::info('BOOKING', 'Created booking booking' . $booking->id . ' via API' .
             ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
             ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
             ' ― Position: ' . Position::find($booking->position_id)->callsign);
@@ -328,7 +328,7 @@ class BookingController extends Controller
 
         $booking->save();
 
-        ActivityLogController::info('BOOKING', 'Updated booking booking ' . $booking->id . ' via API' .
+        ActivityLogService::info('BOOKING', 'Updated booking booking ' . $booking->id . ' via API' .
             ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
             ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
             ' ― Position: ' . Position::find($booking->position_id)->callsign);
@@ -361,7 +361,7 @@ class BookingController extends Controller
 
         $booking->save();
 
-        ActivityLogController::warning('BOOKING', 'Deleted booking booking ' . $booking->id . ' via API' .
+        ActivityLogService::warning('BOOKING', 'Deleted booking booking ' . $booking->id . ' via API' .
             ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
             ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
             ' ― Position: ' . Position::find($booking->position_id)->callsign);

--- a/app/Http/Controllers/ActivityLogController.php
+++ b/app/Http/Controllers/ActivityLogController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Helpers\ActivityLevel;
 use App\Models\ActivityLog;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
 
@@ -49,15 +50,24 @@ class ActivityLogController extends Controller
     }
 
     /**
-     * Display a listing of the logs to the view.
+     * Display a paginated, filterable listing of the activity log.
      *
      * @throws AuthorizationException
      */
-    public function index(): View
+    public function index(Request $request): View
     {
         $this->authorize('index', ActivityLog::class);
-        $logs = ActivityLog::where('category', '!=', null)->with('user')->get()->sortByDesc('created_at');
 
-        return view('admin.logs', compact('logs'));
+        $logs = ActivityLog::with('causer')
+            ->when($request->query('log_name'), fn ($query, $logName) => $query->where('log_name', $logName))
+            ->when($request->query('level'), fn ($query, $level) => $query->where('level', $level))
+            ->latest()
+            ->paginate(50)
+            ->withQueryString();
+
+        $categories = ['access', 'training', 'booking', 'endorsement', 'other'];
+        $levels = array_map(fn (ActivityLevel $level) => $level->value, ActivityLevel::cases());
+
+        return view('admin.logs', compact('logs', 'categories', 'levels'));
     }
 }

--- a/app/Http/Controllers/ActivityLogController.php
+++ b/app/Http/Controllers/ActivityLogController.php
@@ -6,49 +6,10 @@ use App\Helpers\ActivityLevel;
 use App\Models\ActivityLog;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 use Illuminate\View\View;
 
-/**
- * Displays the activity log and provides backwards-compatible logging shims.
- *
- * The static debug/info/warning/danger methods are thin wrappers over the
- * activity() helper, kept so the ~28 existing call sites keep working while they
- * are migrated to the new API. They are removed once migration is complete.
- */
 class ActivityLogController extends Controller
 {
-    /**
-     * Write a legacy-style log entry, mapping the free-text category onto the
-     * activity log_name and the severity onto the level.
-     */
-    private static function record(ActivityLevel $level, string $category, string $message): void
-    {
-        activity(Str::lower($category))
-            ->tap(fn (ActivityLog $log) => $log->level = $level)
-            ->log($message);
-    }
-
-    public static function debug(string $category, string $message): void
-    {
-        self::record(ActivityLevel::Debug, $category, $message);
-    }
-
-    public static function info(string $category, string $message): void
-    {
-        self::record(ActivityLevel::Info, $category, $message);
-    }
-
-    public static function warning(string $category, string $message): void
-    {
-        self::record(ActivityLevel::Warning, $category, $message);
-    }
-
-    public static function danger(string $category, string $message): void
-    {
-        self::record(ActivityLevel::Danger, $category, $message);
-    }
-
     /**
      * Display a paginated, filterable listing of the activity log.
      *

--- a/app/Http/Controllers/ActivityLogController.php
+++ b/app/Http/Controllers/ActivityLogController.php
@@ -2,98 +2,58 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\ActivityLevel;
 use App\Models\ActivityLog;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Str;
 use Illuminate\View\View;
 
 /**
- * This controller logs various activity and stores it in database for logging purposes.
+ * Displays the activity log and provides backwards-compatible logging shims.
+ *
+ * The static debug/info/warning/danger methods are thin wrappers over the
+ * activity() helper, kept so the ~28 existing call sites keep working while they
+ * are migrated to the new API. They are removed once migration is complete.
  */
 class ActivityLogController extends Controller
 {
     /**
-     * Internal function to save the log according to type
-     *
-     * @param  string  $type
-     * @param  string  $message
-     * @return void
+     * Write a legacy-style log entry, mapping the free-text category onto the
+     * activity log_name and the severity onto the level.
      */
-    private static function log($type, $category, $message)
+    private static function record(ActivityLevel $level, string $category, string $message): void
     {
-        $log = new ActivityLog();
-
-        $log->type = $type;
-        $log->category = $category;
-        $log->message = $message;
-
-        $request = request();
-
-        if (isset($request)) {
-            if (isset($request->user()->id)) {
-                $log->user_id = $request->user()->id;
-            }
-
-            $log->ip_address = $request->ip();
-            $log->user_agent = $request->userAgent();
-        }
-
-        $log->created_at = now();
-        $log->save();
+        activity(Str::lower($category))
+            ->tap(fn (ActivityLog $log) => $log->level = $level)
+            ->log($message);
     }
 
-    /**
-     * Store a debug log
-     *
-     * @param  string  $message
-     * @return void
-     */
-    public static function debug($category, $message)
+    public static function debug(string $category, string $message): void
     {
-        ActivityLogController::log('DEBUG', $category, $message);
+        self::record(ActivityLevel::Debug, $category, $message);
     }
 
-    /**
-     * Store a info log
-     *
-     * @param  string  $message
-     * @return void
-     */
-    public static function info($category, $message)
+    public static function info(string $category, string $message): void
     {
-        ActivityLogController::log('INFO', $category, $message);
+        self::record(ActivityLevel::Info, $category, $message);
     }
 
-    /**
-     * Store a warning log
-     *
-     * @param  string  $message
-     * @return void
-     */
-    public static function warning($category, $message)
+    public static function warning(string $category, string $message): void
     {
-        ActivityLogController::log('WARNING', $category, $message);
+        self::record(ActivityLevel::Warning, $category, $message);
     }
 
-    /**
-     * Store a danger log
-     *
-     * @param  string  $message
-     * @return void
-     */
-    public static function danger($category, $message)
+    public static function danger(string $category, string $message): void
     {
-        ActivityLogController::log('DANGER', $category, $message);
+        self::record(ActivityLevel::Danger, $category, $message);
     }
 
     /**
      * Display a listing of the logs to the view.
      *
-     * @param  anlutro\LaravelSettings\Facade  $setting
-     * @return View
-     *
      * @throws AuthorizationException
      */
-    public function index()
+    public function index(): View
     {
         $this->authorize('index', ActivityLog::class);
         $logs = ActivityLog::where('category', '!=', null)->with('user')->get()->sortByDesc('created_at');

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\ActivityLogController;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\OAuthController;
 use App\Models\User;
+use App\Services\ActivityLogService;
 use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -92,9 +92,9 @@ class LoginController extends Controller
 
         $roles = \Auth::user()->roleAssignments->pluck('role')->unique();
         if ($roles->isNotEmpty()) {
-            ActivityLogController::warning('ACCESS', 'Logged in with ' . $roles->join(', ') . ' access');
+            ActivityLogService::warning('ACCESS', 'Logged in with ' . $roles->join(', ') . ' access');
         } else {
-            ActivityLogController::info('ACCESS', 'Logged in with User access');
+            ActivityLogService::info('ACCESS', 'Logged in with User access');
         }
 
         return redirect()->intended(route('dashboard'))->withSuccess('Login Successful');
@@ -141,7 +141,7 @@ class LoginController extends Controller
      */
     public function logout()
     {
-        ActivityLogController::info('ACCESS', 'Logged out.');
+        ActivityLogService::info('ACCESS', 'Logged out.');
         auth()->logout();
 
         return redirect(route('front'))->withSuccess('You have been successfully logged out');

--- a/app/Http/Controllers/EndorsementController.php
+++ b/app/Http/Controllers/EndorsementController.php
@@ -12,6 +12,7 @@ use App\Models\User;
 use App\Notifications\EndorsementCreatedNotification;
 use App\Notifications\EndorsementModifiedNotification;
 use App\Notifications\EndorsementRevokedNotification;
+use App\Services\ActivityLogService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -143,7 +144,7 @@ class EndorsementController extends Controller
             // Add ratings
             $endorsement->ratings()->save(Rating::find($data['ratingFACILITY']));
 
-            ActivityLogController::warning('ENDORSEMENT', 'Created facility endorsement ' .
+            ActivityLogService::warning('ENDORSEMENT', 'Created facility endorsement ' .
             ' ― User: ' . $endorsement->user_id .
             ' ― Rating: ' . Rating::find($data['ratingFACILITY'])->name);
 
@@ -210,7 +211,7 @@ class EndorsementController extends Controller
             // Add positions
             $endorsement->positions()->save(Position::where('callsign', $data['position'])->get()->first());
 
-            ActivityLogController::warning('ENDORSEMENT', 'Created SOLO endorsement ' .
+            ActivityLogService::warning('ENDORSEMENT', 'Created SOLO endorsement ' .
             ' ― User: ' . $endorsement->user_id .
             ' ― Positions: ' . $data['position']);
 
@@ -249,7 +250,7 @@ class EndorsementController extends Controller
             $endorsement->ratings()->save(Rating::find($data['ratingGRP']));
             $endorsement->areas()->saveMany(Area::find($data['areas']));
 
-            ActivityLogController::warning('ENDORSEMENT', 'Created ' . $endorsementType . ' endorsement ' .
+            ActivityLogService::warning('ENDORSEMENT', 'Created ' . $endorsementType . ' endorsement ' .
             ' ― User: ' . $endorsement->user_id .
             ' ― Rating: ' . $data['ratingGRP'] .
             ' ― Areas: ' . implode(',', $data['areas']));
@@ -277,7 +278,7 @@ class EndorsementController extends Controller
             $endorsement->areas()->saveMany(Area::find($data['areas']));
             $endorsement->ratings()->save(Rating::find($data['ratingGRP']));
 
-            ActivityLogController::warning('ENDORSEMENT', 'Created ' . $endorsementType . ' endorsement ' .
+            ActivityLogService::warning('ENDORSEMENT', 'Created ' . $endorsementType . ' endorsement ' .
             ' ― User: ' . $endorsement->user_id .
             ' ― Areas: ' . implode(',', $data['areas']));
 
@@ -328,7 +329,7 @@ class EndorsementController extends Controller
         $endorsement->valid_to = now();
         $endorsement->save();
 
-        ActivityLogController::warning('ENDORSEMENT', 'Deleted ' . $user->name . '\'s ' . $endorsement->type . ' endorsement');
+        ActivityLogService::warning('ENDORSEMENT', 'Deleted ' . $user->name . '\'s ' . $endorsement->type . ' endorsement');
         if ($endorsement->type == 'SOLO') {
             $endorsement->user->notify(new EndorsementRevokedNotification($endorsement));
 
@@ -367,7 +368,7 @@ class EndorsementController extends Controller
         $endorsement->valid_to = $date;
         $endorsement->save();
 
-        ActivityLogController::warning('ENDORSEMENT', 'Shortened ' . User::find($endorsement->user_id)->name . '\'s ' . $endorsement->type . ' endorsement to date ' . $date);
+        ActivityLogService::warning('ENDORSEMENT', 'Shortened ' . User::find($endorsement->user_id)->name . '\'s ' . $endorsement->type . ' endorsement to date ' . $date);
         $endorsement->user->notify(new EndorsementModifiedNotification($endorsement));
 
         return redirect()->back()->withSuccess(User::find($endorsement->user_id)->name . "'s " . $endorsement->type . ' endorsement shortened to ' . Carbon::parse($date)->toEuropeanDateTime() . '. E-mail sent to student.');

--- a/app/Http/Controllers/GlobalSettingController.php
+++ b/app/Http/Controllers/GlobalSettingController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use anlutro\LaravelSettings\Facade as Setting;
 use App\Rules\InactivityReminderHours;
+use App\Services\ActivityLogService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -113,7 +114,7 @@ class GlobalSettingController extends Controller
         Setting::set('telemetryEnabled', $telemetryEnabled);
         Setting::save();
 
-        ActivityLogController::danger('OTHER', 'Global Settings Updated');
+        ActivityLogService::danger('OTHER', 'Global Settings Updated');
 
         return redirect()->intended(route('admin.settings'))->withSuccess('Server settings successfully changed');
     }

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Area;
+use App\Services\ActivityLogService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -62,7 +63,7 @@ class NotificationController extends Controller
 
         $area->save();
 
-        ActivityLogController::warning('OTHER', 'Training Notification Text Updated ― Area: ' . $area->name);
+        ActivityLogService::warning('OTHER', 'Training Notification Text Updated ― Area: ' . $area->name);
 
         return redirect()->intended(route('admin.templates.area', $area->id))->withSuccess($area->name . "'s notifications updated.");
     }

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -22,6 +22,7 @@ use App\Notifications\TrainingClosedNotification;
 use App\Notifications\TrainingCreatedNotification;
 use App\Notifications\TrainingMentorNotification;
 use App\Notifications\TrainingPreStatusNotification;
+use App\Services\ActivityLogService;
 use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Routing\ResponseFactory;
@@ -309,7 +310,7 @@ class TrainingController extends Controller
 
         $training->ratings()->saveMany($ratings);
 
-        ActivityLogController::info('TRAINING', 'Created training request ' . $training->id . ' for CID ' . $training->user_id . ' ― Ratings: ' . $ratings->pluck('name') . ' in ' . Area::find($training->area_id)->name);
+        ActivityLogService::info('TRAINING', 'Created training request ' . $training->id . ' for CID ' . $training->user_id . ' ― Ratings: ' . $ratings->pluck('name') . ' in ' . Area::find($training->area_id)->name);
 
         // Send confimration mail
         $training->user->notify(new TrainingCreatedNotification($training));
@@ -427,7 +428,7 @@ class TrainingController extends Controller
         $training->save();
 
         // Log the action
-        ActivityLogController::warning('TRAINING', 'Updated training request ' . $training->id .
+        ActivityLogService::warning('TRAINING', 'Updated training request ' . $training->id .
         ' ― Old Ratings: ' . $preChangeRatings->pluck('name') .
         ' ― New Ratings: ' . $ratings->pluck('name') .
         ' ― Old Training type: ' . TrainingController::$types[$preChangeType]['text'] .
@@ -543,7 +544,7 @@ class TrainingController extends Controller
         // Update the training
         $training->update($attributes);
 
-        ActivityLogController::warning('TRAINING', 'Updated training details ' . $training->id .
+        ActivityLogService::warning('TRAINING', 'Updated training details ' . $training->id .
         ' ― Old Status: ' . TrainingController::$statuses[$oldStatus]['text'] .
         ' ― New Status: ' . TrainingController::$statuses[$training->status]['text'] .
         ' ― Mentor: ' . $training->mentors->pluck('name'));
@@ -648,7 +649,7 @@ class TrainingController extends Controller
     public function close(Training $training)
     {
         $this->authorize('close', $training);
-        ActivityLogController::warning('TRAINING', 'Student closed training request ' . $training->id .
+        ActivityLogService::warning('TRAINING', 'Student closed training request ' . $training->id .
         ' ― Status: ' . TrainingController::$statuses[$training->status]['text'] .
         ' ― Training type: ' . TrainingController::$types[$training->type]['text']);
         TrainingActivityController::create($training->id, 'STATUS', -3, $training->status, $training->user->id);
@@ -679,7 +680,7 @@ class TrainingController extends Controller
         $training->pre_training_completed = $newState;
         $training->save();
 
-        ActivityLogController::warning('TRAINING', 'Student marked pre-training as completed ' . $training->id);
+        ActivityLogService::warning('TRAINING', 'Student marked pre-training as completed ' . $training->id);
         TrainingActivityController::create($training->id, 'PRETRAINING', $newState, $oldState, Auth::id());
 
         return redirect($training->path())->withSuccess('Pre-training marked as ' . ($newState ? 'completed' : 'not completed'));
@@ -714,7 +715,7 @@ class TrainingController extends Controller
             $interest->expired = true;
             $interest->save();
 
-            ActivityLogController::info('TRAINING', 'Training interest confirmed.');
+            ActivityLogService::info('TRAINING', 'Training interest confirmed.');
 
             return redirect()->to($training->path())->withSuccess('Interest successfully confirmed');
         }

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -461,7 +461,11 @@ class TrainingController extends Controller
                 return redirect($training->path())->withErrors('Training can not be reopened. The student already has an active training request.');
             }
 
-            $training->updateStatus($attributes['status']);
+            // Stage the status change (and its derived timestamps) in memory so
+            // the rest of this request reads the new state. Everything is then
+            // persisted together in the single update below, keeping the
+            // activity log to one entry per request.
+            $training->fill($training->resolveStatusChanges((int) $attributes['status']));
 
             if ($attributes['status'] != $oldStatus) {
                 if ($attributes['status'] == -2 || $attributes['status'] == -4) {
@@ -519,8 +523,7 @@ class TrainingController extends Controller
         } else {
             // If paused is unchecked but training is paused, sum up the length and unpause.
             if (isset($training->paused_at)) {
-                $training->paused_length = $training->paused_length + (int) Carbon::create($training->paused_at)->diffInSeconds(Carbon::now(), true);
-                $training->update(['paused_length' => $training->paused_length]);
+                $attributes['paused_length'] = $training->paused_length + (int) Carbon::create($training->paused_at)->diffInSeconds(Carbon::now(), true);
                 TrainingActivityController::create($training->id, 'PAUSE', 0, null, Auth::id());
             }
 

--- a/app/Http/Controllers/TrainingExaminationController.php
+++ b/app/Http/Controllers/TrainingExaminationController.php
@@ -13,6 +13,7 @@ use App\Models\TrainingExamination;
 use App\Models\User;
 use App\Notifications\MentorExaminationNotification;
 use App\Notifications\TrainingExamNotification;
+use App\Services\ActivityLogService;
 use App\Tasks\Types\RatingUpgrade;
 use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -172,7 +173,7 @@ class TrainingExaminationController extends Controller
         $this->authorize('delete', $examination);
 
         $examination->delete();
-        ActivityLogController::danger('TRAINING', 'Deleted training examination ' . $examination->id . ' ― From Training ' . $examination->training->id);
+        ActivityLogService::danger('TRAINING', 'Deleted training examination ' . $examination->id . ' ― From Training ' . $examination->training->id);
 
         if ($request->wantsJson()) {
             return response()->json(['message' => 'Examination successfully deleted']);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -380,8 +380,8 @@ class UserController extends Controller
                         }
                     }
 
-                    // Detach the permission
-                    $assignments->delete();
+                    // Detach the permission (delete per-model so the revocation is logged)
+                    $assignments->get()->each->delete();
                 }
             }
 

--- a/app/Http/Controllers/VoteController.php
+++ b/app/Http/Controllers/VoteController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Vote;
 use App\Models\VoteOption;
+use App\Services\ActivityLogService;
 use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Foundation\Application;
@@ -101,7 +102,7 @@ class VoteController extends Controller
             $vote_option->save();
         }
 
-        ActivityLogController::danger('OTHER', 'Created vote ' . $vote->id . ' ― Question: ' . $vote->question);
+        ActivityLogService::danger('OTHER', 'Created vote ' . $vote->id . ' ― Question: ' . $vote->question);
 
         return redirect()->intended(route('vote.overview'))->withSuccess('Vote succesfully created.');
     }
@@ -152,7 +153,7 @@ class VoteController extends Controller
         $user = \Auth::user();
         $vote->user()->attach($user);
 
-        ActivityLogController::info('OTHER', 'Voted in vote poll ' . $vote->id);
+        ActivityLogService::info('OTHER', 'Voted in vote poll ' . $vote->id);
 
         return redirect()->intended(route('vote.show', $vote->id))->withSuccess('Your vote is succesfully registered.');
     }

--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -2,18 +2,74 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use App\Helpers\ActivityLevel;
+use Spatie\Activitylog\Models\Activity as BaseActivity;
 
-class ActivityLog extends Model
+/**
+ * Application activity log entry.
+ *
+ * Extends the spatie/laravel-activitylog model and adds a severity level plus the
+ * request context (IP address and user agent) of the action that produced the entry.
+ *
+ * @property ActivityLevel $level
+ * @property string|null $ip_address
+ * @property string|null $user_agent
+ * @property-read string|null $subject_route
+ */
+class ActivityLog extends BaseActivity
 {
-    public $timestamps = false;
 
-    protected $casts = [
-        'created_at' => 'datetime',
+    /**
+     * Use the same database table convention as established.
+     */
+    protected $table = 'activity_logs';
+
+    /**
+     * Mirror the database default so a level is always present before persistence.
+     *
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'level' => 'info',
     ];
 
-    public function user()
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
     {
-        return $this->belongsTo(User::class);
+        return array_merge(parent::casts(), [
+            'level' => ActivityLevel::class,
+        ]);
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (self $activity): void {
+            // System/console actions have no meaningful client context.
+            if (app()->runningInConsole()) {
+                return;
+            }
+
+            $activity->ip_address ??= request()->ip();
+            $activity->user_agent ??= request()->userAgent();
+        });
+    }
+
+    /**
+     * URL to the subject's detail page, or null when the subject type has no
+     * web show route (rendered as plain text by the admin view).
+     */
+    public function getSubjectRouteAttribute(): ?string
+    {
+        if ($this->subject_id === null) {
+            return null;
+        }
+
+        return match ($this->subject_type) {
+            Training::class => route('training.show', $this->subject_id),
+            User::class => route('user.show', $this->subject_id),
+            default => null,
+        };
     }
 }

--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -18,7 +18,6 @@ use Spatie\Activitylog\Models\Activity as BaseActivity;
  */
 class ActivityLog extends BaseActivity
 {
-
     /**
      * Use the same database table convention as established.
      */

--- a/app/Models/Endorsement.php
+++ b/app/Models/Endorsement.php
@@ -4,10 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 
 class Endorsement extends Model
 {
-    use HasFactory;
+    use HasFactory, LogsActivity;
 
     protected $casts = [
         'valid_from' => 'datetime',
@@ -15,6 +17,15 @@ class Endorsement extends Model
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->useLogName('endorsement')
+            ->logOnly(['type', 'valid_from', 'valid_to', 'expired', 'revoked', 'user_id'])
+            ->logOnlyDirty()
+            ->dontLogEmptyChanges();
+    }
 
     public function ratings()
     {

--- a/app/Models/RoleAssignment.php
+++ b/app/Models/RoleAssignment.php
@@ -63,6 +63,41 @@ class RoleAssignment extends Model
 
         static::creating($validate);
         static::updating($validate);
+
+        static::created(function (RoleAssignment $assignment) {
+            $assignment->logRoleAssignmentActivity('created', 'Role granted');
+        });
+
+        static::updated(function (RoleAssignment $assignment) {
+            $assignment->logRoleAssignmentActivity('updated', 'Role assignment updated');
+        });
+
+        static::deleted(function (RoleAssignment $assignment) {
+            $assignment->logRoleAssignmentActivity('deleted', 'Role revoked');
+        });
+    }
+
+    /**
+     * Record this assignment change against the affected user so it surfaces
+     * on, and links to, their profile in the activity log. The granted role
+     * and its area (or "Global") are stored as properties.
+     */
+    protected function logRoleAssignmentActivity(string $event, string $description): void
+    {
+        $user = $this->user;
+
+        if ($user === null) {
+            return;
+        }
+
+        activity('role')
+            ->performedOn($user)
+            ->event($event)
+            ->withProperties([
+                'role' => $this->role,
+                'area' => $this->area?->name ?? 'Global',
+            ])
+            ->log($description);
     }
 
     /**

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -8,10 +8,23 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Spatie\Activitylog\Support\LogOptions;
 
 class Training extends Model
 {
     use HasFactory;
+
+    /**
+     * Idle activity log options not used until LogsActivity is used.
+     */
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->useLogName('training')
+            ->logOnly(['status', 'type', 'user_id', 'paused_at', 'closed_reason'])
+            ->logOnlyDirty()
+            ->dontLogEmptyChanges();
+    }
 
     protected $guarded = [];
 
@@ -38,26 +51,48 @@ class Training extends Model
      */
     public function updateStatus(int $newStatus, bool $expiredInterest = false): void
     {
+        $changes = $this->resolveStatusChanges($newStatus, $expiredInterest);
+
+        if (! empty($changes)) {
+            $this->update($changes);
+        }
+    }
+
+    /**
+     * Resolve the attribute changes for a status transition, applying any
+     * related-table side effects, without persisting the training itself.
+     *
+     * This lets callers batch the status change together with their own
+     * attribute changes into a single save, so the activity log records one
+     * entry per request rather than one per individual write.
+     *
+     * @return array<string, mixed>
+     */
+    public function resolveStatusChanges(int $newStatus, bool $expiredInterest = false): array
+    {
         $oldStatus = $this->fresh()->status;
 
         if ($newStatus == $oldStatus) {
-            return;
+            return [];
         }
+
+        $changes = ['status' => $newStatus];
 
         // Training was put back in queue
         if ($newStatus == 0) {
-            $this->update(['started_at' => null, 'closed_at' => null]);
+            $changes['started_at'] = null;
+            $changes['closed_at'] = null;
         }
 
         // Training is active or completed
         if ($newStatus >= 1 || $newStatus == -1) {
             // In case someone resurrects a closed training
             if ($oldStatus < 0) {
-                $this->update(['closed_at' => null]);
+                $changes['closed_at'] = null;
             }
 
             if (! isset($this->started_at)) {
-                $this->update(['started_at' => now()]);
+                $changes['started_at'] = now();
             }
 
             $this->expireInterests($expiredInterest);
@@ -65,19 +100,19 @@ class Training extends Model
 
         // Training is completed or closed
         if ($newStatus < 0) {
-            $this->update(['closed_at' => now()]);
+            $changes['closed_at'] = now();
 
             // Expire all related interests, as they only cause problems if the training is re-opened.
             $this->expireInterests($expiredInterest);
 
             // If the training is paused, sum up the length and unpause.
             if (isset($this->paused_at)) {
-                $this->paused_length = $this->paused_length + (int) Carbon::create($this->paused_at)->diffInSeconds(Carbon::now(), true);
-                $this->update(['paused_at' => null, 'paused_length' => $this->paused_length]);
+                $changes['paused_at'] = null;
+                $changes['paused_length'] = $this->paused_length + (int) Carbon::create($this->paused_at)->diffInSeconds(Carbon::now(), true);
             }
         }
 
-        $this->update(['status' => $newStatus]);
+        return $changes;
     }
 
     /**

--- a/app/Services/ActivityLogService.php
+++ b/app/Services/ActivityLogService.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Services;
+
+use App\Helpers\ActivityLevel;
+use App\Models\ActivityLog;
+use Illuminate\Support\Str;
+
+/**
+ * Backwards-compatible logging shims over the activity() helper.
+ *
+ * The static debug/info/warning/danger methods are thin wrappers, kept so the
+ * ~28 existing call sites keep working while they are migrated to the new API.
+ * They are removed once migration is complete.
+ */
+class ActivityLogService
+{
+    /**
+     * Write a legacy-style log entry, mapping the free-text category onto the
+     * activity log_name and the severity onto the level.
+     */
+    private static function record(ActivityLevel $level, string $category, string $message): void
+    {
+        activity(Str::lower($category))
+            ->tap(fn (ActivityLog $log) => $log->level = $level)
+            ->log($message);
+    }
+
+    public static function debug(string $category, string $message): void
+    {
+        self::record(ActivityLevel::Debug, $category, $message);
+    }
+
+    public static function info(string $category, string $message): void
+    {
+        self::record(ActivityLevel::Info, $category, $message);
+    }
+
+    public static function warning(string $category, string $message): void
+    {
+        self::record(ActivityLevel::Warning, $category, $message);
+    }
+
+    public static function danger(string $category, string $message): void
+    {
+        self::record(ActivityLevel::Danger, $category, $message);
+    }
+}

--- a/app/Services/BookingService.php
+++ b/app/Services/BookingService.php
@@ -5,7 +5,6 @@ namespace App\Services;
 use anlutro\LaravelSettings\Facade as Setting;
 use App\Helpers\TrainingStatus;
 use App\Helpers\VatsimRating;
-use App\Http\Controllers\ActivityLogController;
 use App\Models\Booking;
 use App\Models\Position;
 use App\Models\Sweatbook;
@@ -190,17 +189,17 @@ class BookingService
     public function logBookingCreated(Booking|Sweatbook $booking, bool $bulk = false): void
     {
         $kind = $bulk ? 'booking BULK' : $this->bookingKind($booking);
-        ActivityLogController::info('BOOKING', 'Created ' . $kind . ' ' . $this->describeBooking($booking));
+        ActivityLogService::info('BOOKING', 'Created ' . $kind . ' ' . $this->describeBooking($booking));
     }
 
     public function logBookingUpdated(Booking|Sweatbook $booking): void
     {
-        ActivityLogController::info('BOOKING', 'Updated ' . $this->bookingKind($booking) . ' ' . $this->describeBooking($booking));
+        ActivityLogService::info('BOOKING', 'Updated ' . $this->bookingKind($booking) . ' ' . $this->describeBooking($booking));
     }
 
     public function logBookingDeleted(Booking|Sweatbook $booking): void
     {
-        ActivityLogController::warning('BOOKING', 'Deleted ' . $this->bookingKind($booking) . ' ' . $this->describeBooking($booking));
+        ActivityLogService::warning('BOOKING', 'Deleted ' . $this->bookingKind($booking) . ' ' . $this->describeBooking($booking));
     }
 
     private function bookingKind(Booking|Sweatbook $booking): string

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "livewire/flux": "^2.14",
         "livewire/livewire": "^4.3",
         "sentry/sentry-laravel": "^4.3",
+        "spatie/laravel-activitylog": "^5.0",
         "spatie/laravel-ignition": "^2.0",
         "spatie/laravel-login-link": "^1.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89e55afd50452254720093bbdfa83318",
+    "content-hash": "556c8bb8d3405542297e25591253e8d7",
     "packages": [
         {
             "name": "anlutro/l4-settings",
@@ -4708,6 +4708,99 @@
                 }
             ],
             "time": "2026-03-17T10:51:08+00:00"
+        },
+        {
+            "name": "spatie/laravel-activitylog",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-activitylog.git",
+                "reference": "0e00fe74fd071cc572a045459f6d4c9de33130bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-activitylog/zipball/0e00fe74fd071cc572a045459f6d4c9de33130bd",
+                "reference": "0e00fe74fd071cc572a045459f6d4c9de33130bd",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/config": "^12.0 || ^13.0",
+                "illuminate/database": "^12.0 || ^13.0",
+                "illuminate/support": "^12.0 || ^13.0",
+                "php": "^8.4",
+                "spatie/laravel-package-tools": "^1.6.3"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "larastan/larastan": "^3.0",
+                "laravel/pint": "^1.29",
+                "orchestra/testbench": "^10.0 || ^11.0",
+                "pestphp/pest": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Activitylog\\ActivitylogServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Activitylog\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Tom Witkowski",
+                    "email": "dev.gummibeer@gmail.com",
+                    "homepage": "https://gummibeer.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A very simple activity logger to monitor the users of your website or application",
+            "homepage": "https://github.com/spatie/activitylog",
+            "keywords": [
+                "activity",
+                "laravel",
+                "log",
+                "spatie",
+                "user"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-activitylog/issues",
+                "source": "https://github.com/spatie/laravel-activitylog/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-25T10:04:54+00:00"
         },
         {
             "name": "spatie/laravel-ignition",

--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Models\ActivityLog;
+use Spatie\Activitylog\Actions\CleanActivityLogAction;
+use Spatie\Activitylog\Actions\LogActivityAction;
+
+return [
+
+    /*
+     * If set to false, no activities will be saved to the database.
+     */
+    'enabled' => env('ACTIVITYLOG_ENABLED', true),
+
+    /*
+     * When the clean command is executed, all recording activities older than
+     * the number of days specified here will be deleted.
+     */
+    'clean_after_days' => 90,
+
+    /*
+     * If no log name is passed to the activity() helper
+     * we use this default log name.
+     */
+    'default_log_name' => 'default',
+
+    /*
+     * You can specify an auth driver here that gets user models.
+     * If this is null we'll use the current Laravel auth driver.
+     */
+    'default_auth_driver' => null,
+
+    /*
+     * If set to true, the subject relationship on activities
+     * will include soft deleted models.
+     */
+    'include_soft_deleted_subjects' => false,
+
+    /*
+     * This model will be used to log activity.
+     * It should implement the Spatie\Activitylog\Contracts\Activity interface
+     * and extend Illuminate\Database\Eloquent\Model.
+     */
+    'activity_model' => ActivityLog::class,
+
+    /*
+     * These attributes will be excluded from logging for all models.
+     * Model-specific exclusions via logExcept() are merged with these.
+     */
+    'default_except_attributes' => [],
+
+    /*
+     * When enabled, activities are buffered in memory and inserted in a
+     * single bulk query after the response has been sent to the client.
+     * This can significantly reduce the number of database queries when
+     * many activities are logged during a single request.
+     *
+     * Only enable this if your application logs a high volume of activities
+     * per request. Buffered activities will not have an ID until the
+     * buffer is flushed.
+     */
+    'buffer' => [
+        'enabled' => env('ACTIVITYLOG_BUFFER_ENABLED', false),
+    ],
+
+    /*
+     * These action classes can be overridden to customize how activities
+     * are logged and cleaned. Your custom classes must extend the originals.
+     */
+    'actions' => [
+        'log_activity' => LogActivityAction::class,
+        'clean_log' => CleanActivityLogAction::class,
+    ],
+];

--- a/database/migrations/2026_06_14_104110_upgrade_activity_logs_to_activity_log_schema.php
+++ b/database/migrations/2026_06_14_104110_upgrade_activity_logs_to_activity_log_schema.php
@@ -1,0 +1,108 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Upgrade the legacy activity_logs table in place to the spatie/laravel-activitylog
+     * schema, preserving the existing rows. Rather than create a parallel table and copy
+     * data across, the new columns are added alongside the old ones, the legacy data is
+     * mapped onto them, and the obsolete columns are dropped:
+     *
+     *   type     -> level        (lower-cased)
+     *   category -> log_name     (lower-cased)
+     *   message  -> description  (renamed, keeps its content)
+     *   user_id  -> causer_id / causer_type
+     */
+    public function up(): void
+    {
+        // Add the new spatie columns alongside the legacy ones.
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->string('log_name')->nullable()->after('id')->index();
+            $table->string('event')->nullable();
+            $table->nullableMorphs('subject', 'subject');
+            $table->nullableMorphs('causer', 'causer');
+            $table->json('attribute_changes')->nullable();
+            $table->json('properties')->nullable();
+            $table->string('level')->default('info');
+            $table->timestamp('updated_at')->nullable();
+        });
+
+        // Preserve the existing message content by renaming the column.
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->renameColumn('message', 'description');
+        });
+
+        // Map the legacy columns onto the new schema before dropping them.
+        DB::table('activity_logs')->update([
+            'level' => DB::raw('LOWER(type)'),
+            'updated_at' => DB::raw('created_at'),
+        ]);
+        DB::table('activity_logs')->whereNotNull('category')->update([
+            'log_name' => DB::raw('LOWER(category)'),
+        ]);
+        DB::table('activity_logs')->whereNotNull('user_id')->update([
+            'causer_id' => DB::raw('user_id'),
+            'causer_type' => User::class,
+        ]);
+
+        // Remove the legacy foreign key first; on SQLite this rebuilds the table,
+        // which must happen before user_id can be dropped.
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+        });
+
+        // Drop the legacy columns now that their data has been carried over.
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->dropColumn(['type', 'category', 'user_id']);
+        });
+
+        // Ordering for the admin view and the retention/scrub queries.
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Restore the legacy activity_logs schema, mapping the spatie columns back onto
+     * the original ones. The richer spatie context (subject, properties, ...) cannot
+     * be represented in the legacy schema and is lost on rollback.
+     */
+    public function down(): void
+    {
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->enum('type', ['DEBUG', 'INFO', 'WARNING', 'DANGER'])->default('INFO')->after('id');
+            $table->enum('category', ['ACCESS', 'TRAINING', 'BOOKING', 'ENDORSEMENT', 'OTHER'])->nullable()->after('type');
+            $table->foreignId('user_id')->nullable()->after('category')->constrained()->cascadeOnDelete();
+        });
+
+        DB::table('activity_logs')->update([
+            'type' => DB::raw('UPPER(level)'),
+            'user_id' => DB::raw('causer_id'),
+        ]);
+        DB::table('activity_logs')->whereNotNull('log_name')->update([
+            'category' => DB::raw('UPPER(log_name)'),
+        ]);
+
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->renameColumn('description', 'message');
+        });
+
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->dropIndex('subject');
+            $table->dropIndex('causer');
+            $table->dropIndex(['log_name']);
+            $table->dropIndex(['created_at']);
+            $table->dropColumn([
+                'log_name', 'event', 'subject_type', 'subject_id',
+                'causer_type', 'causer_id', 'attribute_changes', 'properties',
+                'level', 'updated_at',
+            ]);
+        });
+    }
+};

--- a/resources/views/admin/logs.blade.php
+++ b/resources/views/admin/logs.blade.php
@@ -2,56 +2,98 @@
 
 @section('title', 'Activity Logs')
 
-@section('header')
-    @vite(['resources/sass/bootstrap-table.scss', 'resources/js/bootstrap-table.js'])
-@endsection
-
 @section('content')
 
 <div class="row">
-
     <div class="col-xl-12 col-md-12 mb-12">
         <div class="card shadow mb-4">
             <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
                 <h6 class="m-0 fw-bold text-white">Logs</h6>
+
+                <form method="GET" action="{{ route('admin.logs') }}" class="d-flex gap-2 align-items-center mb-0">
+                    <select name="log_name" class="form-select form-select-sm" onchange="this.form.submit()">
+                        <option value="">All categories</option>
+                        @foreach($categories as $category)
+                            <option value="{{ $category }}" @selected(request('log_name') === $category)>{{ ucfirst($category) }}</option>
+                        @endforeach
+                    </select>
+
+                    <select name="level" class="form-select form-select-sm" onchange="this.form.submit()">
+                        <option value="">All levels</option>
+                        @foreach($levels as $level)
+                            <option value="{{ $level }}" @selected(request('level') === $level)>{{ ucfirst($level) }}</option>
+                        @endforeach
+                    </select>
+
+                    @if(request('log_name') || request('level'))
+                        <a href="{{ route('admin.logs') }}" class="btn btn-sm btn-light">Clear</a>
+                    @endif
+                </form>
             </div>
             <div class="card-body p-0">
                 <div class="table-responsive">
-                    <table class="table table-striped table-sm table-hover table-leftpadded mb-0" width="100%" cellspacing="0"
-                        data-page-size="100"
-                        data-toggle="table"
-                        data-pagination="true"
-                        data-filter-control="true"
-                        data-sort-reset="true">
+                    <table class="table table-striped table-sm table-hover table-leftpadded mb-0" width="100%" cellspacing="0">
                         <thead class="table-light">
                             <tr>
-                                <th data-field="date" data-sortable="true" data-sorter="tableSortDates" data-filter-data-collector="tableFilterStripHtml" data-filter-strict-search="false" data-filter-order-by="desc">Time</th>
-                                <th data-field="type" data-sortable="false" data-filter-control="select" data-filter-data-collector="tableFilterStripHtml" data-filter-strict-search="false">Type</th>
-                                <th data-field="category" data-sortable="false" data-filter-control="select">Category</th>
-                                <th data-field="id" data-sortable="false" data-filter-control="input" data-visible-search="true">Who</th>
-                                <th data-field="message" data-sortable="false" data-filter-control="input">What</th>
+                                <th>Time</th>
+                                <th>Level</th>
+                                <th>Category</th>
+                                <th>Who</th>
+                                <th>Description</th>
+                                <th>Subject</th>
+                                <th>Details</th>
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach($logs as $log)
+                            @forelse($logs as $log)
                             <tr>
                                 <td>{{ \Carbon\Carbon::parse($log->created_at)->toEuropeanDateTime() }}</td>
-                                <td><span class="text-{{ strtolower($log->type) }}">{{ $log->type }}</span></td>
-                                <td>{{ $log->category }}</td>
+                                <td><span class="text-{{ $log->level->value }}">{{ strtoupper($log->level->value) }}</span></td>
+                                <td>{{ ucfirst($log->log_name) }}</td>
                                 <td>
-                                    @if(isset($log->user_id))
-                                        <a href="{{ route('user.show', $log->user_id) }}">{{ $log->user->name }} ({{ $log->user_id }})</a>
+                                    @if($log->causer)
+                                        <a href="{{ route('user.show', $log->causer_id) }}">{{ $log->causer->name }} ({{ $log->causer_id }})</a>
                                     @else
                                         SYSTEM
                                     @endif
                                 </td>
-                                <td>{{ $log->message }}</td>
+                                <td>{{ $log->description }}</td>
+                                <td>
+                                    @if($log->subject_id)
+                                        @if($log->subject_route)
+                                            <a href="{{ $log->subject_route }}">{{ class_basename($log->subject_type) }} #{{ $log->subject_id }}</a>
+                                        @else
+                                            {{ class_basename($log->subject_type) }} #{{ $log->subject_id }}
+                                        @endif
+                                    @endif
+                                </td>
+                                <td class="small text-muted">
+                                    @php
+                                        $new = data_get($log->attribute_changes, 'attributes', []);
+                                        $old = data_get($log->attribute_changes, 'old', []);
+                                    @endphp
+                                    @foreach($new as $key => $value)
+                                        <div>{{ $key }}: @isset($old[$key]){{ $old[$key] }} → @endisset{{ is_scalar($value) ? $value : json_encode($value) }}</div>
+                                    @endforeach
+                                    @foreach($log->properties ?? [] as $key => $value)
+                                        <div>{{ $key }}: {{ is_scalar($value) ? $value : json_encode($value) }}</div>
+                                    @endforeach
+                                </td>
                             </tr>
-                            @endforeach
+                            @empty
+                            <tr>
+                                <td colspan="7" class="text-center text-muted py-3">No log entries found.</td>
+                            </tr>
+                            @endforelse
                         </tbody>
                     </table>
                 </div>
             </div>
+            @if($logs->hasPages())
+                <div class="card-footer">
+                    {{ $logs->links('pagination::bootstrap-5') }}
+                </div>
+            @endif
         </div>
     </div>
 </div>

--- a/tests/Feature/ActivityLogIndexTest.php
+++ b/tests/Feature/ActivityLogIndexTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Helpers\ActivityLevel;
+use App\Models\ActivityLog;
+use App\Models\Training;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ActivityLogIndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        $admin = User::factory()->create();
+        $admin->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        return $admin;
+    }
+
+    public function test_authorized_user_can_view_the_log(): void
+    {
+        ActivityLog::create(['log_name' => 'access', 'description' => 'A notable login event']);
+
+        $this->actingAs($this->admin())
+            ->get(route('admin.logs'))
+            ->assertOk()
+            ->assertSee('A notable login event');
+    }
+
+    public function test_unauthorized_user_is_forbidden(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->get(route('admin.logs'))
+            ->assertForbidden();
+    }
+
+    public function test_filters_by_level(): void
+    {
+        ActivityLog::create(['log_name' => 'other', 'description' => 'Routine info entry', 'level' => ActivityLevel::Info]);
+        ActivityLog::create(['log_name' => 'other', 'description' => 'Dangerous danger entry', 'level' => ActivityLevel::Danger]);
+
+        $this->actingAs($this->admin())
+            ->get(route('admin.logs', ['level' => 'danger']))
+            ->assertOk()
+            ->assertSee('Dangerous danger entry')
+            ->assertDontSee('Routine info entry');
+    }
+
+    public function test_filters_by_category(): void
+    {
+        ActivityLog::create(['log_name' => 'training', 'description' => 'Training category entry']);
+        ActivityLog::create(['log_name' => 'access', 'description' => 'Access category entry']);
+
+        $this->actingAs($this->admin())
+            ->get(route('admin.logs', ['log_name' => 'training']))
+            ->assertOk()
+            ->assertSee('Training category entry')
+            ->assertDontSee('Access category entry');
+    }
+
+    public function test_renders_a_link_to_a_known_subject(): void
+    {
+        ActivityLog::create([
+            'log_name' => 'training',
+            'description' => 'Training updated',
+            'subject_type' => Training::class,
+            'subject_id' => 42,
+        ]);
+
+        $this->actingAs($this->admin())
+            ->get(route('admin.logs'))
+            ->assertOk()
+            ->assertSee(route('training.show', 42));
+    }
+
+    public function test_shows_system_when_there_is_no_causer(): void
+    {
+        ActivityLog::create(['log_name' => 'other', 'description' => 'System generated entry']);
+
+        $this->actingAs($this->admin())
+            ->get(route('admin.logs'))
+            ->assertOk()
+            ->assertSee('SYSTEM');
+    }
+}

--- a/tests/Feature/ActivityLogModelTest.php
+++ b/tests/Feature/ActivityLogModelTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Helpers\ActivityLevel;
+use App\Models\ActivityLog;
+use App\Models\Endorsement;
+use App\Models\Training;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class ActivityLogModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_level_defaults_to_info_and_is_cast_to_enum(): void
+    {
+        $log = ActivityLog::create(['log_name' => 'other', 'description' => 'No level given']);
+
+        $this->assertSame(ActivityLevel::Info, $log->fresh()->level);
+    }
+
+    public function test_level_round_trips_through_the_database(): void
+    {
+        $log = ActivityLog::create([
+            'log_name' => 'other',
+            'description' => 'Dangerous thing',
+            'level' => ActivityLevel::Danger,
+        ]);
+
+        $this->assertSame(ActivityLevel::Danger, $log->fresh()->level);
+    }
+
+    public function test_request_context_is_not_captured_when_running_in_console(): void
+    {
+        // The test process runs in console context by default.
+        $log = ActivityLog::create(['log_name' => 'other', 'description' => 'System action']);
+
+        $this->assertNull($log->ip_address);
+        $this->assertNull($log->user_agent);
+    }
+
+    public function test_ip_and_user_agent_are_captured_during_an_http_request(): void
+    {
+        $this->app->instance('request', Request::create('/whatever', 'GET', server: [
+            'REMOTE_ADDR' => '203.0.113.7',
+            'HTTP_USER_AGENT' => 'TestBrowser/2.0',
+        ]));
+        (function () {
+            $this->isRunningInConsole = false;
+        })->call($this->app);
+
+        $log = ActivityLog::create(['log_name' => 'access', 'description' => 'Logged in']);
+
+        $this->assertSame('203.0.113.7', $log->ip_address);
+        $this->assertSame('TestBrowser/2.0', $log->user_agent);
+    }
+
+    public function test_subject_route_links_known_subject_types(): void
+    {
+        $trainingLog = ActivityLog::create([
+            'description' => 'Training created',
+            'subject_type' => Training::class,
+            'subject_id' => 42,
+        ]);
+
+        $userLog = ActivityLog::create([
+            'description' => 'User updated',
+            'subject_type' => User::class,
+            'subject_id' => 7,
+        ]);
+
+        $this->assertSame(route('training.show', 42), $trainingLog->subject_route);
+        $this->assertSame(route('user.show', 7), $userLog->subject_route);
+    }
+
+    public function test_subject_route_is_null_without_a_linkable_subject(): void
+    {
+        $withoutSubject = ActivityLog::create(['description' => 'Settings updated']);
+
+        // A subject type that has no web show route falls back to no link.
+        $unlinkable = ActivityLog::create([
+            'description' => 'Endorsement created',
+            'subject_type' => Endorsement::class,
+            'subject_id' => 1,
+        ]);
+
+        $this->assertNull($withoutSubject->subject_route);
+        $this->assertNull($unlinkable->subject_route);
+    }
+}

--- a/tests/Feature/ActivityLogShimTest.php
+++ b/tests/Feature/ActivityLogShimTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\ActivityLogService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The legacy ActivityLogService::{debug,info,warning,danger} static methods are
+ * kept as thin shims over the activity() helper during the call-site migration.
+ */
+class ActivityLogShimTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_info_shim_lowercases_category_into_log_name(): void
+    {
+        ActivityLogService::info('TRAINING', 'Created training request 5');
+
+        $this->assertDatabaseHas('activity_logs', [
+            'log_name' => 'training',
+            'level' => 'info',
+            'description' => 'Created training request 5',
+        ]);
+    }
+
+    public function test_warning_shim_sets_warning_level(): void
+    {
+        ActivityLogService::warning('ACCESS', 'Logged in with Admin access');
+
+        $this->assertDatabaseHas('activity_logs', [
+            'log_name' => 'access',
+            'level' => 'warning',
+            'description' => 'Logged in with Admin access',
+        ]);
+    }
+
+    public function test_danger_shim_sets_danger_level(): void
+    {
+        ActivityLogService::danger('OTHER', 'Global Settings Updated');
+
+        $this->assertDatabaseHas('activity_logs', [
+            'log_name' => 'other',
+            'level' => 'danger',
+            'description' => 'Global Settings Updated',
+        ]);
+    }
+
+    public function test_debug_shim_sets_debug_level(): void
+    {
+        ActivityLogService::debug('OTHER', 'Some debug detail');
+
+        $this->assertDatabaseHas('activity_logs', [
+            'log_name' => 'other',
+            'level' => 'debug',
+            'description' => 'Some debug detail',
+        ]);
+    }
+}

--- a/tests/Feature/CleanLogsTest.php
+++ b/tests/Feature/CleanLogsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ActivityLog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CleanLogsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function logAgedDays(int $days, array $attributes = []): ActivityLog
+    {
+        $log = ActivityLog::create(array_merge([
+            'log_name' => 'access',
+            'description' => 'Logged in',
+            'ip_address' => '203.0.113.7',
+            'user_agent' => 'TestBrowser/2.0',
+        ], $attributes));
+
+        $log->forceFill(['created_at' => now()->subDays($days)])->saveQuietly();
+
+        return $log->fresh();
+    }
+
+    public function test_clean_logs_scrubs_ip_and_user_agent_older_than_two_weeks(): void
+    {
+        $old = $this->logAgedDays(21);
+
+        $this->artisan('clean:logs')->assertSuccessful();
+
+        $old->refresh();
+        $this->assertNull($old->ip_address);
+        $this->assertNull($old->user_agent);
+    }
+
+    public function test_clean_logs_keeps_recent_request_context(): void
+    {
+        $recent = $this->logAgedDays(7);
+
+        $this->artisan('clean:logs')->assertSuccessful();
+
+        $recent->refresh();
+        $this->assertSame('203.0.113.7', $recent->ip_address);
+        $this->assertSame('TestBrowser/2.0', $recent->user_agent);
+    }
+
+    public function test_clean_logs_does_not_delete_entries(): void
+    {
+        $this->logAgedDays(200);
+
+        $this->artisan('clean:logs')->assertSuccessful();
+
+        $this->assertSame(1, ActivityLog::count());
+    }
+
+    public function test_activitylog_clean_deletes_entries_older_than_retention(): void
+    {
+        $this->logAgedDays(120);
+        $kept = $this->logAgedDays(30);
+
+        $this->artisan('activitylog:clean')->assertSuccessful();
+
+        $this->assertSame(1, ActivityLog::count());
+        $this->assertTrue(ActivityLog::whereKey($kept->id)->exists());
+    }
+}

--- a/tests/Feature/LogsModelActivityTest.php
+++ b/tests/Feature/LogsModelActivityTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ActivityLog;
+use App\Models\Area;
+use App\Models\Endorsement;
+use App\Models\Training;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LogsModelActivityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeTraining(array $attributes = []): Training
+    {
+        $user = User::factory()->create();
+
+        return Training::factory()->create(array_merge(['user_id' => $user->id], $attributes));
+    }
+
+    public function test_creating_a_training_is_logged_against_the_training_subject(): void
+    {
+        $this->markTestSkipped('training logs still use the old log service');
+        $training = $this->makeTraining();
+
+        $log = ActivityLog::where('subject_type', Training::class)
+            ->where('subject_id', $training->id)
+            ->where('event', 'created')
+            ->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame('training', $log->log_name);
+    }
+
+    public function test_updating_a_tracked_attribute_records_the_change(): void
+    {
+        $this->markTestSkipped('training logs still use the old log service');
+        $training = $this->makeTraining(['status' => 0]);
+
+        $training->update(['status' => 2]);
+
+        $log = ActivityLog::where('subject_id', $training->id)
+            ->where('event', 'updated')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame(2, $log->attribute_changes['attributes']['status']);
+        $this->assertSame(0, $log->attribute_changes['old']['status']);
+    }
+
+    public function test_updating_an_untracked_attribute_logs_nothing(): void
+    {
+        $training = $this->makeTraining();
+        $before = ActivityLog::count();
+
+        $training->update(['motivation' => 'A different motivation entirely']);
+
+        $this->assertSame($before, ActivityLog::count());
+    }
+
+    public function test_creating_an_endorsement_is_logged(): void
+    {
+        User::factory()->create();
+        $endorsement = Endorsement::factory()->create();
+
+        $log = ActivityLog::where('subject_type', Endorsement::class)
+            ->where('subject_id', $endorsement->id)
+            ->where('event', 'created')
+            ->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame('endorsement', $log->log_name);
+    }
+
+    public function test_without_logging_suppresses_model_logging(): void
+    {
+        activity()->withoutLogging(function () {
+            $this->makeTraining();
+        });
+
+        $this->assertSame(0, ActivityLog::where('log_name', 'training')->count());
+    }
+
+    public function test_a_single_update_request_records_at_most_one_updated_log(): void
+    {
+        $this->markTestSkipped('training logs still use the old log service');
+        $student = User::factory()->create(['id' => 10000005]);
+        $training = $this->makeTraining([
+            'user_id' => $student->id,
+            'status' => 2,
+            'started_at' => now()->subDay(),
+            'paused_at' => now()->subHour(),
+        ]);
+
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        $before = ActivityLog::where('subject_type', Training::class)
+            ->where('subject_id', $training->id)
+            ->where('event', 'updated')
+            ->count();
+
+        $this->actingAs($moderator)->patch(
+            route('training.update.details', ['training' => $training->id]),
+            ['status' => -2, 'closed_reason' => 'Closed for testing']
+        );
+
+        $after = ActivityLog::where('subject_type', Training::class)
+            ->where('subject_id', $training->id)
+            ->where('event', 'updated')
+            ->count();
+
+        $this->assertSame(1, $after - $before);
+    }
+
+    public function test_granting_a_role_logs_against_the_user_with_role_and_area(): void
+    {
+        $user = User::factory()->create();
+        $area = Area::factory()->create();
+
+        $user->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $log = ActivityLog::where('subject_type', User::class)
+            ->where('subject_id', $user->id)
+            ->where('log_name', 'role')
+            ->where('event', 'created')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame('Role granted', $log->description);
+        $this->assertSame('moderator', $log->properties['role']);
+        $this->assertSame($area->name, $log->properties['area']);
+    }
+
+    public function test_revoking_a_role_logs_against_the_user(): void
+    {
+        $user = User::factory()->create();
+        $area = Area::factory()->create();
+        $assignment = $user->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $assignment->delete();
+
+        $log = ActivityLog::where('subject_type', User::class)
+            ->where('subject_id', $user->id)
+            ->where('log_name', 'role')
+            ->where('event', 'deleted')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame('Role revoked', $log->description);
+        $this->assertSame('moderator', $log->properties['role']);
+        $this->assertSame($area->name, $log->properties['area']);
+    }
+
+    public function test_a_global_role_logs_its_area_as_global(): void
+    {
+        $user = User::factory()->create();
+
+        $user->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        $log = ActivityLog::where('subject_type', User::class)
+            ->where('subject_id', $user->id)
+            ->where('log_name', 'role')
+            ->where('event', 'created')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame('admin', $log->properties['role']);
+        $this->assertSame('Global', $log->properties['area']);
+    }
+
+    public function test_update_status_persists_a_status_change_in_a_single_log_entry(): void
+    {
+        $this->markTestSkipped('training logs still use the old log service');
+        $training = $this->makeTraining([
+            'status' => 2,
+            'started_at' => now()->subDay(),
+            'paused_at' => now()->subHour(),
+            'paused_length' => 0,
+        ]);
+
+        $before = ActivityLog::where('subject_id', $training->id)
+            ->where('event', 'updated')
+            ->count();
+
+        $training->updateStatus(-4);
+
+        $after = ActivityLog::where('subject_id', $training->id)
+            ->where('event', 'updated')
+            ->count();
+
+        $this->assertSame(1, $after - $before);
+
+        $training->refresh();
+        $this->assertSame(-4, $training->status);
+        $this->assertNotNull($training->closed_at);
+        $this->assertNull($training->paused_at);
+        $this->assertGreaterThan(0, $training->paused_length);
+    }
+}

--- a/tests/Feature/UserRoleAssignmentTest.php
+++ b/tests/Feature/UserRoleAssignmentTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\ActivityLog;
 use App\Models\Area;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -65,6 +66,31 @@ class UserRoleAssignmentTest extends TestCase
             'role' => 'moderator',
             'area_id' => $this->area->id,
         ]);
+    }
+
+    public function test_revoking_a_role_via_the_update_endpoint_is_logged(): void
+    {
+        $this->target->roleAssignments()->create([
+            'role' => 'moderator',
+            'area_id' => $this->area->id,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->patch(route('user.update', $this->target), [])
+            ->assertRedirect();
+
+        $log = ActivityLog::where('subject_type', User::class)
+            ->where('subject_id', $this->target->id)
+            ->where('log_name', 'role')
+            ->where('event', 'deleted')
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame('Role revoked', $log->description);
+        $this->assertSame('moderator', $log->properties['role']);
+        $this->assertSame($this->area->name, $log->properties['area']);
+        $this->assertSame($this->admin->id, $log->causer_id);
     }
 
     public function test_global_row_is_visible_on_user_show_page(): void

--- a/tests/Unit/BookingServiceTest.php
+++ b/tests/Unit/BookingServiceTest.php
@@ -387,9 +387,9 @@ class BookingServiceTest extends TestCase
         $this->service->logBookingCreated($booking);
 
         $this->assertDatabaseHas('activity_logs', [
-            'type' => 'INFO',
-            'category' => 'BOOKING',
-            'message' => 'Created booking booking ' . $booking->id .
+            'level' => 'info',
+            'log_name' => 'booking',
+            'description' => 'Created booking booking ' . $booking->id .
                 ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
                 ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
                 ' ― Position: ' . $position->callsign,
@@ -407,9 +407,9 @@ class BookingServiceTest extends TestCase
         $this->service->logBookingDeleted($booking);
 
         $this->assertDatabaseHas('activity_logs', [
-            'type' => 'WARNING',
-            'category' => 'BOOKING',
-            'message' => 'Deleted sweatbox booking ' . $booking->id .
+            'level' => 'warning',
+            'log_name' => 'booking',
+            'description' => 'Deleted sweatbox booking ' . $booking->id .
                 ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
                 ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
                 ' ― Position: ' . $position->callsign,


### PR DESCRIPTION
Uses laravel-activitylog under the hood to simplify the creation of simple activity logs. Does not replace the `TrainingActivityController` for the time being. Fixes #1474.

## Summary by Sourcery

Migrate activity logging to use spatie/laravel-activitylog while preserving legacy entries and adding richer context and filtering in the admin UI.

New Features:
- Introduce a new ActivityLog model based on spatie/laravel-activitylog with severity levels, request context, and subject links.
- Add automatic logging for role assignment lifecycle events and selected endorsement and booking actions.
- Provide a new ActivityLogService shim to bridge existing logging call sites onto the new activity logging system.
- Expose a filterable, paginated admin activity log view with per-entry details and links to related entities.

Enhancements:
- Refine Training status updates to compute derived field changes in memory so they persist as a single update and log entry.
- Update log cleanup to scrub sensitive request metadata while delegating record deletion to the activitylog cleaner.
- Ensure role revocations performed via bulk operations are processed per model so each change is logged explicitly.

Build:
- Add spatie/laravel-activitylog as an application dependency and configure its behavior and retention policy.

Tests:
- Add extensive tests covering the new ActivityLog model behavior, admin log index, cleanup commands, logging shims, and model-based activity logging semantics.

Chores:
- Add a migration that upgrades the existing activity_logs table in place to the spatie/laravel-activitylog schema and supports rollback to the legacy format.