### PR TITLE
fix: remove flux and tailwindcss to avoid overlap and invisible menu

### DIFF
--- a/resources/views/layouts/header.blade.php
+++ b/resources/views/layouts/header.blade.php
@@ -11,10 +11,10 @@
 {{-- Only applies explicit (non-system) preferences synchronously. All other logic in theme.js --}}
 <script>
 (function() {
-    var storedPreference = localStorage.getItem('user_theme_preference') || 
-                          document.documentElement.getAttribute('data-user-theme') || 
+    var storedPreference = localStorage.getItem('user_theme_preference') ||
+                          document.documentElement.getAttribute('data-user-theme') ||
                           'system';
-    
+
     // Only apply non-system preferences to avoid FOUC
     // System preference detection is handled by theme.js after load
     if (storedPreference === 'light' || storedPreference === 'dark') {
@@ -27,12 +27,9 @@
 })();
 </script>
 
-@vite(['resources/js/theme.js', 'resources/sass/app.scss', 'resources/css/flux.css'])
+@vite(['resources/js/theme.js', 'resources/sass/app.scss'])
 
-@livewireStyles
-@fluxAppearance
-
-{{-- Custom fonts --}} 
+{{-- Custom fonts --}}
 <link href="https://fonts.googleapis.com/css?family=Roboto:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i" rel="stylesheet">
 
 {{-- Favicon --}}


### PR DESCRIPTION
Due to the lack of prefixes for the style classes, flux collides with the sidebar and its collapse/expand functionality.

## Summary by Sourcery

Enhancements:
- Simplify asset loading in the header layout by dropping Flux-specific styles and directives.