### PR TITLE
feat(themes): customize theme via gitignored _custom.scss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ public/css/*
 public/fonts/vendor/*
 public/images/logos/*
 public/js/*
-resources/sass/_env.scss
+resources/sass/themes/_custom.scss
 yarn-error.log
 storage/.container-setup-complete
 

--- a/docs/_theme/README.md
+++ b/docs/_theme/README.md
@@ -1,3 +1,0 @@
-# Theme Overrides
-
-Theme overrides go here.

--- a/docs/setup/custom.md
+++ b/docs/setup/custom.md
@@ -21,14 +21,13 @@ FROM ghcr.io/vatsim-scandinavia/control-center:6.4.3
 
 ### Custom Theme
 
-You can customise the theme by [copying your modified theme files and running `/container/theme/build.sh`](./theme.md):
+You can customise the theme by [creating a `_custom.scss` override](./theme.md#customizing-theme) and running `container/theme/build.sh` to recompile the assets:
 
 ```Dockerfile title="Custom theme in Control Center"
 FROM ghcr.io/vatsim-scandinavia/control-center:6.4.3
 
-# Copy your custom theme files
-COPY _light.scss /app/resources/sass/themes/_light.scss
-COPY _dark.scss /app/resources/sass/themes/_dark.scss
+# Copy your theme override
+COPY _custom.scss /app/resources/sass/themes/_custom.scss
 
 # Make the theme build script executable and run it
 RUN chmod +x container/theme/build.sh && container/theme/build.sh

--- a/docs/setup/theme.md
+++ b/docs/setup/theme.md
@@ -32,46 +32,41 @@ Automatically switches between light and dark based on:
 - Time of day settings (on supported systems)
 - No page reload required when system theme changes
 
-## Customizing Theme Colors
-To customize the colors for your division, edit the theme files directly:
+## Customizing Theme
 
-### Light Theme Colors
+To brand your instance, put your overrides in `resources/sass/themes/_custom.scss`.
+That file is git-ignored, so your styles stay out of version control while still
+compiling into the regular front-end build.
 
-Edit: `resources/sass/themes/_light.scss`
+### 1. Create the override file
 
-```scss
-:root, [data-theme="light"] {
-    --color-primary: #1a475f;      // Your primary color
-    --color-secondary: #484b4c;    // Your secondary color
-    --color-success: #41826e;      // Success/green color
-    --color-info: #17a2b8;         // Info/blue color
-    --color-warning: #ff9800;      // Warning/orange color
-    --color-danger: #b63f3f;       // Danger/red color
-    // ... more variables
-}
+Copy the example to get started:
+
+```sh
+cp resources/sass/themes/_custom.scss.example resources/sass/themes/_custom.scss
 ```
 
-### Dark Theme Colors
+### 2. Edit your colors
 
-Edit: `resources/sass/themes/_dark.scss`
+Edit `resources/sass/themes/_custom.scss`. Override only what you need.
+Anything left out keeps its default.
 
-```scss
-[data-theme="dark"] {
-    --color-primary: #4a9cc5;      // Your primary color (adjusted for dark)
-    --color-secondary: #6c757d;    // Your secondary color
-    // ... more variables
-}
-```
+Reference for the available values:
 
-### Rebuild After Changes
+- `resources/sass/themes/_light.scss` — CSS custom properties for the light theme
+- `resources/sass/themes/_dark.scss` — CSS custom properties for the dark theme
+- `resources/sass/_variables.scss` — SCSS variables consumed by Bootstrap
 
-After editing theme files, rebuild the frontend assets:
+### 3. Rebuild the assets
+
+After editing `_custom.scss`, rebuild the frontend assets:
 
 ```sh
 npm run build
 ```
 
 For Docker deployments:
+
 ```sh
 docker exec -it control-center npm run build
 ```
@@ -86,8 +81,6 @@ The theme system uses CSS variables for dynamic switching:
 - **Bootstrap overrides**: `resources/sass/_theme-overrides.scss`
 - **JavaScript**: `resources/js/theme.js`
 
-See the root-level `THEME_*.md` files for comprehensive developer documentation.
-
 Older browsers (like IE11) will fall back to the default light theme without switching capability.
 
 ## Troubleshooting
@@ -98,11 +91,10 @@ Older browsers (like IE11) will fall back to the default light theme without swi
 - Verify assets are built: `npm run build`
 
 ### Colors look wrong
-- Ensure you edited both `_light.scss` and `_dark.scss`
+- Ensure you edited both the light and dark blocks in `_custom.scss` so the colors match in either mode
 - Rebuild assets after changes
 - Check CSS variables in browser DevTools
 
 ## Further Reading
-
 
 - [Custom Container](./custom.md) - Persistent customizations

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -17,6 +17,9 @@
 // Variables
 @import "variables";
 
+// Instance theme override (see themes/_custom.scss.example).
+@import "themes/custom";
+
 // Bootstrap
 @import "~bootstrap/scss/bootstrap";
 

--- a/resources/sass/themes/_custom.scss.example
+++ b/resources/sass/themes/_custom.scss.example
@@ -1,0 +1,18 @@
+// Instance theme override
+//
+// `_custom.scss` is gitignored, so your styles stay out of version control and never
+// conflict on update. Override only what you need. Anything left out keeps its default.
+
+// 1. Variables (overrides `resources/sass/_variables.scss`)
+$border-radius: 2px;
+
+// 2a. CSS custom properties — light theme (overrides `resources/sass/themes/_light.scss`)
+:root,
+[data-theme="light"] {
+    --color-primary: #6d28d9;
+}
+
+// 2b. CSS custom properties — dark theme (overrides `resources/sass/themes/_dark.scss`)
+[data-theme="dark"] {
+    --color-primary: #8b5cf6;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import tailwindcss from '@tailwindcss/vite';
 import vue from '@vitejs/plugin-vue';
+import fs from 'fs';
 import path from 'path';
 
 // TODO: remove these warnings once the issue below has been resolved, e.g. bootstrap v5.5
@@ -10,7 +11,26 @@ const BOOTSTRAP_DEPRECATIONS = [
     'import', 'global-builtin', 'color-functions', 'mixed-decls'
 ];
 
+// Git-ignored theme override imported by `app.scss` (see `_custom.scss.example`).
+// `app.scss` always imports it, so an empty stub is created when it is missing.
+// An existing file is never touched.
+const CUSTOM_THEME_FILE = path.resolve(__dirname, 'resources/sass/themes/_custom.scss');
+
+function ensureCustomThemeFile() {
+    if (fs.existsSync(CUSTOM_THEME_FILE)) {
+        return;
+    }
+
+    fs.writeFileSync(
+        CUSTOM_THEME_FILE,
+        `// Drop instance theme override here to brand this installation.\n`
+        + `// This file is gitignored. See themes/_custom.scss.example for the format.\n`,
+    );
+}
+
 export default () => {
+    // Make sure the optional theme override exists before compiling the front-end.
+    ensureCustomThemeFile();
 
     // Return the Vite configuration
     return defineConfig({


### PR DESCRIPTION
Restore per-instance theme customization without editing tracked source, a regression from #1369 which replaced the .env-driven theming with hardcoded SCSS files.

app.scss now imports a gitignored resources/sass/themes/_custom.scss, created as an empty stub by Vite when missing. It is imported after _variables.scss but before Bootstrap, so an instance can override both layers the theme is built from -- Bootstrap $ variables (baked into compiled output) and the --color-* CSS custom properties -- without merge conflicts on update.

A _custom.scss.example documents the format, and docs/setup/theme.md is updated to the new workflow.

Related to #1422

## Summary by Sourcery

Restore per-instance theme customization via a git-ignored SCSS override file that is automatically created and imported into the main stylesheet.

New Features:
- Allow instances to customize theme branding through a git-ignored resources/sass/themes/_custom.scss override file imported into the main app stylesheet.

Enhancements:
- Automatically create an empty _custom.scss stub during Vite builds if it does not exist, without touching existing overrides.
- Update theme setup documentation to describe the new _custom.scss override workflow and reference files for available variables.

Documentation:
- Revise theme customization docs to focus on using _custom.scss for per-instance overrides instead of editing core theme files.