### PR TITLE
fix(reports): track and sort by activity date (e.g. publish time)

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -175,7 +175,7 @@ class ReportController extends Controller
                 ->when($filterArea, function (Builder $query, $filterArea) {
                     $query->whereHas('training', fn (Builder $q) => $q->where('area_id', $filterArea));
                 })
-                ->where($filterArea ? 'created_at' : 'updated_at', '>=', $filterArea ? $activities->last()->created_at : $activities->last()->updated_at)
+                ->where('published_at', '>=', $activities->last()->created_at)
                 ->get();
 
             $examinationReports = TrainingExamination::where('created_at', '>=', $activities->last()->created_at)
@@ -187,7 +187,7 @@ class ReportController extends Controller
             $entries = $entries->concat($trainingReports)->concat($examinationReports);
         }
 
-        $entries = $entries->concat($activities)->sortByDesc('created_at');
+        $entries = $entries->concat($activities)->sortByDesc('activity_date');
         $statuses = TrainingController::$statuses;
 
         $areas = Area::all();

--- a/app/Http/Controllers/TrainingReportController.php
+++ b/app/Http/Controllers/TrainingReportController.php
@@ -139,7 +139,6 @@ class TrainingReportController extends Controller
     public function update(Request $request, TrainingReport $report)
     {
         $this->authorize('update', $report);
-        $oldDraftStatus = $report->fresh()->draft;
 
         $data = $this->validateRequest();
 
@@ -151,8 +150,8 @@ class TrainingReportController extends Controller
 
         $report->update($data);
 
-        // Notify student of new training request if it's not a draft anymore
-        if ($oldDraftStatus == true && $report->draft == false && $report->training->user->setting_notify_newreport) {
+        // Notify student when the report is first published (published_at just stamped)
+        if ($report->wasChanged('published_at') && $report->training->user->setting_notify_newreport) {
             $report->training->user->notify(new TrainingReportNotification($report->training, $report));
         }
 

--- a/app/Models/TrainingActivity.php
+++ b/app/Models/TrainingActivity.php
@@ -29,4 +29,12 @@ class TrainingActivity extends Model
     {
         return $this->belongsTo(Endorsement::class, 'new_data');
     }
+
+    /**
+     * The date this entry should be sorted and displayed by in activity feeds.
+     */
+    public function getActivityDateAttribute()
+    {
+        return $this->created_at;
+    }
 }

--- a/app/Models/TrainingObject.php
+++ b/app/Models/TrainingObject.php
@@ -15,4 +15,12 @@ class TrainingObject extends Model
     {
         return $this->belongsTo(Training::class);
     }
+
+    /**
+     * The date this entry should be sorted and displayed by in activity feeds.
+     */
+    public function getActivityDateAttribute()
+    {
+        return $this->created_at;
+    }
 }

--- a/app/Models/TrainingReport.php
+++ b/app/Models/TrainingReport.php
@@ -13,7 +13,31 @@ class TrainingReport extends TrainingObject
     protected $casts = [
         'draft' => 'boolean',
         'report_date' => 'datetime',
+        'published_at' => 'datetime',
     ];
+
+    /**
+     * Stamp the publishing date the first time a report becomes non-draft.
+     *
+     * Keeping this on the model makes it the single source of truth, so the
+     * date is set correctly regardless of which code path publishes.
+     */
+    protected static function booted(): void
+    {
+        static::saving(function (self $report): void {
+            if (! $report->draft && $report->published_at === null) {
+                $report->published_at = now();
+            }
+        });
+    }
+
+    /**
+     * The date this report should be sorted and displayed by in activity feeds.
+     */
+    public function getActivityDateAttribute()
+    {
+        return $this->published_at ?? $this->created_at;
+    }
 
     public function path()
     {

--- a/database/factories/TrainingReportFactory.php
+++ b/database/factories/TrainingReportFactory.php
@@ -24,6 +24,7 @@ class TrainingReportFactory extends Factory
     public function definition()
     {
         $date = $this->faker->dateTimeBetween($startDate = '-1 years', $endDate = 'now');
+        $isDraft = (bool) $this->faker->numberBetween(0, 1);
 
         return [
             'written_by_id' => User::factory(),
@@ -31,9 +32,10 @@ class TrainingReportFactory extends Factory
             'content' => $this->faker->paragraph(),
             'contentimprove' => $this->faker->paragraph(),
             'position' => Position::inRandomOrder()->first()->callsign,
-            'draft' => $this->faker->numberBetween(0, 1),
+            'draft' => $isDraft,
             'created_at' => $date,
             'updated_at' => $date,
+            'published_at' => $isDraft ? null : $date,
         ];
     }
 }

