### PR TITLE
fix(feedback): change controller column filter control to input

### DIFF
--- a/resources/views/reports/feedback.blade.php
+++ b/resources/views/reports/feedback.blade.php
@@ -32,7 +32,7 @@
                             <tr>
                                 <th data-field="received" data-sortable="true">Received</th>
                                 <th data-field="submitter" data-sortable="true" data-filter-control="input">Submitter</th>
-                                <th data-field="controller" data-sortable="true" data-filter-control="select">Controller</th>
+                                <th data-field="controller" data-sortable="true" data-filter-control="input">Controller</th>
                                 <th data-field="position" data-sortable="true" data-filter-control="select">Position</th>
                                 <th data-field="area" data-sortable="true" data-filter-control="select">Area</th>
                                 <th data-field="feedback" data-sortable="false" data-filter-control="input">Feedback</th>


### PR DESCRIPTION
It simply works. Sort of fixes #1551.

## Summary by Sourcery

Enhancements:
- Replace the controller column filter control with an input field to align filtering behavior with other text-based columns.