### PR TITLE
feat(reports): add sessions-per-rating chart to training statistics view

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -117,6 +117,7 @@ class ReportController extends Controller
         $cardStats = $this->getCardStats($filterArea, $startDate, $endDate);
         $totalRequests = $this->getDailyRequestsStats($filterArea, $startDate, $endDate);
         $queues = $this->getQueueStats($filterArea);
+        $sessionsPerRating = $this->getSessionsPerRatingStats($filterArea, $startDate, $endDate);
 
         return view('reports.trainings', [
             'filterName' => $filterName,
@@ -129,6 +130,7 @@ class ReportController extends Controller
             'passedExamRequests' => $passedExamRequests,
             'failedExamRequests' => $failedExamRequests,
             'queues' => $queues,
+            'sessionsPerRating' => $sessionsPerRating,
             'labels' => $labels,
             'startDate' => $startDate,
             'endDate' => $endDate,
@@ -546,5 +548,143 @@ class ReportController extends Controller
             ->keyBy('name')
             ->map(fn ($row) => [$row->avg_low, $row->avg_high])
             ->all();
+    }
+
+    /**
+     * Return per-rating training session statistics.
+     *
+     * A session is a single non-draft training report. Volume is the count of
+     * non-draft reports within the window/area, attributed to each rating linked
+     * to the report's training. Average/median are computed over the per-training
+     * session counts of ended (completed/closed) trainings within the window/area
+     * that recorded at least one session; trainings with zero sessions (e.g. queue
+     * drop-outs) are excluded. When a rating has no qualifying sample, average and
+     * median are null so the chart omits the marker rather than plotting a false 0.
+     *
+     * @param  false|int  $areaFilter  areaId to filter by
+     * @param  ?Carbon  $startDate  window start; defaults to 6 months ago
+     * @param  ?Carbon  $endDate  window end; defaults to now
+     * @return array<string, array{volume: int, average: ?float, median: ?float}>
+     */
+    protected function getSessionsPerRatingStats(false|int $areaFilter, ?Carbon $startDate = null, ?Carbon $endDate = null): array
+    {
+        $queryStart = $startDate ?? now()->subMonths(6)->startOfMonth();
+        $queryEnd = $endDate ?? now()->endOfDay();
+
+        // Volume: count of non-draft reports per rating, scoped by activity date.
+        $activityDate = Sql::coalesce('training_reports.published_at', 'training_reports.created_at');
+
+        $volumeQuery = DB::table('training_reports')
+            ->select('ratings.id as rating_id', 'ratings.name as rating_name', DB::raw('count(training_reports.id) as volume'))
+            ->join('trainings', 'trainings.id', '=', 'training_reports.training_id')
+            ->join('rating_training', 'rating_training.training_id', '=', 'trainings.id')
+            ->join('ratings', 'ratings.id', '=', 'rating_training.rating_id')
+            ->where('training_reports.draft', false)
+            ->whereRaw("$activityDate >= ?", [$queryStart])
+            ->whereRaw("$activityDate <= ?", [$queryEnd])
+            ->groupBy('ratings.id', 'ratings.name');
+
+        if ($areaFilter) {
+            $volumeQuery->where('trainings.area_id', $areaFilter);
+        }
+
+        // Accumulate per-rating data keyed by rating id, so the final order can
+        // follow the ratings table (training progression) like the sibling charts.
+        $ratings = [];
+        foreach ($volumeQuery->get() as $row) {
+            $ratings[$row->rating_id]['name'] = $row->rating_name;
+            $ratings[$row->rating_id]['volume'] = (int) $row->volume;
+        }
+
+        // Average/median: per-training non-draft report counts over ended trainings.
+        $sampleQuery = DB::table('trainings')
+            ->select(
+                'ratings.id as rating_id',
+                'ratings.name as rating_name',
+                DB::raw('count(training_reports.id) as report_count')
+            )
+            ->join('rating_training', 'rating_training.training_id', '=', 'trainings.id')
+            ->join('ratings', 'ratings.id', '=', 'rating_training.rating_id')
+            // Inner join: trainings with zero non-draft sessions are excluded from
+            // the sample. A closed training that never recorded a session is a queue
+            // drop-out, not a training that "took zero sessions", so counting it
+            // would wrongly drag the average/median toward zero.
+            ->join('training_reports', function ($join) {
+                $join->on('training_reports.training_id', '=', 'trainings.id')
+                    ->where('training_reports.draft', '=', false);
+            })
+            ->whereIn('trainings.status', [-1, -2])
+            ->whereBetween('trainings.closed_at', [$queryStart, $queryEnd])
+            ->groupBy('trainings.id', 'ratings.id', 'ratings.name');
+
+        if ($areaFilter) {
+            $sampleQuery->where('trainings.area_id', $areaFilter);
+        }
+
+        foreach ($sampleQuery->get() as $row) {
+            $ratings[$row->rating_id]['name'] = $row->rating_name;
+            $ratings[$row->rating_id]['sample'][] = (int) $row->report_count;
+        }
+
+        // Order by rating id (S1, S2, S3, …) to match the sibling charts' x-axis.
+        ksort($ratings);
+
+        $payload = [];
+        foreach ($ratings as $rating) {
+            $volume = $rating['volume'] ?? 0;
+            $sample = $rating['sample'] ?? [];
+
+            // Drop ratings with no volume and no ended-training sample.
+            if ($volume === 0 && count($sample) === 0) {
+                continue;
+            }
+
+            $payload[$rating['name']] = [
+                'volume' => $volume,
+                'average' => $this->mean($sample),
+                'median' => $this->median($sample),
+            ];
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Compute the mean of a sample, rounded to one decimal. Returns null for an
+     * empty sample so callers can omit the data point rather than plot a false 0.
+     *
+     * @param  array<int>  $sample
+     */
+    private function mean(array $sample): ?float
+    {
+        if (count($sample) === 0) {
+            return null;
+        }
+
+        return round(array_sum($sample) / count($sample), 1);
+    }
+
+    /**
+     * Compute the median of a sample. Even-sized samples return the mean of the
+     * two middle values. Returns null for an empty sample so callers can omit the
+     * data point rather than plot a false 0.
+     *
+     * @param  array<int>  $sample
+     */
+    private function median(array $sample): ?float
+    {
+        $count = count($sample);
+        if ($count === 0) {
+            return null;
+        }
+
+        sort($sample);
+        $middle = intdiv($count, 2);
+
+        if ($count % 2 === 0) {
+            return round(($sample[$middle - 1] + $sample[$middle]) / 2, 1);
+        }
+
+        return round((float) $sample[$middle], 1);
     }
 }

--- a/app/Services/Sql/Sql.php
+++ b/app/Services/Sql/Sql.php
@@ -44,4 +44,13 @@ class Sql
 
         return SQL::as($sql, $alias);
     }
+
+    /**
+     * Build an ANSI-standard COALESCE expression over the given columns,
+     * returning the first non-null value. Portable across sqlite/MySQL/Postgres.
+     */
+    public static function coalesce(string ...$columns): string
+    {
+        return 'COALESCE(' . implode(', ', $columns) . ')';
+    }
 }