--- a/database/migrations/2026_06_15_233952_add_published_at_to_training_reports_table.php
+++ b/database/migrations/2026_06_15_233952_add_published_at_to_training_reports_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('training_reports', function (Blueprint $table) {
+            $table->timestamp('published_at')->nullable()->after('draft')->index();
+        });
+
+        // Backfill the publishing date for already-published reports. updated_at is
+        // the best available proxy: it is the value the activities view has been
+        // displaying as the "published" timestamp prior to this column existing.
+        DB::table('training_reports')
+            ->where('draft', false)
+            ->update(['published_at' => DB::raw('updated_at')]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('training_reports', function (Blueprint $table) {
+            $table->dropColumn('published_at');
+        });
+    }
+};

--- a/resources/views/reports/activities.blade.php
+++ b/resources/views/reports/activities.blade.php
@@ -174,15 +174,9 @@
 
                                     </td>
                                     <td>
-                                        @if(is_a($activity, 'App\Models\TrainingReport'))
-                                            <span data-bs-toggle="tooltip" data-bs-placement="top" title="{{ $activity->updated_at->toEuropeanDateTime() }}">
-                                                {{ $activity->updated_at->diffForHumans() }}
-                                            </span>
-                                        @else
-                                            <span data-bs-toggle="tooltip" data-bs-placement="top" title="{{ $activity->created_at->toEuropeanDateTime() }}">
-                                                {{ $activity->created_at->diffForHumans() }}
-                                            </span>
-                                        @endif
+                                        <span data-bs-toggle="tooltip" data-bs-placement="top" title="{{ $activity->activity_date->toEuropeanDateTime() }}">
+                                            {{ $activity->activity_date->diffForHumans() }}
+                                        </span>
                                     </td>
                                 </tr>
                             @endforeach

--- a/tests/Feature/ReportControllerTest.php
+++ b/tests/Feature/ReportControllerTest.php
@@ -5,6 +5,9 @@ namespace Tests\Feature;
 use App\Models\Area;
 use App\Models\Feedback;
 use App\Models\Position;
+use App\Models\Training;
+use App\Models\TrainingActivity;
+use App\Models\TrainingReport;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -185,6 +188,39 @@ class ReportControllerTest extends TestCase
         $response->assertViewIs('partials.area-picker');
         $response->assertViewHas('route', 'reports.activities.area');
         $response->assertViewHas('title', 'Training Activities');
+    }
+
+    #[Test]
+    public function activities_report_orders_training_reports_by_publishing_date(): void
+    {
+        $training = Training::factory()->create([
+            'user_id' => User::factory()->create()->id,
+        ]);
+
+        // A single activity defines the lower bound of the displayed time window.
+        $activity = new TrainingActivity;
+        $activity->training_id = $training->id;
+        $activity->triggered_by_id = $this->adminUser->id;
+        $activity->type = 'COMMENT';
+        $activity->comment = 'An activity comment';
+        $activity->created_at = now()->subDays(5);
+        $activity->updated_at = now()->subDays(5);
+        $activity->save();
+
+        // Created long ago but only published recently. Ordered by created_at it
+        // would sort last (and fall outside the window); by published_at it sorts first.
+        $report = TrainingReport::factory()->create([
+            'training_id' => $training->id,
+            'draft' => false,
+            'created_at' => now()->subDays(30),
+            'published_at' => now()->subDay(),
+        ]);
+
+        $response = $this->actingAs($this->adminUser)->get(route('reports.activities'));
+
+        $response->assertOk();
+        $entries = $response->viewData('entries');
+        $this->assertTrue($entries->first()->is($report));
     }
 
     #[Test]

--- a/tests/Feature/TrainingReportsTest.php
+++ b/tests/Feature/TrainingReportsTest.php
@@ -7,9 +7,11 @@ use App\Models\OneTimeLink;
 use App\Models\Training;
 use App\Models\TrainingReport;
 use App\Models\User;
+use App\Notifications\TrainingReportNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Notification;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -219,6 +221,144 @@ class TrainingReportsTest extends TestCase
             ->assertRedirect();
 
         $this->assertDatabaseHas('training_reports', ['content' => $content]);
