### PR TITLE
refactor(roles): dot-namespace permissions and invert the role matrix

### DIFF
--- a/app/Console/Commands/CheckOnlineControllers.php
+++ b/app/Console/Commands/CheckOnlineControllers.php
@@ -90,7 +90,7 @@ class CheckOnlineControllers extends Command
                             $user->save();
 
                             // Send warning to staff holding the alert permission, limited to the position's area when known
-                            $sendToStaff = User::allWithPermission('receive-inactivity-alerts', $area);
+                            $sendToStaff = User::allWithPermission('notifications.inactivity.receive', $area);
 
                             $user->notify(new InactiveOnlineStaffNotification($sendToStaff, $user, $d['callsign'], $d['logon_time']));
                         } else {

--- a/app/Console/Commands/UpdateWorkmails.php
+++ b/app/Console/Commands/UpdateWorkmails.php
@@ -44,7 +44,7 @@ class UpdateWorkmails extends Command
 
         // Check for users that no longer hold a role granting workmail
         foreach (User::whereNotNull('setting_workmail_address')->get() as $user) {
-            if (! $user->hasPermission('use-workmail')) {
+            if (! $user->hasPermission('users.workmail.use')) {
                 $user->setting_workmail_address = null;
                 $user->setting_workmail_expire = null;
                 $user->save();

--- a/app/Http/Controllers/API/BookingController.php
+++ b/app/Http/Controllers/API/BookingController.php
@@ -106,10 +106,10 @@ class BookingController extends Controller
 
         $forcedTrainingTag = false;
 
-        if (($booking->position->rating > $user->rating) && ! $user->hasPermission('bypass-booking-restrictions')) {
+        if (($booking->position->rating > $user->rating) && ! $user->hasPermission('bookings.bypass-restrictions')) {
             $booking->training = 1;
             $forcedTrainingTag = true;
-        } elseif ($position->requiredRating && ! $user->hasEndorsementRating($position->requiredRating) && ! $user->hasPermission('bypass-booking-restrictions')) {
+        } elseif ($position->requiredRating && ! $user->hasEndorsementRating($position->requiredRating) && ! $user->hasPermission('bookings.bypass-restrictions')) {
             $booking->training = 1;
             $forcedTrainingTag = true;
         } else {
@@ -200,7 +200,7 @@ class BookingController extends Controller
             $positions = $positions->merge($user->getActiveTraining()->area->positions->where('rating', '<=', $user->getActiveTraining()->first()->vatsim_rating));
         }
 
-        if ($user->hasPermission('bypass-booking-restrictions')) {
+        if ($user->hasPermission('bookings.bypass-restrictions')) {
             $positions = Position::all();
         }
 
@@ -271,10 +271,10 @@ class BookingController extends Controller
 
         $forcedTrainingTag = false;
 
-        if (($booking->position->rating > $user->rating) && ! $user->hasPermission('bypass-booking-restrictions')) {
+        if (($booking->position->rating > $user->rating) && ! $user->hasPermission('bookings.bypass-restrictions')) {
             $booking->training = 1;
             $forcedTrainingTag = true;
-        } elseif ($position->requiredRating && ! $user->hasEndorsementRating($position->requiredRating) && ! $user->hasPermission('bypass-booking-restrictions')) {
+        } elseif ($position->requiredRating && ! $user->hasEndorsementRating($position->requiredRating) && ! $user->hasPermission('bookings.bypass-restrictions')) {
             $booking->training = 1;
             $forcedTrainingTag = true;
         } else {

--- a/app/Http/Controllers/Admin/PositionController.php
+++ b/app/Http/Controllers/Admin/PositionController.php
@@ -75,7 +75,7 @@ class PositionController extends Controller
 
     private function redirectAfterMutation(Request $request, int $areaId): RedirectResponse
     {
-        $route = $request->user()->accessibleAreasForPermission('manage-positions')->isGlobal
+        $route = $request->user()->accessibleAreasForPermission('fir.positions.manage')->isGlobal
             ? route('positions.index.area', $areaId)
             : route('positions.index');
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -77,9 +77,9 @@ class DashboardController extends Controller
 
         $studentTrainings = \Auth::user()->mentoringTrainings();
 
-        $cronJobError = (($user->hasPermission('view-system-health') && App::environment('production')) && (Carbon::parse(Setting::get('_lastCronRun', '2000-01-01')) <= Carbon::now()->subMinutes(5)));
+        $cronJobError = (($user->hasPermission('system.health.view') && App::environment('production')) && (Carbon::parse(Setting::get('_lastCronRun', '2000-01-01')) <= Carbon::now()->subMinutes(5)));
 
-        $oudatedVersionWarning = $user->hasPermission('view-system-health') && Setting::get('_updateAvailable');
+        $oudatedVersionWarning = $user->hasPermission('system.health.view') && Setting::get('_updateAvailable');
 
         return view('dashboard', compact('data', 'trainings', 'statuses', 'types', 'dueInterestRequest', 'atcInactiveMessage', 'completedTrainingMessage', 'activeVote', 'atcHours', 'workmailRenewal', 'studentTrainings', 'cronJobError', 'oudatedVersionWarning'));
     }

--- a/app/Http/Controllers/MentorController.php
+++ b/app/Http/Controllers/MentorController.php
@@ -21,7 +21,7 @@ class MentorController extends Controller
         $trainings = $user->mentoringTrainings();
         $statuses = TrainingController::$statuses;
         $types = TrainingController::$types;
-        if ($user->hasPermission('view-mentor-dashboard')) {
+        if ($user->hasPermission('training.mentor-dashboard.view')) {
             return view('mentor.index', compact('trainings', 'user', 'statuses', 'types'));
         }
 

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -56,7 +56,7 @@ class ReportController extends Controller
     {
         if (! $filterArea) {
             if ($response = $this->resolveAreaScope(
-                'view-training-statistics',
+                'training.statistics.view',
                 'reports.training.area',
                 'Training Statistics',
             )) {
@@ -147,7 +147,7 @@ class ReportController extends Controller
     {
         if (! $filterArea) {
             if ($response = $this->resolveAreaScope(
-                'view-training-activities',
+                'training.activities.view',
                 'reports.activities.area',
                 'Training Activities',
             )) {
@@ -218,7 +218,7 @@ class ReportController extends Controller
     {
         $this->authorize('viewMentors', ManagementReport::class);
 
-        $scope = auth()->user()->accessibleAreasForPermission('view-management-reports');
+        $scope = auth()->user()->accessibleAreasForPermission('fir.management.reports.view');
 
         $query = User::whereHas('roleAssignments', function ($q) {
             $q->where('role', 'mentor');
@@ -253,8 +253,8 @@ class ReportController extends Controller
         $this->authorize('viewFeedback', ManagementReport::class);
 
         $user = auth()->user();
-        $correlatedScope = $user->accessibleAreasForPermission('view-correlated-feedback');
-        $canViewUncorrelated = $user->accessibleAreasForPermission('view-uncorrelated-feedback')->hasAccess();
+        $correlatedScope = $user->accessibleAreasForPermission('feedback.correlated.view');
+        $canViewUncorrelated = $user->accessibleAreasForPermission('feedback.uncorrelated.view')->hasAccess();
 
         $feedback = Feedback::with(['submitter', 'referenceUser', 'referencePosition.area'])
             ->latest()

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -162,7 +162,7 @@ class TaskController extends Controller
 
         // Filter out users who no longer can receive tasks and end up with 3
         $users = $users->filter(function ($user) {
-            return $user->hasPermission('suggested-task-recipient');
+            return $user->hasPermission('tasks.suggested-recipient');
         })->take(3);
 
         return $users;

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -480,7 +480,7 @@ class TrainingController extends Controller
         $notifyOfNewMentor = false;
         if (array_key_exists('mentors', $attributes)) {
             foreach ((array) $attributes['mentors'] as $mentor) {
-                if (! $training->mentors->contains($mentor) && User::find($mentor) != null && User::find($mentor)->hasPermission('mentor-trainings', $training->area)) {
+                if (! $training->mentors->contains($mentor) && User::find($mentor) != null && User::find($mentor)->hasPermission('training.mentor', $training->area)) {
                     $training->mentors()->attach($mentor, ['expire_at' => now()->addMonths(12)]);
 
                     // Notify student of their new mentor

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use anlutro\LaravelSettings\Facade as Setting;
 use App\Exceptions\PolicyMethodMissingException;
 use App\Exceptions\PolicyMissingException;
+use App\Services\PermissionMatrix;
 use App\Support\AreaScope;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
@@ -67,7 +68,7 @@ class User extends Authenticatable
      */
     public static function allWithPermission(string $permission, ?Area $area = null): Collection
     {
-        $allowedRoles = config("roles.matrix.{$permission}", []);
+        $allowedRoles = app(PermissionMatrix::class)->rolesFor($permission);
 
         if (empty($allowedRoles)) {
             return (new User)->newCollection();
@@ -504,7 +505,7 @@ class User extends Authenticatable
 
     public function hasPermission(string $permission, ?Area $area = null): bool
     {
-        $allowedRoles = config("roles.matrix.{$permission}", []);
+        $allowedRoles = app(PermissionMatrix::class)->rolesFor($permission);
         if (empty($allowedRoles)) {
             return false;
         }
@@ -514,7 +515,7 @@ class User extends Authenticatable
 
     public function accessibleAreasForPermission(string $permission): AreaScope
     {
-        $allowedRoles = config("roles.matrix.{$permission}", []);
+        $allowedRoles = app(PermissionMatrix::class)->rolesFor($permission);
 
         if (empty($allowedRoles)) {
             return AreaScope::forAreas(collect());

--- a/app/Notifications/TrainingClosedNotification.php
+++ b/app/Notifications/TrainingClosedNotification.php
@@ -80,7 +80,7 @@ class TrainingClosedNotification extends Notification implements ShouldQueue
         }
 
         // Find staff who wants notification of new training request
-        $bcc = User::allWithPermission('receive-training-notifications', $this->training->area)
+        $bcc = User::allWithPermission('training.notifications.receive', $this->training->area)
             ->where('setting_notify_closedreq', true);
 
         return (new TrainingMail('Training Request Closed', $this->training, $textLines, $contactMail))

--- a/app/Notifications/TrainingCreatedNotification.php
+++ b/app/Notifications/TrainingCreatedNotification.php
@@ -60,7 +60,7 @@ class TrainingCreatedNotification extends Notification implements ShouldQueue
         }
 
         // Find staff who wants notification of new training request
-        $bcc = User::allWithPermission('receive-training-notifications', $this->training->area)
+        $bcc = User::allWithPermission('training.notifications.receive', $this->training->area)
             ->where('setting_notify_newreq', true);
 
         $contactMail = $area->contact;

--- a/app/Notifications/TrainingExamNotification.php
+++ b/app/Notifications/TrainingExamNotification.php
@@ -58,7 +58,7 @@ class TrainingExamNotification extends Notification implements ShouldQueue
         ];
 
         // Find staff who wants notification of new training request
-        $bcc = User::allWithPermission('receive-training-notifications', $this->training->area)
+        $bcc = User::allWithPermission('training.notifications.receive', $this->training->area)
             ->where('setting_notify_newexamreport', true);
 
         return (new TrainingMail('Training Examination Result', $this->training, $textLines, null, route('training.show', $this->training->id), 'Read Report'))

--- a/app/Policies/ActivityLogPolicy.php
+++ b/app/Policies/ActivityLogPolicy.php
@@ -16,6 +16,6 @@ class ActivityLogPolicy
      */
     public function index(User $user)
     {
-        return $user->hasPermission('view-activity-log');
+        return $user->hasPermission('system.activity-log.view');
     }
 }

--- a/app/Policies/BookingPolicy.php
+++ b/app/Policies/BookingPolicy.php
@@ -34,7 +34,7 @@ class BookingPolicy
             $user->isAtcActive() && $user->rating >= VatsimRating::S1->value
             || $user->hasActiveEndorsement('VISITING')
             || $user->getActiveTraining(TrainingStatus::PRE_TRAINING->value) != null
-            || $user->hasPermission('manage-bookings');
+            || $user->hasPermission('bookings.manage');
     }
 
     /**
@@ -55,7 +55,7 @@ class BookingPolicy
         }
 
         // The booking is not Discord but the user is moderator or above
-        if ($booking->source != 'DISCORD' && $user->hasPermission('manage-bookings')) {
+        if ($booking->source != 'DISCORD' && $user->hasPermission('bookings.manage')) {
             return Response::allow();
         }
 
@@ -75,7 +75,7 @@ class BookingPolicy
      */
     public function bookTrainingTag(User $user): bool
     {
-        if ($user->hasPermission('manage-bookings')) {
+        if ($user->hasPermission('bookings.manage')) {
             return true;
         }
 
@@ -98,7 +98,7 @@ class BookingPolicy
     public function bookExamTag(User $user): bool
     {
 
-        return $user->isMember() && ($user->rating >= VatsimRating::C1->value || $user->hasPermission('manage-bookings'));
+        return $user->isMember() && ($user->rating >= VatsimRating::C1->value || $user->hasPermission('bookings.manage'));
     }
 
     /**
@@ -109,7 +109,7 @@ class BookingPolicy
     public function position(User $user, Booking $booking)
     {
         // TODO: Make it easier to read the order of checks
-        if (($booking->position->rating->value > $user->rating || $user->rating < VatsimRating::S1->value) && ! $user->hasPermission('manage-bookings')) {
+        if (($booking->position->rating->value > $user->rating || $user->rating < VatsimRating::S1->value) && ! $user->hasPermission('bookings.manage')) {
             if (
                 $user->getActiveTraining(TrainingStatus::PRE_TRAINING->value) &&
                 $user->getActiveTraining()->getHighestVatsimRating()?->vatsim_rating >= $booking->position->rating->value &&

--- a/app/Policies/EndorsementPolicy.php
+++ b/app/Policies/EndorsementPolicy.php
@@ -17,7 +17,7 @@ class EndorsementPolicy
      */
     public function view(User $user)
     {
-        return $user == Auth::user() || $user->hasPermission('manage-endorsements');
+        return $user == Auth::user() || $user->hasPermission('endorsements.solo.manage');
     }
 
     /**
@@ -28,14 +28,14 @@ class EndorsementPolicy
     public function create(User $user, $type = null)
     {
         if ($type == 'VISITING') {
-            return $user->hasPermission('manage-visiting-endorsements');
+            return $user->hasPermission('endorsements.visiting.manage');
         }
 
         if ($type == 'EXAMINER') {
-            return $user->hasPermission('manage-examiner-endorsements');
+            return $user->hasPermission('endorsements.examiner.manage');
         }
 
-        return $user->hasPermission('manage-endorsements');
+        return $user->hasPermission('endorsements.solo.manage');
     }
 
     /**
@@ -52,14 +52,14 @@ class EndorsementPolicy
 
         // Check if user got correct permissions
         if ($endorsement->type == 'VISITING') {
-            return $user->hasPermission('manage-visiting-endorsements');
+            return $user->hasPermission('endorsements.visiting.delete');
         }
 
         if ($endorsement->type == 'EXAMINER') {
-            return $user->hasPermission('manage-examiner-endorsements');
+            return $user->hasPermission('endorsements.examiner.delete');
         }
 
-        return $user->hasPermission('manage-endorsements');
+        return $user->hasPermission('endorsements.solo.delete');
     }
 
     /**

--- a/app/Policies/FilePolicy.php
+++ b/app/Policies/FilePolicy.php
@@ -17,7 +17,7 @@ class FilePolicy
      */
     public function view(User $user, File $file)
     {
-        return $user->hasPermission('manage-files') ||
+        return $user->hasPermission('files.manage') ||
                 $user->is($file->owner) ||
                 ($file->trainingReportAttachment != null ? $user->can('view', $file->trainingReportAttachment) : false);
     }
@@ -29,7 +29,7 @@ class FilePolicy
      */
     public function create(User $user)
     {
-        return $user->hasPermission('upload-files');
+        return $user->hasPermission('files.upload');
     }
 
     /**
@@ -39,7 +39,7 @@ class FilePolicy
      */
     public function update(User $user, File $file)
     {
-        return $user->hasPermission('manage-files') || $user->is($file->owner);
+        return $user->hasPermission('files.manage') || $user->is($file->owner);
     }
 
     /**
@@ -49,6 +49,6 @@ class FilePolicy
      */
     public function delete(User $user, File $file)
     {
-        return $user->hasPermission('manage-files') || $user->is($file->owner);
+        return $user->hasPermission('files.manage') || $user->is($file->owner);
     }
 }

--- a/app/Policies/ManagementReportPolicy.php
+++ b/app/Policies/ManagementReportPolicy.php
@@ -18,10 +18,10 @@ class ManagementReportPolicy
     public function accessTrainingReports(User $user, $filterArea)
     {
         if ($filterArea) {
-            return $user->hasPermission('view-training-statistics', Area::find($filterArea));
+            return $user->hasPermission('training.statistics.view', Area::find($filterArea));
         }
 
-        return $user->hasPermission('view-training-statistics');
+        return $user->hasPermission('training.statistics.view');
     }
 
     /**
@@ -32,10 +32,10 @@ class ManagementReportPolicy
     public function accessActivityReports(User $user, $filterArea)
     {
         if ($filterArea) {
-            return $user->hasPermission('view-training-activities', Area::find($filterArea));
+            return $user->hasPermission('training.activities.view', Area::find($filterArea));
         }
 
-        return $user->hasPermission('view-training-activities');
+        return $user->hasPermission('training.activities.view');
     }
 
     /**
@@ -45,7 +45,7 @@ class ManagementReportPolicy
      */
     public function viewMentors(User $user)
     {
-        return $user->hasPermission('view-management-reports');
+        return $user->hasPermission('fir.management.reports.view');
     }
 
     /** Determine whether the user can see the feedback index
@@ -53,7 +53,7 @@ class ManagementReportPolicy
      */
     public function viewFeedback(User $user): bool
     {
-        return $user->accessibleAreasForPermission('view-correlated-feedback')->hasAccess();
+        return $user->accessibleAreasForPermission('feedback.correlated.view')->hasAccess();
     }
 
     /**
@@ -63,6 +63,6 @@ class ManagementReportPolicy
      */
     public function viewAccessReport(User $user)
     {
-        return $user->hasPermission('view-management-reports');
+        return $user->hasPermission('fir.management.reports.view');
     }
 }

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -17,7 +17,7 @@ class NotificationPolicy
      */
     public function viewTemplates(User $user)
     {
-        return $user->hasPermission('manage-notification-templates');
+        return $user->hasPermission('notifications.templates.manage');
     }
 
     /**
@@ -27,6 +27,6 @@ class NotificationPolicy
      */
     public function modifyAreaTemplate(User $user, Area $area)
     {
-        return $user->hasPermission('manage-notification-templates', $area);
+        return $user->hasPermission('notifications.templates.manage', $area);
     }
 }

--- a/app/Policies/OneTimeLinkPolicy.php
+++ b/app/Policies/OneTimeLinkPolicy.php
@@ -22,10 +22,10 @@ class OneTimeLinkPolicy
     {
         // Only allow examination link generation if the training is awaiting exam
         if ($type == OneTimeLink::TRAINING_EXAMINATION_TYPE) {
-            return $training->status == TrainingStatus::AWAITING_EXAM->value && ($training->mentors->contains($user) || $user->hasPermission('update-training', $training->area));
+            return $training->status == TrainingStatus::AWAITING_EXAM->value && ($training->mentors->contains($user) || $user->hasPermission('training.update', $training->area));
         }
 
-        return $training->mentors->contains($user) || $user->hasPermission('update-training', $training->area);
+        return $training->mentors->contains($user) || $user->hasPermission('training.update', $training->area);
     }
 
     /**
@@ -41,7 +41,7 @@ class OneTimeLinkPolicy
             return Response::denyAsNotFound('The one-time link provided has expired');
         }
 
-        return ($link->reportType() && $user->hasPermission('use-report-one-time-link'))
+        return ($link->reportType() && $user->hasPermission('training.reports.one-time-link'))
             || ($link->examinationType() && $user->isExaminer())
             ? Response::allow()
             : Response::deny('You are not allowed to access the one-time link');

--- a/app/Policies/PositionPolicy.php
+++ b/app/Policies/PositionPolicy.php
@@ -14,7 +14,7 @@ class PositionPolicy
 
     public function viewAny(User $user, ?Area $area = null): bool
     {
-        return $user->hasPermission('manage-positions', $area);
+        return $user->hasPermission('fir.positions.manage', $area);
     }
 
     public function before(User $user): ?bool
@@ -28,14 +28,14 @@ class PositionPolicy
 
     public function update(User $user, Position $position): Response
     {
-        return $user->hasPermission('manage-positions', $position->area)
+        return $user->hasPermission('fir.positions.manage', $position->area)
             ? Response::allow()
             : Response::deny('You are not authorized to update this position.');
     }
 
     public function delete(User $user, Position $position): Response
     {
-        return $user->hasPermission('manage-positions', $position->area)
+        return $user->hasPermission('fir.positions.manage', $position->area)
             ? Response::allow()
             : Response::deny('You are not authorized to delete this position.');
     }
@@ -46,14 +46,14 @@ class PositionPolicy
         // unsaved models (e.g. when authorising a create with a transient Position).
         $area = Area::find($position->area_id);
 
-        return $user->hasPermission('manage-positions', $area)
+        return $user->hasPermission('fir.positions.manage', $area)
             ? Response::allow()
             : Response::deny('You are not authorized to create positions in this area.');
     }
 
     public function createAny(User $user): Response
     {
-        return $user->hasPermission('manage-positions')
+        return $user->hasPermission('fir.positions.manage')
             ? Response::allow()
             : Response::deny('You are not authorized to create positions.');
     }

--- a/app/Policies/RatingPolicy.php
+++ b/app/Policies/RatingPolicy.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Rating;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class RatingPolicy
+{
+    use HandlesAuthorization;
+
+    public function before(User $user): ?bool
+    {
+        if ($user->hasRole('admin')) {
+            return true;
+        }
+
+        return null;
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $user->hasPermission('training.ratings.manage');
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->hasPermission('training.ratings.manage');
+    }
+
+    public function update(User $user, Rating $rating): bool
+    {
+        return $user->hasPermission('training.ratings.manage');
+    }
+
+    public function delete(User $user, Rating $rating): bool
+    {
+        return $user->hasPermission('training.ratings.manage');
+    }
+}

--- a/app/Policies/SettingPolicy.php
+++ b/app/Policies/SettingPolicy.php
@@ -17,7 +17,7 @@ class SettingPolicy
      */
     public function index(User $user, Setting $setting)
     {
-        return $user->hasPermission('manage-settings');
+        return $user->hasPermission('system.settings.manage');
     }
 
     /**
@@ -27,6 +27,6 @@ class SettingPolicy
      */
     public function edit(User $user, Setting $setting)
     {
-        return $user->hasPermission('manage-settings');
+        return $user->hasPermission('system.settings.manage');
     }
 }

--- a/app/Policies/SweatbookPolicy.php
+++ b/app/Policies/SweatbookPolicy.php
@@ -17,7 +17,7 @@ class SweatbookPolicy
      */
     public function view(User $user)
     {
-        return $user->hasPermission('use-sweatbook');
+        return $user->hasPermission('bookings.sweatbox.use');
     }
 
     /**
@@ -27,7 +27,7 @@ class SweatbookPolicy
      */
     public function create(User $user)
     {
-        return $user->hasPermission('use-sweatbook');
+        return $user->hasPermission('bookings.sweatbox.use');
     }
 
     /**
@@ -37,6 +37,6 @@ class SweatbookPolicy
      */
     public function update(User $user, Sweatbook $booking)
     {
-        return $booking->user_id == $user->id || $user->hasPermission('manage-sweatbook');
+        return $booking->user_id == $user->id || $user->hasPermission('bookings.sweatbox.manage');
     }
 }

--- a/app/Policies/TaskPolicy.php
+++ b/app/Policies/TaskPolicy.php
@@ -16,7 +16,7 @@ class TaskPolicy
      */
     public function create(User $user)
     {
-        return $user->hasPermission('manage-tasks') || $user->isExaminer();
+        return $user->hasPermission('tasks.manage') || $user->isExaminer();
     }
 
     /**
@@ -26,7 +26,7 @@ class TaskPolicy
      */
     public function update(User $user)
     {
-        return $user->hasPermission('manage-tasks') || $user->isExaminer();
+        return $user->hasPermission('tasks.manage') || $user->isExaminer();
     }
 
     /**
@@ -36,6 +36,6 @@ class TaskPolicy
      */
     public function receive(User $user)
     {
-        return $user->hasPermission('manage-tasks') || $user->isExaminer();
+        return $user->hasPermission('tasks.manage') || $user->isExaminer();
     }
 }

--- a/app/Policies/TrainingActivityPolicy.php
+++ b/app/Policies/TrainingActivityPolicy.php
@@ -29,7 +29,7 @@ class TrainingActivityPolicy
     public function view(User $user, Training $training, string $type)
     {
         if ($type == 'COMMENT') {
-            return $training->mentors->contains($user) || $user->hasPermission('view-training-activities', $training->area);
+            return $training->mentors->contains($user) || $user->hasPermission('training.activities.view', $training->area);
         }
 
         return true;

--- a/app/Policies/TrainingExaminationPolicy.php
+++ b/app/Policies/TrainingExaminationPolicy.php
@@ -19,7 +19,7 @@ class TrainingExaminationPolicy
      */
     public function view(User $user, TrainingExamination $examination)
     {
-        return $user->hasPermission('manage-examinations', $examination->training->area) || ($examination->training->mentors->contains($user) || $user->is($examination->training->user) || $user->isExaminer());
+        return $user->hasPermission('examinations.manage', $examination->training->area) || ($examination->training->mentors->contains($user) || $user->is($examination->training->user) || $user->isExaminer());
     }
 
     /**
@@ -30,7 +30,7 @@ class TrainingExaminationPolicy
     public function create(User $user, Training $training)
     {
 
-        if ($user->hasPermission('create-examinations')) {
+        if ($user->hasPermission('examinations.create')) {
             return true;
         }
 
@@ -51,7 +51,7 @@ class TrainingExaminationPolicy
      */
     public function update(User $user, TrainingExamination $examination)
     {
-        return $examination->draft ? ($user->hasPermission('manage-examinations', $examination->training->area) || $user->isExaminer()) : $user->hasPermission('manage-examinations', $examination->training->area);
+        return $examination->draft ? ($user->hasPermission('examinations.manage', $examination->training->area) || $user->isExaminer()) : $user->hasPermission('examinations.manage', $examination->training->area);
     }
 
     /**
@@ -61,6 +61,6 @@ class TrainingExaminationPolicy
      */
     public function delete(User $user, TrainingExamination $trainingExamination)
     {
-        return $user->hasPermission('manage-examinations', $trainingExamination->training->area);
+        return $user->hasPermission('examinations.manage', $trainingExamination->training->area);
     }
 }

--- a/app/Policies/TrainingObjectAttachmentPolicy.php
+++ b/app/Policies/TrainingObjectAttachmentPolicy.php
@@ -19,7 +19,7 @@ class TrainingObjectAttachmentPolicy
     {
         $attachmentArea = $attachment->object->training->area;
 
-        return ($user->can('view', $attachment->object) && $attachment->hidden != true) || $user->hasPermission('view-hidden-training-attachments', $attachmentArea);
+        return ($user->can('view', $attachment->object) && $attachment->hidden != true) || $user->hasPermission('training.attachments.view-hidden', $attachmentArea);
     }
 
     /**
@@ -29,7 +29,7 @@ class TrainingObjectAttachmentPolicy
      */
     public function create(User $user)
     {
-        return $user->hasPermission('upload-files');
+        return $user->hasPermission('files.upload');
     }
 
     /**
@@ -39,6 +39,6 @@ class TrainingObjectAttachmentPolicy
      */
     public function delete(User $user, TrainingObjectAttachment $attachment)
     {
-        return $user->hasPermission('manage-files', $attachment->object->training->area) || $user->is($attachment->file->owner);
+        return $user->hasPermission('files.manage', $attachment->object->training->area) || $user->is($attachment->file->owner);
     }
 }

--- a/app/Policies/TrainingPolicy.php
+++ b/app/Policies/TrainingPolicy.php
@@ -22,7 +22,7 @@ class TrainingPolicy
     public function view(User $user, Training $training)
     {
         return $training->mentors->contains($user) ||
-                $user->hasPermission('update-training', $training->area) ||
+                $user->hasPermission('training.update', $training->area) ||
                 $user->is($training->user);
     }
 
@@ -33,7 +33,7 @@ class TrainingPolicy
      */
     public function update(User $user, Training $training)
     {
-        return $user->hasPermission('update-training', $training->area);
+        return $user->hasPermission('training.update', $training->area);
     }
 
     /**
@@ -43,7 +43,7 @@ class TrainingPolicy
      */
     public function delete(User $user, Training $training)
     {
-        return $user->hasPermission('delete-training', $training->area);
+        return $user->hasPermission('training.delete', $training->area);
     }
 
     /**
@@ -64,7 +64,7 @@ class TrainingPolicy
     public function togglePreTrainingCompleted(User $user, Training $training)
     {
         return $training->status == TrainingStatus::PRE_TRAINING->value &&
-                ($training->pre_training_completed == false || $user->hasPermission('update-training', $training->area));
+                ($training->pre_training_completed == false || $user->hasPermission('training.update', $training->area));
     }
 
     /**
@@ -118,7 +118,7 @@ class TrainingPolicy
      */
     public function create(User $user)
     {
-        return $user->hasPermission('view-management-reports');
+        return $user->hasPermission('fir.management.reports.view');
     }
 
     /**
@@ -133,7 +133,7 @@ class TrainingPolicy
             return true;
         }
 
-        return $user->hasPermission('update-training', Area::find($data['training_area']));
+        return $user->hasPermission('training.update', Area::find($data['training_area']));
     }
 
     /**
@@ -143,16 +143,16 @@ class TrainingPolicy
      */
     public function edit(User $user, Training $training)
     {
-        return $user->hasPermission('update-training', $training->area);
+        return $user->hasPermission('training.update', $training->area);
     }
 
     public function viewActiveRequests(User $user)
     {
-        return $user->hasPermission('view-management-reports');
+        return $user->hasPermission('fir.management.reports.view');
     }
 
     public function viewHistoricRequests(User $user)
     {
-        return $user->hasPermission('view-management-reports');
+        return $user->hasPermission('fir.management.reports.view');
     }
 }

--- a/app/Policies/TrainingReportPolicy.php
+++ b/app/Policies/TrainingReportPolicy.php
@@ -20,7 +20,7 @@ class TrainingReportPolicy
     {
         return $training->mentors->contains($user) ||
                 $user->is($training->user) ||
-                $user->hasPermission('view-training-reports', $training->area);
+                $user->hasPermission('training.reports.view', $training->area);
     }
 
     /**
@@ -36,7 +36,7 @@ class TrainingReportPolicy
             && ! ($isTrainee && $trainingReport->draft)
         )
             || $trainingReport->author->is($user) // If the user is the author of the report
-            || $user->hasPermission('view-training-reports', $trainingReport->training->area)
+            || $user->hasPermission('training.reports.view', $trainingReport->training->area)
             || ($isTrainee && ! $trainingReport->draft);
     }
 
@@ -51,13 +51,13 @@ class TrainingReportPolicy
         }
 
         // Training mentors and report-managing staff can create a report
-        if ($user->hasPermission('create-training-reports', $training->area) || $training->mentors->contains($user)) {
+        if ($user->hasPermission('training.reports.create', $training->area) || $training->mentors->contains($user)) {
             return true;
         }
 
         // Otherwise, let's see if a one-time link is used
         if (($link = OneTimeLink::getFromSession($training)) != null) {
-            return $user->hasPermission('use-report-one-time-link', $link->training->area);
+            return $user->hasPermission('training.reports.one-time-link', $link->training->area);
         }
 
         return false;
@@ -81,7 +81,7 @@ class TrainingReportPolicy
     public function update(User $user, TrainingReport $trainingReport): bool
     {
         return $trainingReport->training->mentors->contains($user) ||
-                $user->hasPermission('update-training-reports', $trainingReport->training->area);
+                $user->hasPermission('training.reports.update', $trainingReport->training->area);
     }
 
     /**
@@ -89,7 +89,7 @@ class TrainingReportPolicy
      */
     public function delete(User $user, TrainingReport $trainingReport): Response
     {
-        return ($user->hasPermission('delete-training-reports', $trainingReport->training->area) || ($user->is($trainingReport->author) && $user->hasRole('mentor', $trainingReport->training->area)))
+        return ($user->hasPermission('training.reports.delete', $trainingReport->training->area) || ($user->is($trainingReport->author) && $user->hasRole('mentor', $trainingReport->training->area)))
             ? Response::allow()
             : Response::deny('Only moderators and the author of the training report can delete it.');
     }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -17,7 +17,7 @@ class UserPolicy
      */
     public function index(User $user)
     {
-        return $user->hasPermission('manage-users');
+        return $user->hasPermission('users.manage');
     }
 
     /**
@@ -27,7 +27,7 @@ class UserPolicy
      */
     public function view(User $user, User $model)
     {
-        return $user->is($model) || $user->hasPermission('manage-users') || $user->isTeaching($model);
+        return $user->is($model) || $user->hasPermission('users.manage') || $user->isTeaching($model);
     }
 
     /**
@@ -37,7 +37,7 @@ class UserPolicy
      */
     public function viewAccess(User $user)
     {
-        return $user->hasPermission('view-user-access');
+        return $user->hasPermission('users.access.view');
     }
 
     /**
@@ -47,7 +47,7 @@ class UserPolicy
      */
     public function viewReports(User $user, User $model)
     {
-        return $user->is($model) || $user->hasPermission('view-management-reports');
+        return $user->is($model) || $user->hasPermission('fir.management.reports.view');
     }
 
     /**
@@ -57,7 +57,7 @@ class UserPolicy
      */
     public function update(User $user, User $model)
     {
-        return $user->hasPermission('manage-users');
+        return $user->hasPermission('users.manage');
     }
 
     /**

--- a/app/Policies/VotePolicy.php
+++ b/app/Policies/VotePolicy.php
@@ -19,7 +19,7 @@ class VotePolicy
      */
     public function index(User $user)
     {
-        return $user->hasPermission('manage-votes');
+        return $user->hasPermission('system.votes.manage');
     }
 
     /**
@@ -29,7 +29,7 @@ class VotePolicy
      */
     public function create(User $user)
     {
-        return $user->hasPermission('manage-votes');
+        return $user->hasPermission('system.votes.manage');
     }
 
     /**
@@ -39,7 +39,7 @@ class VotePolicy
      */
     public function store(User $user)
     {
-        return $user->hasPermission('manage-votes');
+        return $user->hasPermission('system.votes.manage');
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Services\PermissionMatrix;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +12,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(PermissionMatrix::class);
     }
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -22,9 +22,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        $matrix = config('roles.matrix', []);
-
-        foreach ($matrix as $permission => $roles) {
+        foreach (config('roles.permissions', []) as $permission) {
             Gate::define($permission, function ($user, $area = null) use ($permission) {
                 return $user->hasPermission($permission, $area);
             });

--- a/app/Services/BookingService.php
+++ b/app/Services/BookingService.php
@@ -40,7 +40,7 @@ class BookingService
     public function getBookablePositions(User $user)
     {
         // Moderators and above can book any position
-        if ($user->hasPermission('bypass-booking-restrictions')) {
+        if ($user->hasPermission('bookings.bypass-restrictions')) {
             return Position::all();
         }
 
@@ -141,7 +141,7 @@ class BookingService
      */
     public function shouldForceTrainingTag(Booking $booking, Position $position, User $bookingUser): bool
     {
-        if ($bookingUser->hasPermission('bypass-booking-restrictions')) {
+        if ($bookingUser->hasPermission('bookings.bypass-restrictions')) {
             return false;
         }
 

--- a/app/Services/PermissionMatrix.php
+++ b/app/Services/PermissionMatrix.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Services;
+
+class PermissionMatrix
+{
+    /**
+     * Compiled regex cache, keyed by pattern.
+     *
+     * @var array<string, string>
+     */
+    private array $compiled = [];
+
+    /**
+     * Every concrete permission name defined in the catalogue.
+     *
+     * @return array<int, string>
+     */
+    public function all(): array
+    {
+        return array_values(config('roles.permissions', []));
+    }
+
+    /**
+     * All roles whose grant patterns include the given permission.
+     *
+     * @return array<int, string>
+     */
+    public function rolesFor(string $permission): array
+    {
+        if (! in_array($permission, $this->all(), true)) {
+            return [];
+        }
+
+        $roles = [];
+
+        foreach (config('roles.matrix', []) as $role => $patterns) {
+            if ($this->granted($permission, $patterns)) {
+                $roles[] = $role;
+            }
+        }
+
+        return $roles;
+    }
+
+    /**
+     * Every concrete permission a role holds, after applying wildcards and negation.
+     *
+     * @return array<int, string>
+     */
+    public function permissionsFor(string $role): array
+    {
+        $patterns = config("roles.matrix.{$role}", []);
+
+        return array_values(array_filter(
+            $this->all(),
+            fn (string $permission): bool => $this->granted($permission, $patterns)
+        ));
+    }
+
+    /**
+     * Decide whether a set of patterns grants a permission. Deny (`!`) always wins.
+     *
+     * @param  array<int, string>  $patterns
+     */
+    private function granted(string $permission, array $patterns): bool
+    {
+        $allowed = false;
+
+        foreach ($patterns as $pattern) {
+            if (str_starts_with($pattern, '!')) {
+                if ($this->matches(substr($pattern, 1), $permission)) {
+                    return false;
+                }
+            } elseif ($this->matches($pattern, $permission)) {
+                $allowed = true;
+            }
+        }
+
+        return $allowed;
+    }
+
+    private function matches(string $pattern, string $permission): bool
+    {
+        return (bool) preg_match($this->compile($pattern), $permission);
+    }
+
+    private function compile(string $pattern): string
+    {
+        return $this->compiled[$pattern] ??= '/^' . implode('\.', array_map(
+            fn (string $segment): string => match ($segment) {
+                '**' => '.+',
+                '*' => '[^.]+',
+                default => preg_quote($segment, '/'),
+            },
+            explode('.', $pattern)
+        )) . '$/';
+    }
+}

--- a/config/roles.php
+++ b/config/roles.php
@@ -45,85 +45,141 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Permission Catalogue
+    |--------------------------------------------------------------------------
+    |
+    | The flat, authoritative list of every concrete permission. This drives
+    | gate registration and the expansion of wildcard patterns in the matrix.
+    | A permission must appear here to exist.
+    |
+    */
+    'permissions' => [
+        // Training
+        'training.view',
+        'training.create',
+        'training.update',
+        'training.delete',
+        'training.mentor',
+        'training.mentor-dashboard.view',
+        'training.ratings.manage',
+        'training.reports.view',
+        'training.reports.create',
+        'training.reports.update',
+        'training.reports.delete',
+        'training.reports.one-time-link',
+        'training.attachments.view-hidden',
+        'training.activities.view',
+        'training.statistics.view',
+        'training.notifications.receive',
+
+        // Examinations
+        'examinations.manage',
+        'examinations.create',
+
+        // Endorsements
+        'endorsements.solo.manage',
+        'endorsements.solo.delete',
+        'endorsements.visiting.manage',
+        'endorsements.visiting.delete',
+        'endorsements.examiner.manage',
+        'endorsements.examiner.delete',
+
+        // FIR operations
+        'fir.positions.manage',
+        'fir.management.reports.view',
+
+        // Users
+        'users.manage',
+        'users.access.view',
+        'users.workmail.use',
+
+        // Tasks
+        'tasks.manage',
+        'tasks.suggested-recipient',
+
+        // Files
+        'files.manage',
+        'files.upload',
+
+        // Feedback
+        'feedback.correlated.view',
+        'feedback.uncorrelated.view',
+
+        // Bookings
+        'bookings.bypass-restrictions',
+        'bookings.manage',
+        'bookings.sweatbox.use',
+        'bookings.sweatbox.manage',
+
+        // Notifications
+        'notifications.inactivity.receive',
+        'notifications.templates.manage',
+
+        // System
+        'system.health.view',
+        'system.settings.manage',
+        'system.votes.manage',
+        'system.activity-log.view',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Permission Matrix
     |--------------------------------------------------------------------------
     |
-    | Map specific granular permissions to the assigned roles.
+    | Maps each role to the permission patterns it grants. Patterns support
+    | dot-wildcards: '*' matches exactly one segment, '**' matches one or more,
+    | and a leading '!' negates (deny always wins over allow).
     |
     */
     'matrix' => [
-        // Training permissions
-        'view-training' => ['admin', 'director', 'moderator', 'mentor', 'buddy'],
-        'create-training' => ['admin', 'director', 'moderator', 'mentor'],
-        'update-training' => ['admin', 'director', 'moderator'],
-        'delete-training' => ['admin', 'director'],
-        'mentor-trainings' => ['admin', 'director', 'moderator', 'mentor'],
-        'view-mentor-dashboard' => ['admin', 'director', 'moderator', 'mentor'],
-
-        // Training reports
-        'view-training-reports' => ['admin', 'director', 'moderator'],
-        'create-training-reports' => ['admin', 'director', 'moderator'],
-        'update-training-reports' => ['admin', 'director', 'moderator'],
-        'delete-training-reports' => ['admin', 'director', 'moderator'],
-        'use-report-one-time-link' => ['mentor', 'buddy'],
-        'view-hidden-training-attachments' => ['mentor'],
-
-        // Examinations
-        'manage-examinations' => ['admin', 'director', 'moderator'],
-        'create-examinations' => ['admin'],
-
-        // Area management
-        'manage-area' => ['admin'],
-
-        // System
-        'view-system-health' => ['admin'],
-        'manage-settings' => ['admin'],
-        'manage-votes' => ['admin'],
-        'view-activity-log' => ['admin'],
-
-        // Users & Access
-        'manage-users' => ['admin', 'director', 'moderator'],
-        'view-user-access' => ['admin', 'director', 'moderator'],
-
-        // Operations
-        'manage-positions' => ['admin', 'director', 'moderator', 'nav-editor'],
-
-        // Endorsements
-        'manage-endorsements' => ['admin', 'director', 'moderator'],
-        'manage-visiting-endorsements' => ['admin', 'director'],
-        'manage-examiner-endorsements' => ['admin', 'director'],
-
-        // Tasks
-        'manage-tasks' => ['admin', 'director', 'moderator', 'mentor'],
-        'suggested-task-recipient' => ['admin', 'director', 'moderator'],
-
-        // Files
-        'manage-files' => ['admin', 'director', 'moderator'],
-        'upload-files' => ['admin', 'director', 'moderator', 'mentor'],
-
-        // Reports
-        'view-management-reports' => ['admin', 'director', 'moderator'],
-        'view-training-activities' => ['admin', 'director', 'moderator'],
-        'view-training-statistics' => ['admin', 'director', 'moderator'],
-
-        // Feedback
-        'view-correlated-feedback' => ['admin', 'director', 'moderator'],
-        'view-uncorrelated-feedback' => ['admin', 'director', 'moderator'],
-
-        // Bookings
-        'bypass-booking-restrictions' => ['admin', 'director', 'moderator', 'mentor'],
-        'manage-bookings' => ['admin', 'director', 'moderator'],
-        'use-sweatbook' => ['admin', 'director', 'moderator', 'mentor'],
-        'manage-sweatbook' => ['admin', 'director', 'moderator'],
-
-        // Alerts & notifications
-        'receive-inactivity-alerts' => ['admin', 'director', 'moderator'],
-        'receive-training-notifications' => ['admin', 'director', 'moderator'],
-
-        // Notification templates
-        'manage-notification-templates' => ['admin', 'director', 'moderator'],
-
-        // Workmail
-        'use-workmail' => ['admin', 'director', 'moderator'],
+        'admin' => [
+            '**',
+            '!training.reports.one-time-link',
+            '!training.attachments.view-hidden',
+        ],
+        'director' => [
+            '**',
+            '!system.**',
+            '!examinations.create',
+            '!training.reports.one-time-link',
+            '!training.attachments.view-hidden',
+        ],
+        'moderator' => [
+            'training.**',
+            '!training.delete',
+            '!training.ratings.manage',
+            '!training.reports.one-time-link',
+            '!training.attachments.view-hidden',
+            'examinations.manage',
+            'endorsements.solo.*',
+            'fir.positions.manage',
+            'fir.management.reports.view',
+            'users.**',
+            'tasks.**',
+            'files.**',
+            'feedback.**',
+            'bookings.**',
+            'notifications.**',
+        ],
+        'nav-editor' => [
+            'fir.positions.*',
+        ],
+        'mentor' => [
+            'training.view',
+            'training.create',
+            'training.mentor',
+            'training.mentor-dashboard.view',
+            'training.reports.one-time-link',
+            'training.attachments.view-hidden',
+            'tasks.manage',
+            'files.upload',
+            'bookings.bypass-restrictions',
+            'bookings.sweatbox.use',
+        ],
+        'buddy' => [
+            'training.view',
+            'training.reports.one-time-link',
+        ],
     ],
 ];

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -11,27 +11,27 @@ Control Center grants access through **roles**, **areas**, and a configurable **
 The system has three layers, intentionally separated so an operator can shift policy without changing code:
 
 1. **Roles** describe what kind of contributor a user is — administrator, moderator, mentor, and so on. A role is an identifier you can assign to a user, optionally inside an area.
-2. **Permissions** describe individual capabilities — `manage-positions`, `view-management-reports`, and the like. They are not assigned to users directly; they are defined in a **matrix** that maps each permission to the roles that may exercise it.
+2. **Permissions** describe individual capabilities — `fir.positions.manage`, `training.reports.view`, and the like. They are dot-namespaced (`{domain}.{action}`) and listed in a **catalogue**. They are never assigned to users directly; the **matrix** maps each role to the permission patterns it grants.
 3. **Areas** scope a role assignment to part of the division (an ARTCC, a vACC, a sector group). The same user can hold the same role in several areas at once, in a single area, or globally.
 
-Both the role list and the matrix live in `config/roles.php`. Granting a role to a new permission, retiring a role, or introducing a new role is a configuration change, not a code change or migration.
+All three blocks — `roles`, `permissions`, and `matrix` — live in `config/roles.php`. The matrix is keyed by role, so granting a role a new capability, retiring a role, or introducing a new role is a configuration change, not a code change or migration.
 
 ## How a Check Resolves
 
 Authorisation asks two questions when checking a permission:
 
-1. **Does the user hold a role that grants this permission?** The matrix is consulted to find which roles satisfy it.
+1. **Does the user hold a role that grants this permission?** The matrix is consulted to find which roles' patterns grant it.
 2. **Does at least one of those role assignments cover the relevant area?** If the action targets an area, the assignment must either be in that area or be a global one. Area-agnostic actions only need the role somewhere.
 
-The matrix is authoritative: a permission that is not listed grants no role — even `admin`. The familiar "administrators can do anything" behaviour is a **per-policy convention**, implemented as a `before` hook in individual policy classes (for example `PositionPolicy::before()` returns `true` when the user holds `admin`). Resources whose policies install that hook let admins through regardless of the matrix; gates and policies without it are bound strictly by it.
+The catalogue is authoritative: a permission that is absent from the `permissions` catalogue grants nothing — even for `admin`. The familiar "administrators can do anything" behaviour is a **per-policy convention**, implemented as a `before` hook in individual policy classes (for example `PositionPolicy::before()` returns `true` when the user holds `admin`). Resources whose policies install that hook let admins through regardless of the matrix; gates and policies without it are bound strictly by it.
 
 ### Example
 
 > A user holds `nav-editor` in Area A.
 >
-> - Editing a position in **Area A** — allowed: `manage-positions` includes `nav-editor`, and the assignment matches the position's area.
+> - Editing a position in **Area A** — allowed: `fir.positions.manage` is in `nav-editor`'s pattern list, and the assignment matches the position's area.
 > - Editing a position in **Area B** — denied: the role assignment does not cover Area B.
-> - Moving a position from **Area A to Area B** — denied unless the user also holds `nav-editor` (or another role granting `manage-positions`) in Area B.
+> - Moving a position from **Area A to Area B** — denied unless the user also holds `nav-editor` (or another role granting `fir.positions.manage`) in Area B.
 
 ## Next Steps
 

--- a/docs/reference/permissions.md
+++ b/docs/reference/permissions.md
@@ -10,8 +10,8 @@ The catalogue of roles, permissions, and configuration knobs that ship with Cont
 
 | Role | Scope | Description |
 | --- | --- | --- |
-| `admin` | `global` | System-wide administrator. Assignable **only** via the `user:makeadmin` CLI command — never through the UI. Bypasses area checks (via the per-policy `before` hook) and is expected to be listed against every permission you want unrestricted. |
-| `director` | `both` | Director of an area, or of the whole organisation when assigned globally. Holds every admin permission except the system-level ones (`manage-area`, `view-system-health`). Only global admins and global directors may grant or revoke it. |
+| `admin` | `global` | System-wide administrator. Assignable **only** via the `user:makeadmin` CLI command — never through the UI. Bypasses area checks (via the per-policy `before` hook) and holds every permission except those explicitly negated in its matrix entry. |
+| `director` | `both` | Director of an area, or of the whole organisation when assigned globally. Holds every permission except the `system.**` namespace (e.g. `system.health.view`, `system.settings.manage`). Only global admins and global directors may grant or revoke it. |
 | `moderator` | `both` | Area moderator. Manages users, reports, positions, and endorsements within the assigned area, or system-wide if assigned globally. |
 | `nav-editor` | `area` | Navigational editor. May edit operationally relevant sector data such as positions within the assigned area. |
 | `mentor` | `area` | Training mentor. Can manage and view training within the assigned area. |
@@ -30,21 +30,30 @@ The `scope` field on a role restricts where assignments are allowed:
 - `area` — only area-scoped assignments (`area_id` required).
 - `both` — either; an area-less assignment behaves as system-wide.
 
-## Default Permission Matrix
+## Permission Catalogue and Matrix
 
-??? abstract "Default matrix in `config/roles.php`"
-    The default permission-to-role mapping lives in the `matrix` block of
-    [`config/roles.php` on `main`](https://github.com/Vatsim-Scandinavia/controlcenter/blob/main/config/roles.php).
+`config/roles.php` holds three blocks:
 
-A permission that is not listed in the matrix grants no role — `admin` included. The "administrators can do anything" behaviour is a per-policy convention (a `before` hook), not a property of the matrix.
+- `roles` — the role definitions above.
+- `permissions` — the flat catalogue of every dot-namespaced permission that exists.
+- `matrix` — maps each role to the permission **patterns** it grants.
+
+Patterns support dot-wildcards:
+
+- `*` matches exactly one segment — `fir.positions.*` covers `fir.positions.manage` but not `fir.positions.foo.bar`.
+- `**` matches one or more segments — `training.**` covers `training.view` and `training.reports.view`.
+- A leading `!` negates a pattern; deny always wins. This is how `director` gets everything except `system.**`.
+
+A permission granted by no role, or absent from the catalogue, grants nothing — `admin` included. The "administrators can do anything" behaviour remains a per-policy `before` hook, not a property of the matrix.
 
 ## Customising Roles and Permissions
 
 `config/roles.php` is the single source of truth.
 
-- **Rewire** an existing permission by changing the role list for that key in the `matrix` block. Example: drop `mentor` from `bypass-booking-restrictions` to tighten booking enforcement.
-- **Add** a new role by adding an entry under `roles` with a `name`, `description`, and `scope`, then add it to whichever permissions it should hold in the `matrix`.
-- **Remove** a role you don't use by deleting it from `roles`, dropping it from any permission lists in the `matrix`, and clearing its assignments from the `role_user` table.
+- **Rewire** a role by editing its pattern list in the `matrix` block. Example: drop `bookings.sweatbox.use` from `mentor` to remove their sweatbox access.
+- **Add** a new permission by adding it to the `permissions` catalogue and granting it to roles via patterns in the `matrix`.
+- **Add** a new role by adding an entry under `roles`, then granting it permissions in the `matrix`.
+- **Remove** a role by deleting it from `roles` and `matrix`, and clearing its assignments from the `role_user` table.
 
 After changing the file, clear the config cache so the new mapping is picked up:
 

--- a/resources/views/booking/index.blade.php
+++ b/resources/views/booking/index.blade.php
@@ -63,7 +63,7 @@
                                             {{ \Carbon\Carbon::create($booking->time_start)->toEuropeanDate(true) }}
                                         @endif 
                                         
-                                        @if(Auth::user()->id == $booking->user_id || Auth::user()->hasPermission('manage-bookings'))
+                                        @if(Auth::user()->id == $booking->user_id || Auth::user()->hasPermission('bookings.manage'))
 
                                             @if($booking->source == "DISCORD")
                                                 <i class="fab fa-discord text-primary" data-bs-toggle="tooltip" data-bs-placement="top" aria-hidden="true" title="{{ Gate::inspect('update', $booking, \App\Models\Booking::class)->message() }}"></i>

--- a/resources/views/endorsements/examiners.blade.php
+++ b/resources/views/endorsements/examiners.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Examiners')
 @section('title-flex')
     <div>
-        @can('manage-examiner-endorsements')
+        @can('endorsements.examiner.manage')
             <a href="{{ route('endorsements.create') }}" class="btn btn-outline-success"><i class="fas fa-plus"></i> Add new endorsement</a>
         @endcan
     </div>

--- a/resources/views/endorsements/mascs.blade.php
+++ b/resources/views/endorsements/mascs.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Facility Endorsements')
 @section('title-flex')
     <div>
-        @can('manage-endorsements')
+        @can('endorsements.solo.manage')
             <a href="{{ route('endorsements.create') }}" class="btn btn-outline-success"><i class="fas fa-plus"></i> Add new endorsement</a>
         @endcan
     </div>

--- a/resources/views/endorsements/solos.blade.php
+++ b/resources/views/endorsements/solos.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Solo Endorsements')
 @section('title-flex')
     <div>
-        @can('manage-endorsements')
+        @can('endorsements.solo.manage')
             <a href="{{ route('endorsements.create') }}" class="btn btn-outline-success"><i class="fas fa-plus"></i> Add new endorsement</a>
         @endcan
     </div>

--- a/resources/views/endorsements/visiting.blade.php
+++ b/resources/views/endorsements/visiting.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Visiting')
 @section('title-flex')
     <div>
-        @can('manage-visiting-endorsements')
+        @can('endorsements.visiting.manage')
             <a href="{{ route('endorsements.create') }}" class="btn btn-outline-success"><i class="fas fa-plus"></i> Add new endorsement</a>
         @endcan
     </div>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -52,7 +52,7 @@
             </li>
         @endif
 
-        @canany(['view-mentor-dashboard', 'use-sweatbook', 'view-management-reports'])
+        @canany(['training.mentor-dashboard.view', 'bookings.sweatbox.use', 'fir.management.reports.view'])
 
             {{-- Divider --}}
             <div class="sidebar-divider"></div>
@@ -62,7 +62,7 @@
             Training
             </div>
 
-            @can('view-mentor-dashboard')
+            @can('training.mentor-dashboard.view')
                 <li class="nav-item {{ Route::is('mentor') ? 'active' : '' }}">
                 <a class="nav-link" href="{{ route('mentor') }}">
                     <i class="fas fa-fw fa-chalkboard-teacher"></i>
@@ -70,7 +70,7 @@
                 </li>
             @endcan
 
-            @can('use-sweatbook')
+            @can('bookings.sweatbox.use')
                 <li class="nav-item {{ Route::is('sweatbook') ? 'active' : '' }}">
                     <a class="nav-link" href="{{ route('sweatbook') }}">
                         <i class="fas fa-fw fa-calendar-alt"></i>
@@ -79,7 +79,7 @@
                 </li>
             @endcan
 
-            @can('view-management-reports')
+            @can('fir.management.reports.view')
 
                 {{-- Nav Item - Pages Collapse Menu --}}
                 <li class="nav-item {{ Route::is('requests') || Route::is('requests.history') ? 'active' : '' }}">
@@ -106,7 +106,7 @@
         Members
         </div>
 
-        @can('manage-users')
+        @can('users.manage')
 
             {{-- Nav Item - Pages Collapse Menu --}}
             <li class="nav-item {{ Route::is('users') || Route::is('users.other') ? 'active' : '' }}">
@@ -170,7 +170,7 @@
 
 
 
-        @can('view-management-reports')
+        @can('fir.management.reports.view')
             {{-- Divider --}}
             <div class="sidebar-divider"></div>
 
@@ -183,10 +183,10 @@
             <div id="collapseTwo" class="collapse" data-bs-parent="#sidebar">
                 <div class="bg-white py-2 collapse-inner rounded">
 
-                @can('view-training-statistics')
+                @can('training.statistics.view')
                     <a class="collapse-item" href="{{ route('reports.trainings') }}">Training Statistics</a>
                 @endcan
-                @can('view-training-activities')
+                @can('training.activities.view')
                     <a class="collapse-item" href="{{ route('reports.activities') }}">Training Activities</a>
                 @endcan
 
@@ -203,7 +203,7 @@
             </li>
         @endif
 
-        @if(auth()->user()->canAny(['view-system-health', 'manage-users']) || auth()->user()->can('viewAny', App\Models\Position::class))
+        @if(auth()->user()->canAny(['system.health.view', 'users.manage']) || auth()->user()->can('viewAny', App\Models\Position::class))
 
             {{-- Nav Item - Utilities Collapse Menu --}}
             <li class="nav-item {{ Route::is('admin.*') || Route::is('positions.*') || Route::is('vote.overview') ? 'active' : '' }}">
@@ -213,13 +213,13 @@
             </a>
             <div id="collapseUtilities" class="collapse" aria-labelledby="headingUtilities" data-bs-parent="#sidebar">
                 <div class="bg-white py-2 collapse-inner rounded">
-                @can('view-system-health')
+                @can('system.health.view')
                     <a class="collapse-item" href="{{ route('admin.settings') }}">Settings</a>
                     <a class="collapse-item" href="{{ route('vote.overview') }}">Votes</a>
                     <a class="collapse-item" href="{{ route('admin.logs') }}">Logs</a>
                 @endcan
 
-                @can('manage-users')
+                @can('users.manage')
                     <a class="collapse-item" href="{{ route('admin.templates') }}">Notification templates</a>
                 @endcan
                 @can('viewAny', App\Models\Position::class)

--- a/resources/views/layouts/topbar.blade.php
+++ b/resources/views/layouts/topbar.blade.php
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand bg-white topbar {{ (\Auth::user()->can('manage-users')) ? 'topbar-justify-moderator' : 'topbar-justify-user' }} mb-4 ps-4 pe-4 static-top shadow">
+<nav class="navbar navbar-expand bg-white topbar {{ (\Auth::user()->can('users.manage')) ? 'topbar-justify-moderator' : 'topbar-justify-user' }} mb-4 ps-4 pe-4 static-top shadow">
 
     <a class="sidebar-brand sidebar-brand-topbar align-items-center" href="{{ route('dashboard') }}">
         <div class="sidebar-brand-icon">
@@ -9,7 +9,7 @@
     </a>
 
     {{-- Topbar Desktop Search --}}
-    @can('manage-users')
+    @can('users.manage')
         <form class="d-none d-md-inline-block my-2 my-md-0 mw-100 navbar-search" id="user-search-form-desktop">
             <div class="input-group">
                 <div class="search input-group input-lg">
@@ -30,7 +30,7 @@
     {{-- Topbar Navbar --}}
     <ul class="navbar-nav">
 
-        @can('manage-users')
+        @can('users.manage')
 
             {{-- Search Dropdown (Visible Only XS) --}}
             <li class="nav-item dropdown no-arrow d-md-none">

--- a/resources/views/mentor/index.blade.php
+++ b/resources/views/mentor/index.blade.php
@@ -42,7 +42,7 @@
                                 <td>
                                     <i class="{{ $statuses[$training->status]["icon"] }} text-{{ $statuses[$training->status]["color"] }}"></i>&ensp;<a href="/training/{{ $training->id }}">{{ $statuses[$training->status]["text"] }}</a>{{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
                                 </td>
-                                @can('manage-users')
+                                @can('users.manage')
                                     <td><a href="{{ route('user.show', $training->user->id) }}">{{ $training->user->id }}</a></td>
                                     <td><a href="{{ route('user.show', $training->user->id) }}">{{ $training->user->name }}</a></td>
                                 @else

--- a/resources/views/reports/activities.blade.php
+++ b/resources/views/reports/activities.blade.php
@@ -4,11 +4,11 @@
 @section('title-flex')
     <div>
         <i class="fas fa-filter text-secondary"></i>&nbsp;Filter&nbsp;
-        @if(\Auth::user()->accessibleAreasForPermission('view-training-activities')->isGlobal)
+        @if(\Auth::user()->accessibleAreasForPermission('training.activities.view')->isGlobal)
             <a class="btn btn-sm {{ $filterName == "All Areas" ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('reports.activities') }}">All Areas</a>
         @endif
         @foreach($areas as $area)
-            @can('view-training-activities', $area)
+            @can('training.activities.view', $area)
                 <a class="btn btn-sm {{ $filterName == $area->name ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('reports.activities.area', $area->id) }}">{{ $area->name }}</a>
             @endcan
         @endforeach

--- a/resources/views/reports/trainings.blade.php
+++ b/resources/views/reports/trainings.blade.php
@@ -19,11 +19,11 @@
 
         <div class="input-group input-group-sm w-auto">
             <span class="input-group-text"><i class="fas fa-filter me-1"></i>Filter</span>
-            @if(\Auth::user()->accessibleAreasForPermission('view-training-statistics')->isGlobal)
+            @if(\Auth::user()->accessibleAreasForPermission('training.statistics.view')->isGlobal)
                 <a class="btn btn-sm {{ $filterName == "All Areas" ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('reports.trainings', ['start_date' => request('start_date'), 'end_date' => request('end_date')]) }}">All Areas</a>
             @endif
             @foreach($areas as $area)
-                @can('view-training-statistics', $area)
+                @can('training.statistics.view', $area)
                     <a class="btn btn-sm {{ $filterName == $area->name ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('reports.training.area', ['id' => $area->id, 'start_date' => request('start_date'), 'end_date' => request('end_date')]) }}">{{ $area->name }}</a>
                 @endcan
             @endforeach

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -24,7 +24,7 @@
                         {{ $user->id }}
                         <button type="button" onclick="navigator.clipboard.writeText('{{ $user->id }}')"><i class="fas fa-copy"></i></button>
                         <a href="https://stats.vatsim.net/stats/{{ $user->id }}" target="_blank" title="VATSIM Stats" class="link-btn me-1"><i class="fas fa-chart-simple"></i></button></a>
-                        @if($user->division == 'EUD' && Auth::user()->can('manage-users'))
+                        @if($user->division == 'EUD' && Auth::user()->can('users.manage'))
                             <a href="https://core.vateud.net/manage/controller/{{ $user->id }}/view" target="_blank" title="VATEUD Core Profile" class="link-btn"><i class="fa-solid fa-earth-europe"></i></button></a>
                         @endif
                     </dd>
@@ -83,7 +83,7 @@
                     <dt class="pt-2">Last login</dt>
                     <dd>{{ $user->last_login->toEuropeanDateTime() }}</dd>
 
-                    @can('manage-users')
+                    @can('users.manage')
                         <dt class="pt-2">Last activity</dt>
                         <dd>{{ isset($user->last_activity) ? $user->last_activity->toEuropeanDateTime() : 'N/A' }}</dd>
                     @endcan

--- a/resources/views/usersettings.blade.php
+++ b/resources/views/usersettings.blade.php
@@ -47,7 +47,7 @@
                                 @endif
                             </div>
 
-                            @can('manage-tasks')
+                            @can('tasks.manage')
                                 <hr>
 
                                 <h5>Mentor Notifications</h5>
@@ -61,7 +61,7 @@
 
                             @endcan
 
-                            @can('receive-training-notifications')
+                            @can('training.notifications.receive')
                                 <hr>
 
                                 <h5>Moderator Notifications</h5>

--- a/tests/Feature/EndorsementPolicyDeleteTest.php
+++ b/tests/Feature/EndorsementPolicyDeleteTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Endorsement;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EndorsementPolicyDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function endorsement(string $type): Endorsement
+    {
+        // `revoked`/`expired` are real columns the factory doesn't set; force them
+        // off so the endorsement is eligible for deletion. `type` other than
+        // VISITING/EXAMINER is treated as a solo endorsement by the policy.
+        $endorsement = Endorsement::factory()->create(['type' => $type]);
+        $endorsement->forceFill(['revoked' => false, 'expired' => false])->save();
+
+        return $endorsement;
+    }
+
+    public function test_moderator_can_delete_solo_but_not_visiting_or_examiner(): void
+    {
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => null]);
+
+        $this->assertTrue($moderator->can('delete', $this->endorsement('FACILITY')));
+        $this->assertFalse($moderator->can('delete', $this->endorsement('VISITING')));
+        $this->assertFalse($moderator->can('delete', $this->endorsement('EXAMINER')));
+    }
+
+    public function test_director_can_delete_every_type(): void
+    {
+        $director = User::factory()->create();
+        $director->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
+
+        $this->assertTrue($director->can('delete', $this->endorsement('FACILITY')));
+        $this->assertTrue($director->can('delete', $this->endorsement('VISITING')));
+        $this->assertTrue($director->can('delete', $this->endorsement('EXAMINER')));
+    }
+}

--- a/tests/Feature/OneTimeLinkPermissionsTest.php
+++ b/tests/Feature/OneTimeLinkPermissionsTest.php
@@ -21,8 +21,8 @@ class OneTimeLinkPermissionsTest extends TestCase
         $moderator = User::factory()->create();
         $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
 
-        $this->assertTrue($buddy->hasPermission('use-report-one-time-link'));
-        $this->assertFalse($moderator->hasPermission('use-report-one-time-link'));
+        $this->assertTrue($buddy->hasPermission('training.reports.one-time-link'));
+        $this->assertFalse($moderator->hasPermission('training.reports.one-time-link'));
     }
 
     public function test_director_holds_update_training_in_their_area(): void
@@ -31,6 +31,6 @@ class OneTimeLinkPermissionsTest extends TestCase
         $director = User::factory()->create();
         $director->roleAssignments()->create(['role' => 'director', 'area_id' => $area->id]);
 
-        $this->assertTrue($director->hasPermission('update-training', $area));
+        $this->assertTrue($director->hasPermission('training.update', $area));
     }
 }

--- a/tests/Feature/TaskPermissionsTest.php
+++ b/tests/Feature/TaskPermissionsTest.php
@@ -64,7 +64,7 @@ class TaskPermissionsTest extends TestCase
         $moderator = User::factory()->create();
         $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
 
-        $this->assertFalse($mentor->hasPermission('suggested-task-recipient'));
-        $this->assertTrue($moderator->hasPermission('suggested-task-recipient'));
+        $this->assertFalse($mentor->hasPermission('tasks.suggested-recipient'));
+        $this->assertTrue($moderator->hasPermission('tasks.suggested-recipient'));
     }
 }

--- a/tests/Feature/TrainingsTest.php
+++ b/tests/Feature/TrainingsTest.php
@@ -86,8 +86,8 @@ class TrainingsTest extends TestCase
         $director = User::factory()->create();
         $director->roleAssignments()->create(['role' => 'director', 'area_id' => $area->id]);
 
-        $this->assertTrue($director->hasPermission('mentor-trainings', $area));
-        $this->assertTrue($director->hasPermission('view-mentor-dashboard'));
+        $this->assertTrue($director->hasPermission('training.mentor', $area));
+        $this->assertTrue($director->hasPermission('training.mentor-dashboard.view'));
     }
 
     #[Test]
@@ -219,7 +219,7 @@ class TrainingsTest extends TestCase
         $director->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
 
         $this->assertTrue($director->can('create', Training::class));
-        $this->assertTrue($director->hasPermission('view-training-activities', Area::factory()->create()));
+        $this->assertTrue($director->hasPermission('training.activities.view', Area::factory()->create()));
     }
 
     #[Test]

--- a/tests/Feature/UpdateWorkmailsTest.php
+++ b/tests/Feature/UpdateWorkmailsTest.php
@@ -44,7 +44,10 @@ class UpdateWorkmailsTest extends TestCase
 
     public function test_workmail_eligibility_follows_configured_permission(): void
     {
-        config(['roles.matrix.use-workmail' => ['mentor']]);
+        config([
+            'roles.permissions' => ['users.workmail.use'],
+            'roles.matrix' => ['mentor' => ['users.workmail.use']],
+        ]);
 
         $area = Area::factory()->create();
 

--- a/tests/Unit/DirectorRoleTest.php
+++ b/tests/Unit/DirectorRoleTest.php
@@ -19,8 +19,8 @@ class DirectorRoleTest extends TestCase
         $director = User::factory()->create();
         $director->roleAssignments()->create(['role' => 'director', 'area_id' => $area->id]);
 
-        $this->assertFalse($director->hasPermission('view-system-health'));
-        $this->assertFalse($director->hasPermission('manage-area', $area));
+        $this->assertFalse($director->hasPermission('system.health.view'));
+        $this->assertFalse($director->hasPermission('system.settings.manage', $area));
     }
 
     #[Test]
@@ -31,6 +31,6 @@ class DirectorRoleTest extends TestCase
         $director = User::factory()->create();
         $director->roleAssignments()->create(['role' => 'director', 'area_id' => $area->id]);
 
-        $this->assertFalse($director->hasPermission('manage-users', $otherArea));
+        $this->assertFalse($director->hasPermission('users.manage', $otherArea));
     }
 }

--- a/tests/Unit/PermissionMatrixTest.php
+++ b/tests/Unit/PermissionMatrixTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\PermissionMatrix;
+use Tests\TestCase;
+
+class PermissionMatrixTest extends TestCase
+{
+    private function matrix(): PermissionMatrix
+    {
+        config([
+            'roles.permissions' => [
+                'training.view',
+                'training.delete',
+                'training.reports.view',
+                'training.reports.one-time-link',
+                'system.health.view',
+                'system.settings.manage',
+            ],
+            'roles.matrix' => [
+                'all' => ['**'],
+                'training_top' => ['training.*'],
+                'training_deep' => ['training.**'],
+                'minus' => ['training.**', '!training.delete'],
+                'minus_namespace' => ['**', '!system.**'],
+            ],
+        ]);
+
+        return new PermissionMatrix;
+    }
+
+    public function test_double_star_matches_one_or_more_segments(): void
+    {
+        $perms = $this->matrix()->permissionsFor('training_deep');
+
+        $this->assertContains('training.view', $perms);
+        $this->assertContains('training.reports.view', $perms);
+        $this->assertNotContains('system.health.view', $perms);
+    }
+
+    public function test_single_star_matches_exactly_one_segment(): void
+    {
+        $perms = $this->matrix()->permissionsFor('training_top');
+
+        $this->assertContains('training.view', $perms);
+        $this->assertContains('training.delete', $perms);
+        $this->assertNotContains('training.reports.view', $perms);
+    }
+
+    public function test_negation_denies_a_matched_permission(): void
+    {
+        $perms = $this->matrix()->permissionsFor('minus');
+
+        $this->assertContains('training.view', $perms);
+        $this->assertNotContains('training.delete', $perms);
+    }
+
+    public function test_negation_with_namespace_wildcard(): void
+    {
+        $perms = $this->matrix()->permissionsFor('minus_namespace');
+
+        $this->assertContains('training.view', $perms);
+        $this->assertNotContains('system.health.view', $perms);
+        $this->assertNotContains('system.settings.manage', $perms);
+    }
+
+    public function test_roles_for_returns_every_role_that_grants_permission(): void
+    {
+        $roles = $this->matrix()->rolesFor('training.view');
+
+        sort($roles);
+        $this->assertSame(['all', 'minus', 'minus_namespace', 'training_deep', 'training_top'], $roles);
+    }
+
+    public function test_roles_for_excludes_role_when_negated(): void
+    {
+        $this->assertNotContains('minus', $this->matrix()->rolesFor('training.delete'));
+        $this->assertNotContains('minus_namespace', $this->matrix()->rolesFor('system.health.view'));
+    }
+
+    public function test_unknown_permission_yields_no_roles(): void
+    {
+        $this->assertSame([], $this->matrix()->rolesFor('does.not.exist'));
+    }
+
+    public function test_all_returns_the_catalogue(): void
+    {
+        $this->assertContains('training.view', $this->matrix()->all());
+        $this->assertContains('system.settings.manage', $this->matrix()->all());
+    }
+
+    public function test_container_resolves_a_shared_instance(): void
+    {
+        $this->assertSame(
+            app(PermissionMatrix::class),
+            app(PermissionMatrix::class)
+        );
+    }
+}

--- a/tests/Unit/RolePermissionTest.php
+++ b/tests/Unit/RolePermissionTest.php
@@ -16,19 +16,25 @@ class RolePermissionTest extends TestCase
         parent::setUp();
 
         config([
-            'roles.matrix' => [
-                'view-training' => ['admin', 'moderator', 'mentor', 'buddy'],
-                'create-training' => ['admin', 'moderator', 'mentor'],
-                'update-training' => ['admin', 'moderator'],
-                'delete-training' => ['admin'],
-                'mentor-specific' => ['mentor'],
-                'manage-area' => ['admin'],
-            ],
             'roles.roles' => [
                 'admin' => ['name' => 'Admin', 'description' => 'A', 'scope' => 'global'],
                 'moderator' => ['name' => 'Mod', 'description' => 'M', 'scope' => 'both'],
                 'mentor' => ['name' => 'Mentor', 'description' => 'M', 'scope' => 'area'],
                 'buddy' => ['name' => 'Buddy', 'description' => 'B', 'scope' => 'area'],
+            ],
+            'roles.permissions' => [
+                'training.view',
+                'training.create',
+                'training.update',
+                'training.delete',
+                'training.mentor-specific',
+                'test-permission',
+            ],
+            'roles.matrix' => [
+                'admin' => ['**'],
+                'moderator' => ['training.view', 'training.create', 'training.update'],
+                'mentor' => ['training.view', 'training.create', 'training.mentor-specific'],
+                'buddy' => ['training.view'],
             ],
         ]);
     }
@@ -73,13 +79,13 @@ class RolePermissionTest extends TestCase
         ]);
 
         // Moderator can update training
-        $this->assertTrue($user->hasPermission('update-training', $area));
+        $this->assertTrue($user->hasPermission('training.update', $area));
 
         // Moderator cannot delete training
-        $this->assertFalse($user->hasPermission('delete-training', $area));
+        $this->assertFalse($user->hasPermission('training.delete', $area));
 
         // Moderator cannot do mentor-specific actions
-        $this->assertFalse($user->hasPermission('mentor-specific', $area));
+        $this->assertFalse($user->hasPermission('training.mentor-specific', $area));
     }
 
     public function test_user_has_multiple_roles()
@@ -120,7 +126,7 @@ class RolePermissionTest extends TestCase
 
     public function test_all_with_permission_scoped_to_area_includes_global_and_area_holders()
     {
-        config(['roles.matrix.test-permission' => ['admin', 'moderator']]);
+        config(['roles.matrix.moderator' => ['training.view', 'training.create', 'training.update', 'test-permission']]);
 
         $area = Area::factory()->create();
         $otherArea = Area::factory()->create();
@@ -147,7 +153,7 @@ class RolePermissionTest extends TestCase
 
     public function test_all_with_permission_without_area_includes_holders_anywhere()
     {
-        config(['roles.matrix.test-permission' => ['admin', 'moderator']]);
+        config(['roles.matrix.moderator' => ['training.view', 'training.create', 'training.update', 'test-permission']]);
 
         $area = Area::factory()->create();
 
@@ -169,7 +175,7 @@ class RolePermissionTest extends TestCase
 
     public function test_all_with_permission_matches_has_permission_semantics()
     {
-        config(['roles.matrix.test-permission' => ['moderator']]);
+        config(['roles.matrix.moderator' => ['test-permission']]);
 
         $area = Area::factory()->create();
         $otherArea = Area::factory()->create();
@@ -195,7 +201,7 @@ class RolePermissionTest extends TestCase
 
     public function test_all_with_permission_returns_each_user_once_despite_multiple_assignments()
     {
-        config(['roles.matrix.test-permission' => ['admin', 'moderator']]);
+        config(['roles.matrix.moderator' => ['training.view', 'training.create', 'training.update', 'test-permission']]);
 
         $area = Area::factory()->create();
 

--- a/tests/Unit/RolesConfigTest.php
+++ b/tests/Unit/RolesConfigTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use App\Services\PermissionMatrix;
 use Tests\TestCase;
 
 class RolesConfigTest extends TestCase
@@ -10,39 +11,39 @@ class RolesConfigTest extends TestCase
     {
         $definedRoles = array_keys(config('roles.roles'));
 
-        foreach (config('roles.matrix') as $permission => $roles) {
-            foreach ($roles as $role) {
-                $this->assertContains($role, $definedRoles, "Permission {$permission} references undefined role {$role}");
-            }
+        foreach (array_keys(config('roles.matrix')) as $role) {
+            $this->assertContains($role, $definedRoles, "Matrix references undefined role {$role}");
         }
     }
 
-    public function test_permissions_for_migrated_hasrole_checks_exist(): void
+    public function test_every_role_grants_at_least_one_permission(): void
     {
-        $matrix = config('roles.matrix');
+        $matrix = new PermissionMatrix;
 
-        $expected = [
-            'manage-tasks', 'suggested-task-recipient',
-            'manage-files', 'upload-files',
-            'manage-bookings', 'use-sweatbook', 'manage-sweatbook',
-            'manage-notification-templates',
-            'view-training-reports', 'create-training-reports', 'update-training-reports', 'delete-training-reports',
-            'use-report-one-time-link', 'view-hidden-training-attachments',
-            'manage-examinations', 'create-examinations',
-            'view-mentor-dashboard', 'mentor-trainings',
-            'receive-training-notifications',
-            'manage-settings', 'manage-votes', 'view-activity-log',
-        ];
-
-        foreach ($expected as $permission) {
-            $this->assertArrayHasKey($permission, $matrix);
+        foreach (array_keys(config('roles.matrix')) as $role) {
+            $this->assertNotEmpty($matrix->permissionsFor($role), "Role '{$role}' grants no permissions.");
         }
     }
 
-    public function test_every_matrix_permission_has_at_least_one_role(): void
+    public function test_permission_catalogue_is_unique_and_non_empty(): void
     {
-        foreach (config('roles.matrix') as $permission => $roles) {
-            $this->assertNotEmpty($roles, "Permission '{$permission}' has no roles assigned.");
+        $permissions = config('roles.permissions');
+
+        $this->assertNotEmpty($permissions);
+        $this->assertSame(array_unique($permissions), $permissions, 'The permission catalogue contains duplicates.');
+    }
+
+    public function test_all_returns_the_catalogue(): void
+    {
+        $this->assertSame(array_values(config('roles.permissions')), (new PermissionMatrix)->all());
+    }
+
+    public function test_no_orphan_permissions(): void
+    {
+        $matrix = new PermissionMatrix;
+
+        foreach ($matrix->all() as $permission) {
+            $this->assertNotEmpty($matrix->rolesFor($permission), "Permission '{$permission}' is granted to no role.");
         }
     }
 }

--- a/tests/Unit/UserUnitTest.php
+++ b/tests/Unit/UserUnitTest.php
@@ -121,7 +121,7 @@ class UserUnitTest extends TestCase
     {
         $this->user->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
 
-        $scope = $this->user->accessibleAreasForPermission('view-training-statistics');
+        $scope = $this->user->accessibleAreasForPermission('training.statistics.view');
 
         $this->assertTrue($scope->isGlobal);
         $this->assertTrue($scope->hasAccess());
@@ -133,7 +133,7 @@ class UserUnitTest extends TestCase
         $area = Area::factory()->create();
         $this->user->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
 
-        $scope = $this->user->accessibleAreasForPermission('view-training-statistics');
+        $scope = $this->user->accessibleAreasForPermission('training.statistics.view');
 
         $this->assertFalse($scope->isGlobal);
         $this->assertTrue($scope->hasAccess());
@@ -149,7 +149,7 @@ class UserUnitTest extends TestCase
         $this->user->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area1->id]);
         $this->user->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area2->id]);
 
-        $scope = $this->user->accessibleAreasForPermission('view-training-statistics');
+        $scope = $this->user->accessibleAreasForPermission('training.statistics.view');
 
         $this->assertFalse($scope->isGlobal);
         $this->assertCount(2, $scope->areas);


### PR DESCRIPTION
Documents the dot-namespaced permissions and inverted matrix. Includes a PermissionMatrix wildcard resolver to enable the global use of @can and @canany.

Fixes #1507.

## Summary by Sourcery

Introduce a dot-namespaced permission catalogue with an inverted, pattern-based role matrix and update authorization logic, policies, views, and documentation to use the new permission model globally.

New Features:
- Add a central PermissionMatrix service to resolve roles and permissions from wildcard patterns and a concrete permission catalogue.
- Define a dot-namespaced permission catalogue in configuration and register gates from this authoritative list instead of inferring from the matrix.
- Introduce a RatingPolicy using the new training.ratings.manage permission.

Enhancements:
- Invert the roles-permission matrix to map roles to wildcard-based permission patterns, including support for negation and hierarchical wildcards.
- Refactor all policies, controllers, views, notifications, and console commands to use the new dot-namespaced permission identifiers.
- Tighten role semantics so admin/director capabilities derive from matrix patterns with explicit opt-outs rather than implicit full access.

Documentation:
- Revise permissions documentation to describe the dot-namespaced permission catalogue, pattern-based matrix with wildcards/negation, and updated role semantics for admin and director.

Tests:
- Update and expand unit and feature tests to cover the new matrix shape, permission catalogue invariants, PermissionMatrix wildcard resolution, and revised role/permission assignments, including endorsement deletion behaviour.