--- a/resources/views/reports/trainings.blade.php
+++ b/resources/views/reports/trainings.blade.php
@@ -206,6 +206,22 @@
         </div>
     </div>
 
+    <div class="col-xl-6 col-md-12 mb-12">
+        <div class="card shadow mb-4">
+            <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
+                <h6 class="m-0 fw-bold text-white">
+                    Training sessions per rating
+                </h6>
+            </div>
+            <div class="card-body">
+                <canvas id="sessionsPerRating"></canvas>
+                <p class="text-muted small mb-0 mt-2">
+                    Bars count sessions delivered in the period; the average and median count sessions per completed or closed training.
+                </p>
+            </div>
+        </div>
+    </div>
+
     <div class="col-xl-4 col-md-12 mb-12">
         <div class="card shadow mb-4">
             <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
@@ -606,6 +622,111 @@
                         stacked: true,
                         ticks: {
                             stepSize: 1
+                        }
+                    }
+                }
+            }
+        });
+    });
+</script>
+
+<script>
+
+    document.addEventListener("DOMContentLoaded", function () {
+
+        // Training sessions per rating combo chart
+        var sessionsPerRatingElement = document.getElementById("sessionsPerRating");
+        if (!sessionsPerRatingElement) return;
+
+        var sessionsPerRatingData = {!! json_encode($sessionsPerRating) !!}
+
+        var ratingLabels = Object.keys(sessionsPerRatingData);
+        var volumes = [];
+        var averages = [];
+        var medians = [];
+        for (const rating of ratingLabels) {
+            volumes.push(sessionsPerRatingData[rating].volume);
+            averages.push(sessionsPerRatingData[rating].average);
+            medians.push(sessionsPerRatingData[rating].median);
+        }
+
+        var comboChartData = {
+            labels: ratingLabels,
+            datasets: [
+                {
+                    type: 'bar',
+                    label: 'Sessions delivered',
+                    data: volumes,
+                    backgroundColor: 'rgba(54, 162, 235, 0.6)',
+                    borderColor: 'rgb(54, 162, 235)',
+                    yAxisID: 'y',
+                    order: 2
+                },
+                {
+                    type: 'line',
+                    label: 'Avg sessions / training',
+                    data: averages,
+                    backgroundColor: 'rgb(255, 159, 64)',
+                    borderColor: 'rgb(255, 159, 64)',
+                    yAxisID: 'y1',
+                    showLine: false,
+                    pointStyle: 'circle',
+                    pointRadius: 5,
+                    order: 1
+                },
+                {
+                    type: 'line',
+                    label: 'Median sessions / training',
+                    data: medians,
+                    backgroundColor: 'rgb(46, 184, 92)',
+                    borderColor: 'rgb(46, 184, 92)',
+                    yAxisID: 'y1',
+                    showLine: false,
+                    pointStyle: 'triangle',
+                    pointRadius: 6,
+                    order: 0
+                }
+            ]
+        };
+
+        var mix = sessionsPerRatingElement.getContext('2d');
+        var sessionsPerRatingChart = new Chart(mix, {
+            data: comboChartData,
+            options: {
+                responsive: true,
+                interaction: {
+                    mode: 'index',
+                    intersect: false
+                },
+                scales: {
+                    x: {
+                        title: {
+                            display: true,
+                            text: 'Note: One training may have multiple ratings shown individually in this graph'
+                        }
+                    },
+                    y: {
+                        type: 'linear',
+                        position: 'left',
+                        beginAtZero: true,
+                        title: {
+                            display: true,
+                            text: 'Sessions delivered'
+                        },
+                        ticks: {
+                            stepSize: 1
+                        }
+                    },
+                    y1: {
+                        type: 'linear',
+                        position: 'right',
+                        beginAtZero: true,
+                        title: {
+                            display: true,
+                            text: 'Sessions per training'
+                        },
+                        grid: {
+                            drawOnChartArea: false
                         }
                     }
                 }

--- a/tests/Feature/Statistics/TrainingStatisticsTest.php
+++ b/tests/Feature/Statistics/TrainingStatisticsTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Feature\Statistics;
 
 use App\Models\Area;
+use App\Models\Position;
 use App\Models\Rating;
 use App\Models\Training;
 use App\Models\TrainingExamination;
+use App\Models\TrainingReport;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -193,6 +195,307 @@ class TrainingStatisticsTest extends TestCase
         });
         $response->assertViewHas('failedExamRequests', function ($failedExamRequests) {
             return array_sum(collect($failedExamRequests)->flatten()->all()) === 0;
+        });
+    }
+
+    /**
+     * Create a training report (session) for the given training.
+     */
+    private function createReport(Training $training, bool $draft, Carbon $activityDate): TrainingReport
+    {
+        return TrainingReport::factory()->create([
+            'training_id' => $training->id,
+            'position' => Position::factory()->create()->callsign,
+            'draft' => $draft,
+            'created_at' => $activityDate,
+            'published_at' => $draft ? null : $activityDate,
+            'report_date' => $activityDate,
+        ]);
+    }
+
+    /**
+     * Create a training with the given status, area and ratings.
+     *
+     * @param  array<int>  $ratingIds
+     */
+    private function createTraining(int $status, array $ratingIds, ?Carbon $closedAt = null): Training
+    {
+        $training = Training::factory()->create([
+            'user_id' => $this->admin->id,
+            'area_id' => $this->area->id,
+            'type' => 1,
+            'status' => $status,
+            'closed_at' => $closedAt,
+        ]);
+        $training->ratings()->attach($ratingIds);
+
+        return $training;
+    }
+
+    #[Test]
+    public function it_counts_only_non_draft_reports_in_session_volume()
+    {
+        $rating = Rating::factory()->create(['name' => 'S2', 'vatsim_rating' => 3]);
+        $training = $this->createTraining(0, [$rating->id]);
+
+        $this->createReport($training, draft: false, activityDate: now()->subMonth());
+        $this->createReport($training, draft: false, activityDate: now()->subMonth());
+        $this->createReport($training, draft: true, activityDate: now()->subMonth());
+
+        $response = $this->actingAs($this->admin)->get(route('reports.trainings'));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('sessionsPerRating', function ($sessionsPerRating) {
+            return $sessionsPerRating['S2']['volume'] === 2;
+        });
+    }
+
+    #[Test]
+    public function it_keeps_session_volume_within_the_date_window()
+    {
+        $rating = Rating::factory()->create(['name' => 'S2', 'vatsim_rating' => 3]);
+        $training = $this->createTraining(0, [$rating->id]);
+
+        $start = now()->subMonths(2)->startOfMonth()->addDays(10);
+        $end = $start->copy()->addDays(2)->endOfDay();
+
+        $this->createReport($training, draft: false, activityDate: $start->copy()->addDay());
+        $this->createReport($training, draft: false, activityDate: $start->copy()->subDays(10));
+
+        $response = $this->actingAs($this->admin)->get(route('reports.trainings', [
+            'start_date' => $start->format('Y-m-d'),
+            'end_date' => $end->format('Y-m-d'),
+        ]));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('sessionsPerRating', function ($sessionsPerRating) {
+            return $sessionsPerRating['S2']['volume'] === 1;
+        });
+    }
+
+    #[Test]
+    public function it_respects_the_area_filter_for_session_volume()
+    {
+        $rating = Rating::factory()->create(['name' => 'S2', 'vatsim_rating' => 3]);
+        $otherArea = Area::factory()->create();
+
+        $training = $this->createTraining(0, [$rating->id]);
+        $this->createReport($training, draft: false, activityDate: now()->subMonth());
+
+        $otherTraining = Training::factory()->create([
+            'user_id' => $this->admin->id,
+            'area_id' => $otherArea->id,
+            'type' => 1,
+            'status' => 0,
+        ]);
+        $otherTraining->ratings()->attach($rating->id);
+        $this->createReport($otherTraining, draft: false, activityDate: now()->subMonth());
+
+        $response = $this->actingAs($this->admin)->get(route('reports.training.area', ['id' => $this->area->id]));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('sessionsPerRating', function ($sessionsPerRating) {
+            return $sessionsPerRating['S2']['volume'] === 1;
+        });
+    }
+
+    #[Test]
+    public function it_computes_average_and_median_over_ended_trainings_only()
+    {
+        $rating = Rating::factory()->create(['name' => 'S2', 'vatsim_rating' => 3]);
+
+        // Completed training with 4 reports.
+        $completed = $this->createTraining(-1, [$rating->id], closedAt: now()->subMonth());
+        for ($i = 0; $i < 4; $i++) {
+            $this->createReport($completed, draft: false, activityDate: now()->subMonth());
+        }
+
+        // Closed training with 2 reports.
+        $closed = $this->createTraining(-2, [$rating->id], closedAt: now()->subMonth());
+        for ($i = 0; $i < 2; $i++) {
+            $this->createReport($closed, draft: false, activityDate: now()->subMonth());
+        }
+
+        // In-progress training with 100 reports - must be excluded from avg/median.
+        $inProgress = $this->createTraining(1, [$rating->id]);
+        for ($i = 0; $i < 100; $i++) {
+            $this->createReport($inProgress, draft: false, activityDate: now()->subMonth());
+        }
+
+        $response = $this->actingAs($this->admin)->get(route('reports.trainings'));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('sessionsPerRating', function ($sessionsPerRating) {
+            // Sample [4, 2] -> mean 3.0, median 3.0
+            return $sessionsPerRating['S2']['average'] === 3.0
+                && $sessionsPerRating['S2']['median'] === 3.0;
+        });
+    }
+
+    #[Test]
+    public function it_computes_median_for_odd_sample_sizes()
+    {
+        $rating = Rating::factory()->create(['name' => 'S2', 'vatsim_rating' => 3]);
+
+        foreach ([1, 5, 9] as $count) {
+            $training = $this->createTraining(-1, [$rating->id], closedAt: now()->subMonth());
+            for ($i = 0; $i < $count; $i++) {
+                $this->createReport($training, draft: false, activityDate: now()->subMonth());
+            }
+        }
+
+        $response = $this->actingAs($this->admin)->get(route('reports.trainings'));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('sessionsPerRating', function ($sessionsPerRating) {
+            // Sample [1, 5, 9] -> median 5.0
+            return $sessionsPerRating['S2']['median'] === 5.0;
+        });
+    }
+
+    #[Test]
+    public function it_computes_median_for_even_sample_sizes()
+    {
+        $rating = Rating::factory()->create(['name' => 'S2', 'vatsim_rating' => 3]);
+
+        foreach ([2, 4, 6, 8] as $count) {
+            $training = $this->createTraining(-1, [$rating->id], closedAt: now()->subMonth());
+            for ($i = 0; $i < $count; $i++) {
+                $this->createReport($training, draft: false, activityDate: now()->subMonth());
+            }
+        }
+
+        $response = $this->actingAs($this->admin)->get(route('reports.trainings'));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('sessionsPerRating', function ($sessionsPerRating) {
+            // Sample [2, 4, 6, 8] -> median (4 + 6) / 2 = 5.0
+            return $sessionsPerRating['S2']['median'] === 5.0;
+        });
+    }
+
+    #[Test]
+    public function it_attributes_sessions_to_each_linked_rating()
+    {
+        $s2 = Rating::factory()->create(['name' => 'S2', 'vatsim_rating' => 3]);
+        $s3 = Rating::factory()->create(['name' => 'S3', 'vatsim_rating' => 4]);
+
+        $training = $this->createTraining(-1, [$s2->id, $s3->id], closedAt: now()->subMonth());
+        $this->createReport($training, draft: false, activityDate: now()->subMonth());
+        $this->createReport($training, draft: false, activityDate: now()->subMonth());
+
+        $response = $this->actingAs($this->admin)->get(route('reports.trainings'));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('sessionsPerRating', function ($sessionsPerRating) {
+            return $sessionsPerRating['S2']['volume'] === 2
+                && $sessionsPerRating['S3']['volume'] === 2
+                && $sessionsPerRating['S2']['average'] === 2.0
+                && $sessionsPerRating['S3']['average'] === 2.0;
+        });
+    }
+
+    #[Test]
+    public function it_orders_ratings_by_rating_id_regardless_of_data_order()
+    {
+        $s1 = Rating::factory()->create(['name' => 'S1', 'vatsim_rating' => 2]);
+        $s2 = Rating::factory()->create(['name' => 'S2', 'vatsim_rating' => 3]);
+        $s3 = Rating::factory()->create(['name' => 'S3', 'vatsim_rating' => 4]);
+
+        // Create the data in a non-id order to prove ordering is by rating id,
+        // not by insertion or query result order.
+        foreach ([$s3, $s1, $s2] as $rating) {
+            $training = $this->createTraining(-1, [$rating->id], closedAt: now()->subMonth());
+            $this->createReport($training, draft: false, activityDate: now()->subMonth());
+        }
+
+        $response = $this->actingAs($this->admin)->get(route('reports.trainings'));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('sessionsPerRating', function ($sessionsPerRating) {
+            return array_keys($sessionsPerRating) === ['S1', 'S2', 'S3'];
+        });
+    }
+
+    #[Test]
+    public function it_filters_out_all_zero_ratings()
+    {
+        $s2 = Rating::factory()->create(['name' => 'S2', 'vatsim_rating' => 3]);
+        Rating::factory()->create(['name' => 'S3', 'vatsim_rating' => 4]);
+
+        $training = $this->createTraining(-1, [$s2->id], closedAt: now()->subMonth());
+        $this->createReport($training, draft: false, activityDate: now()->subMonth());
+
+        $response = $this->actingAs($this->admin)->get(route('reports.trainings'));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('sessionsPerRating', function ($sessionsPerRating) {
+            return array_key_exists('S2', $sessionsPerRating)
+                && ! array_key_exists('S3', $sessionsPerRating);
+        });
+    }
+
+    #[Test]
+    public function it_renders_the_sessions_per_rating_chart()
+    {
+        $rating = Rating::factory()->create(['name' => 'S2', 'vatsim_rating' => 3]);
+        $training = $this->createTraining(-1, [$rating->id], closedAt: now()->subMonth());
+        $this->createReport($training, draft: false, activityDate: now()->subMonth());
+
+        $response = $this->actingAs($this->admin)->get(route('reports.trainings'));
+
+        $response->assertStatus(200);
+        $response->assertSee('sessionsPerRating', false);
+        $response->assertSee('Training sessions per rating');
+    }
+
+    #[Test]
+    public function it_excludes_zero_session_trainings_from_average_and_median()
+    {
+        $rating = Rating::factory()->create(['name' => 'S2', 'vatsim_rating' => 3]);
+
+        // Completed training with 4 sessions.
+        $withReports = $this->createTraining(-1, [$rating->id], closedAt: now()->subMonth());
+        for ($i = 0; $i < 4; $i++) {
+            $this->createReport($withReports, draft: false, activityDate: now()->subMonth());
+        }
+
+        // Closed training that recorded zero sessions (queue drop-out) must NOT
+        // count as a 0 data point - it never actually trained.
+        $this->createTraining(-2, [$rating->id], closedAt: now()->subMonth());
+
+        $response = $this->actingAs($this->admin)->get(route('reports.trainings'));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('sessionsPerRating', function ($sessionsPerRating) {
+            // Sample [4] (the zero-session closure excluded) -> mean 4.0, median 4.0; volume still 4.
+            return $sessionsPerRating['S2']['volume'] === 4
+                && $sessionsPerRating['S2']['average'] === 4.0
+                && $sessionsPerRating['S2']['median'] === 4.0;
+        });
+    }
+
+    #[Test]
+    public function it_reports_null_average_and_median_when_no_ended_training_has_sessions()
+    {
+        $rating = Rating::factory()->create(['name' => 'S2', 'vatsim_rating' => 3]);
+
+        // In-progress training with sessions: contributes volume but no ended sample.
+        $inProgress = $this->createTraining(1, [$rating->id]);
+        $this->createReport($inProgress, draft: false, activityDate: now()->subMonth());
+        $this->createReport($inProgress, draft: false, activityDate: now()->subMonth());
+
+        // Closed training with zero sessions: excluded from the sample entirely.
+        $this->createTraining(-2, [$rating->id], closedAt: now()->subMonth());
+
+        $response = $this->actingAs($this->admin)->get(route('reports.trainings'));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('sessionsPerRating', function ($sessionsPerRating) {
+            // Volume present (2), but no qualifying sample -> markers omitted (null), not 0.
+            return $sessionsPerRating['S2']['volume'] === 2
+                && $sessionsPerRating['S2']['average'] === null
+                && $sessionsPerRating['S2']['median'] === null;
         });
     }
 }


### PR DESCRIPTION
Fixes #1143.

Introduces a limited sessions-per-rating chart, which provides a cumulative count of all sessions, and an average and median for all closed and completed trainings with at least one session.

## Summary by Sourcery

Add a training sessions-per-rating statistics chart to the training reports view and expose its aggregated data from the reports controller.

New Features:
- Expose per-rating training session volume, average, and median statistics to the training reports view.
- Render a combo Chart.js chart showing sessions delivered per rating alongside average and median sessions per completed or closed training.

Enhancements:
- Add reusable SQL helper for COALESCE expressions used to compute report activity dates.

Tests:
- Add feature tests covering sessions-per-rating aggregation, filtering, ordering, and chart rendering.