### PR TITLE
Added VATSSA to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Training Management System created by [Daniel L.](https://github.com/blt950) (13
 
 ➡️  **[Get started and learn more about Control Center 📖](https://docs.vatsca.org/controlcenter)**
 
-11 divisions are currently using Control Center:
+12 divisions are currently using Control Center:
 - [VATSIM Scandinavia](https://vatsim-scandinavia.org)
 - [Czech vACC](https://www.vacc-cz.org/)
 - [Hellenic vACC](https://hvacc.org/)
@@ -22,6 +22,7 @@ Training Management System created by [Daniel L.](https://github.com/blt950) (13
 - [VATPHIL](https://vatphil.com/)
 - [Portugal vACC](https://portugal-vacc.org/)
 - [Estonia vACC](https://controlcenter.vatsim.ee/)
+- [ATSIM Sub-Sahara Africa](https://vatssa.com/)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Training Management System created by [Daniel L.](https://github.com/blt950) (13
 - [VATPHIL](https://vatphil.com/)
 - [Portugal vACC](https://portugal-vacc.org/)
 - [Estonia vACC](https://controlcenter.vatsim.ee/)
-- [ATSIM Sub-Sahara Africa](https://vatssa.com/)
+- [VATSIM Sub-Sahara Africa](https://vatssa.com/)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the README to list VATSIM Sub-Sahara Africa as a supported division and adjust the total division count accordingly.