+    }
+
+    #[Test]
+    public function publishing_a_draft_report_stamps_the_published_at_date()
+    {
+        $training = Training::factory()->create([
+            'user_id' => User::factory()->create()->id,
+        ]);
+        $report = TrainingReport::factory()->create([
+            'training_id' => $training->id,
+            'draft' => true,
+            'published_at' => null,
+        ]);
+        $mentor = User::factory()->create();
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $training->area->id]);
+        $training->mentors()->attach($mentor, ['expire_at' => now()->addYear()]);
+
+        $this->assertNull($report->published_at);
+
+        $this->actingAs($mentor)
+            ->patch(route('training.report.update', ['report' => $report->id]), [
+                'report_date' => today()->format('d/m/Y'),
+                'content' => $report->content,
+                // 'draft' omitted, so the report is published
+            ])
+            ->assertRedirect();
+
+        $this->assertNotNull($report->fresh()->published_at);
+    }
+
+    #[Test]
+    public function publishing_a_draft_report_notifies_the_student_once()
+    {
+        Notification::fake();
+
+        $student = User::factory()->create(['setting_notify_newreport' => true]);
+        $training = Training::factory()->create(['user_id' => $student->id]);
+        $report = TrainingReport::factory()->create([
+            'training_id' => $training->id,
+            'draft' => true,
+            'published_at' => null,
+        ]);
+        $mentor = User::factory()->create();
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $training->area->id]);
+        $training->mentors()->attach($mentor, ['expire_at' => now()->addYear()]);
+
+        // First publish notifies the student.
+        $this->actingAs($mentor)
+            ->patch(route('training.report.update', ['report' => $report->id]), [
+                'report_date' => today()->format('d/m/Y'),
+                'content' => $report->content,
+            ])
+            ->assertRedirect();
+
+        // A later edit of the already-published report must not re-notify.
+        $this->actingAs($mentor)
+            ->patch(route('training.report.update', ['report' => $report->id]), [
+                'report_date' => today()->format('d/m/Y'),
+                'content' => $this->faker->paragraph(),
+            ])
+            ->assertRedirect();
+
+        Notification::assertSentToTimes($student, TrainingReportNotification::class, 1);
+    }
+
+    #[Test]
+    public function published_at_is_not_overwritten_on_later_edits()
+    {
+        $publishedAt = now()->subMonth()->startOfSecond();
+        $training = Training::factory()->create([
+            'user_id' => User::factory()->create()->id,
+        ]);
+        $report = TrainingReport::factory()->create([
+            'training_id' => $training->id,
+            'draft' => false,
+            'published_at' => $publishedAt,
+        ]);
+        $mentor = User::factory()->create();
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $training->area->id]);
+        $training->mentors()->attach($mentor, ['expire_at' => now()->addYear()]);
+
+        $this->actingAs($mentor)
+            ->patch(route('training.report.update', ['report' => $report->id]), [
+                'report_date' => today()->format('d/m/Y'),
+                'content' => $this->faker->paragraph(),
+            ])
+            ->assertRedirect();
+
+        $this->assertTrue($report->fresh()->published_at->equalTo($publishedAt));
+    }
+
+    #[Test]
+    public function a_report_created_as_published_gets_a_published_at_date()
+    {
+        $training = Training::factory()->create([
+            'user_id' => User::factory()->create()->id,
+        ]);
+
+        $report = TrainingReport::factory()->create([
+            'training_id' => $training->id,
+            'draft' => false,
+            'published_at' => null,
+        ]);
+
+        $this->assertNotNull($report->published_at);
+    }
+
+    #[Test]
+    public function a_draft_report_has_no_published_at_date()
+    {
+        $training = Training::factory()->create([
+            'user_id' => User::factory()->create()->id,
+        ]);
+
+        $report = TrainingReport::factory()->create([
+            'training_id' => $training->id,
+            'draft' => true,
+            'published_at' => null,
+        ]);
+
+        $this->assertNull($report->published_at);
+    }
+
+    #[Test]
+    public function activity_date_uses_published_at_when_present()
+    {
+        $training = Training::factory()->create([
+            'user_id' => User::factory()->create()->id,
+        ]);
+
+        $report = TrainingReport::factory()->create([
+            'training_id' => $training->id,
+            'draft' => false,
+            'created_at' => now()->subYear(),
+            'published_at' => now()->subDay(),
+        ]);
+
+        $this->assertTrue($report->activity_date->equalTo($report->published_at));
     }
 
     #[Test]


### PR DESCRIPTION
Fixes #1318. Introduces published_at to track when a training report changed from draft to non-draft. Once published, the published_at time cannot be changed.

## Summary by Sourcery

Track a dedicated publish timestamp for training reports and use it as the canonical activity date in activity feeds and reports.

New Features:
- Add a published_at timestamp to training reports and expose an activity_date attribute for activity feed ordering across training-related models.

Bug Fixes:
- Ensure training report notifications are only sent once when a draft report is first published and that subsequent edits do not change the publish timestamp or re-notify the student.
- Order the activities report entries by effective activity date so recently published reports appear correctly within the activity window regardless of their original creation time.

Enhancements:
- Backfill published_at for existing non-draft training reports based on updated_at and adjust the training report factory to generate consistent published_at values for seeded data.
- Simplify the activities view to display a unified activity date for all entry types.

Tests:
- Add feature tests covering publish timestamp stamping and immutability, single-shot student notifications on first publish, activity date semantics, and activities report ordering by publish date.