### PR TITLE
refactor: enforce PHP 8.1 enum semantics for TrainingStatus and VatsimRating

### DIFF
--- a/app/Console/Commands/SendTrainingInterestNotifications.php
+++ b/app/Console/Commands/SendTrainingInterestNotifications.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Helpers\TrainingStatus;
 use App\Http\Controllers\TrainingActivityController;
 use App\Models\Training;
 use App\Models\TrainingInterest;
@@ -43,7 +44,7 @@ class SendTrainingInterestNotifications extends Command
      */
     public function handle()
     {
-        $trainings = Training::where([['status', '>=', 0], ['status', '<=', 1], ['created_at', '<=', Carbon::now()->subDays(30)]])->get();
+        $trainings = Training::where([['status', '>=', TrainingStatus::IN_QUEUE], ['status', '<=', TrainingStatus::PRE_TRAINING], ['created_at', '<=', Carbon::now()->subDays(30)]])->get();
 
         foreach ($trainings as $training) {
             $lastInterestRequest = TrainingInterest::where('training_id', $training->id)->orderBy('created_at')->get()->last();
@@ -79,11 +80,11 @@ class SendTrainingInterestNotifications extends Command
 
                     // Update the training
                     // Note: The training interest is set to expire through updateStatus()
-                    $training->updateStatus(-4, true);
+                    $training->updateStatus(TrainingStatus::CLOSED_BY_SYSTEM, true);
                     $training->closed_reason = 'Continued training interest was not confirmed within deadline.';
                     $training->save();
-                    $training->user->notify(new TrainingClosedNotification($training, -4, 'Continued training interest was not confirmed within deadline.'));
-                    TrainingActivityController::create($training->id, 'STATUS', -4, $oldStatus, null, 'Continued training interest was not confirmed within deadline.');
+                    $training->user->notify(new TrainingClosedNotification($training, TrainingStatus::CLOSED_BY_SYSTEM, 'Continued training interest was not confirmed within deadline.'));
+                    TrainingActivityController::create($training->id, 'STATUS', TrainingStatus::CLOSED_BY_SYSTEM->value, $oldStatus->value, null, 'Continued training interest was not confirmed within deadline.');
                 } elseif ($requestDeadline->diffInDays(now(), true) == 6 && $requestUpdated->diffInDays(now(), true) != 0 && $lastInterestRequest->expired == false && $requestConfirmed == null) {
                     // If the interest is not confirmed after 6 days, we remind
                     $this->info('Reminding training ' . $training->id);

--- a/app/Console/Commands/UpdateMemberDetails.php
+++ b/app/Console/Commands/UpdateMemberDetails.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use anlutro\LaravelSettings\Facade as Setting;
+use App\Helpers\TrainingStatus;
 use App\Models\AtcActivity;
 use App\Models\Training;
 use App\Models\User;
@@ -75,7 +76,7 @@ class UpdateMemberDetails extends Command
         $this->info($count . ' users affected.');
 
         // Get active trainings
-        $trainings = Training::where('status', '>=', 0)->where('type', '!=', 5)->get();
+        $trainings = Training::where('status', '>=', TrainingStatus::IN_QUEUE)->where('type', '!=', 5)->get();
 
         $this->info('Closing trainings for those who left division...');
         $count = 0;
@@ -94,13 +95,13 @@ class UpdateMemberDetails extends Command
             // the closure is recorded explicitly below, so the LogsActivity trait
             // would only add a duplicate entry for this bulk maintenance write.
             activity()->withoutLogging(function () use ($training) {
-                $training->updateStatus(-4);
+                $training->updateStatus(TrainingStatus::CLOSED_BY_SYSTEM);
                 $training->closed_reason = 'The student has left or is no longer part of our division.';
                 $training->save();
             });
 
             // Notify student of closure
-            $training->user->notify(new TrainingClosedNotification($training, -4, 'Student has left the division.'));
+            $training->user->notify(new TrainingClosedNotification($training, TrainingStatus::CLOSED_BY_SYSTEM, 'Student has left the division.'));
 
             // Log the closure
             ActivityLogService::warning('TRAINING', 'Closed training request ' . $training->id . ' due to student leaving division');

--- a/app/Console/Commands/UpdateQueueCalculation.php
+++ b/app/Console/Commands/UpdateQueueCalculation.php
@@ -54,7 +54,7 @@ class UpdateQueueCalculation extends Command
                 foreach ($rating->trainings->where('area_id', $area->id)->whereNotNull('created_at')->whereNull('paused_at') as $training) {
                     // Include training with GRP ratings inside
                     if ($training->ratings->count() >= 1 && $training->ratings->first()->vatsim_rating) {
-                        if ($training->status == TrainingStatus::IN_QUEUE->value) {
+                        if ($training->status === TrainingStatus::IN_QUEUE) {
                             $trainingCreated = $training->created_at;
 
                             // Calculate the difference in seconds with Carbon, then subtract the paused time if any.

--- a/app/Console/Commands/UserDelete.php
+++ b/app/Console/Commands/UserDelete.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Helpers\TrainingStatus;
 use App\Models\Training;
 use App\Models\User;
 use App\Notifications\TrainingClosedNotification;
@@ -40,10 +41,10 @@ class UserDelete extends Command
     private function closeUserTrainings($user)
     {
 
-        $trainings = Training::where('user_id', $user->id)->where('status', '>=', 0)->get();
+        $trainings = Training::where('user_id', $user->id)->where('status', '>=', TrainingStatus::IN_QUEUE)->get();
         foreach ($trainings as $training) {
             // Training should be closed
-            $training->updateStatus(-4);
+            $training->updateStatus(TrainingStatus::CLOSED_BY_SYSTEM);
 
             // Detach mentors
             foreach ($training->mentors as $mentor) {
@@ -53,7 +54,7 @@ class UserDelete extends Command
             // Notify the student
             $training->closed_reason = 'Closed due to data deletion request.';
             $training->save();
-            $training->user->notify(new TrainingClosedNotification($training, -4, 'Closed due to data deletion request.'));
+            $training->user->notify(new TrainingClosedNotification($training, TrainingStatus::CLOSED_BY_SYSTEM, 'Closed due to data deletion request.'));
         }
     }
 

--- a/app/Helpers/FactoryHelper.php
+++ b/app/Helpers/FactoryHelper.php
@@ -134,22 +134,20 @@ class FactoryHelper
         return $region['id'];
     }
 
-    public static function longRating(int $rating)
+    public static function longRating(VatsimRating $rating)
     {
         switch ($rating) {
-            case 0: return 'Suspended';
-            case 1: return 'Pilot/Observer';
-            case 2: return 'Tower Trainee';
-            case 3: return 'Tower Controller';
-            case 4: return 'TMA Controller';
-            case 5: return 'Enroute Controller';
-            case 6: return 'Senior Controller';
-            case 7: return 'Senior Controller';
-            case 8: return 'Instructor';
-            case 9: return 'Senior Instructor';
-            case 10: return 'Senior Instructor';
-            case 11: return 'Supervisor';
-            case 12: return 'Administrator';
+            case VatsimRating::SUS: return 'Suspended';
+            case VatsimRating::OBS: return 'Pilot/Observer';
+            case VatsimRating::S1: return 'Tower Trainee';
+            case VatsimRating::S2: return 'Tower Controller';
+            case VatsimRating::S3: return 'TMA Controller';
+            case VatsimRating::C1: return 'Enroute Controller';
+            case VatsimRating::C3: return 'Senior Controller';
+            case VatsimRating::I1: return 'Instructor';
+            case VatsimRating::I3: return 'Senior Instructor';
+            case VatsimRating::SUP: return 'Supervisor';
+            case VatsimRating::ADM: return 'Administrator';
             default: return 'Inactive';
         }
     }

--- a/app/Helpers/TrainingStatus.php
+++ b/app/Helpers/TrainingStatus.php
@@ -2,11 +2,14 @@
 
 namespace App\Helpers;
 
+use App\Traits\ComparableIntEnum;
+
 /**
  * Constants for training status.
  */
 enum TrainingStatus: int
 {
+    use ComparableIntEnum;
     case CLOSED_BY_SYSTEM = -4;
     case CLOSED_BY_STUDENT = -3;
     case CLOSED_BY_STAFF = -2;
@@ -15,4 +18,70 @@ enum TrainingStatus: int
     case PRE_TRAINING = 1;
     case ACTIVE_TRAINING = 2;
     case AWAITING_EXAM = 3;
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::CLOSED_BY_SYSTEM => 'Closed by system',
+            self::CLOSED_BY_STUDENT => 'Closed by student',
+            self::CLOSED_BY_STAFF => 'Closed by staff',
+            self::COMPLETED => 'Completed',
+            self::IN_QUEUE => 'In queue',
+            self::PRE_TRAINING => 'Pre-training',
+            self::ACTIVE_TRAINING => 'Active training',
+            self::AWAITING_EXAM => 'Awaiting exam',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::CLOSED_BY_SYSTEM,
+            self::CLOSED_BY_STUDENT,
+            self::CLOSED_BY_STAFF => 'danger',
+            self::COMPLETED,
+            self::ACTIVE_TRAINING => 'success',
+            self::IN_QUEUE,
+            self::AWAITING_EXAM => 'warning',
+            self::PRE_TRAINING => 'info',
+        };
+    }
+
+    public function icon(): string
+    {
+        return match ($this) {
+            self::CLOSED_BY_SYSTEM,
+            self::CLOSED_BY_STUDENT => 'fa fa-ban',
+            self::CLOSED_BY_STAFF => 'fas fa-ban',
+            self::COMPLETED => 'fas fa-check',
+            self::IN_QUEUE => 'fas fa-hourglass',
+            self::PRE_TRAINING,
+            self::ACTIVE_TRAINING => 'fas fa-book-open',
+            self::AWAITING_EXAM => 'fas fa-graduation-cap',
+        };
+    }
+
+    public function isAssignableByStaff(): bool
+    {
+        return match ($this) {
+            self::CLOSED_BY_SYSTEM,
+            self::CLOSED_BY_STUDENT => false,
+            default => true,
+        };
+    }
+
+    public function isOpen(): bool
+    {
+        return $this->isGreaterThanOrEqual(self::IN_QUEUE);
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->isLessThan(self::IN_QUEUE);
+    }
+
+    public function isInProgress(): bool
+    {
+        return $this->isGreaterThanOrEqual(self::PRE_TRAINING);
+    }
 }

--- a/app/Helpers/VatsimRating.php
+++ b/app/Helpers/VatsimRating.php
@@ -2,11 +2,14 @@
 
 namespace App\Helpers;
 
+use App\Traits\ComparableIntEnum;
+
 /**
  * Constants for VATSIM ratings.
  */
 enum VatsimRating: int
 {
+    use ComparableIntEnum;
     case INA = -1;
     case SUS = 0;
     case OBS = 1;

--- a/app/Http/Controllers/API/BookingController.php
+++ b/app/Http/Controllers/API/BookingController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API;
 
 use App;
 use App\Helpers\TrainingStatus;
+use App\Helpers\VatsimRating;
 use App\Http\Controllers\Controller;
 use App\Models\Booking;
 use App\Models\Position;
@@ -106,7 +107,7 @@ class BookingController extends Controller
 
         $forcedTrainingTag = false;
 
-        if (($booking->position->rating > $user->rating) && ! $user->hasPermission('bookings.bypass-restrictions')) {
+        if ($booking->position->rating->isGreaterThan($user->rating) && ! $user->hasPermission('bookings.bypass-restrictions')) {
             $booking->training = 1;
             $forcedTrainingTag = true;
         } elseif ($position->requiredRating && ! $user->hasEndorsementRating($position->requiredRating) && ! $user->hasPermission('bookings.bypass-restrictions')) {
@@ -192,12 +193,18 @@ class BookingController extends Controller
     {
         $user = User::findorFail($booking->user_id);
         $positions = new Collection();
-        if ($user->rating >= 3) {
+        if ($user->rating->isGreaterThanOrEqual(VatsimRating::S2)) {
             $positions = Position::where('rating', '<=', $user->rating)->get();
         }
 
-        if ($user->getActiveTraining(TrainingStatus::PRE_TRAINING->value)) {
-            $positions = $positions->merge($user->getActiveTraining()->area->positions->where('rating', '<=', $user->getActiveTraining()->first()->vatsim_rating));
+        if ($user->getActiveTraining(TrainingStatus::PRE_TRAINING)) {
+            $training = $user->getActiveTraining(TrainingStatus::PRE_TRAINING);
+            $highestRating = $training->getHighestVatsimRating()?->vatsim_rating;
+            $positions = $positions->merge(
+                $training->area->positions->filter(
+                    fn (Position $position) => $highestRating !== null && $position->rating->isLessThanOrEqual($highestRating)
+                )
+            );
         }
 
         if ($user->hasPermission('bookings.bypass-restrictions')) {
@@ -271,7 +278,7 @@ class BookingController extends Controller
 
         $forcedTrainingTag = false;
 
-        if (($booking->position->rating > $user->rating) && ! $user->hasPermission('bookings.bypass-restrictions')) {
+        if ($booking->position->rating->isGreaterThan($user->rating) && ! $user->hasPermission('bookings.bypass-restrictions')) {
             $booking->training = 1;
             $forcedTrainingTag = true;
         } elseif ($position->requiredRating && ! $user->hasEndorsementRating($position->requiredRating) && ! $user->hasPermission('bookings.bypass-restrictions')) {

--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API;
 
 use anlutro\LaravelSettings\Facade as Setting;
+use App\Helpers\TrainingStatus;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\TrainingController;
 use App\Models\Area;
@@ -95,7 +96,7 @@ class UserController extends Controller
 
         if ($paramIncludeTraining) {
             $trainingUsers = User::whereHas('trainings', function (Builder $q) {
-                $q->where('status', '>=', 0);
+                $q->where('status', '>=', TrainingStatus::IN_QUEUE);
             })->whereNotIn('id', $returnUsers->pluck('id'));
             if ($paramOnlyActive) {
                 $trainingUsers = $trainingUsers->whereHas('atcActivity', function ($query) {
@@ -138,7 +139,7 @@ class UserController extends Controller
         // Trainings
         if ($paramIncludeTraining) {
             foreach ($returnUsers as $user) {
-                $user->training = $this->mapTrainings($user->trainings->where('status', '>=', 0));
+                $user->training = $this->mapTrainings($user->trainings->filter(fn ($t) => $t->status->isOpen()));
             }
         }
 
@@ -274,8 +275,8 @@ class UserController extends Controller
             return [
                 'area' => $training->area->name,
                 'type' => TrainingController::$types[$training->type]['text'],
-                'status' => $training->status,
-                'status_description' => TrainingController::$statuses[$training->status]['text'],
+                'status' => $training->status->value,
+                'status_description' => $training->status->label(),
                 'created_at' => $training->created_at,
                 'started_at' => $training->started_at,
                 'ratings' => $training->ratings->pluck('name'),

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use anlutro\LaravelSettings\Facade as Setting;
 use App;
+use App\Helpers\VatsimRating;
 use App\Models\TrainingInterest;
 use App\Models\TrainingReport;
 use App\Models\User;
@@ -52,7 +53,6 @@ class DashboardController extends Controller
         ];
 
         $trainings = $user->trainings;
-        $statuses = TrainingController::$statuses;
         $types = TrainingController::$types;
 
         $dueInterestRequest = TrainingInterest::whereIn('training_id', $user->trainings->pluck('id'))->where('expired', false)->first();
@@ -64,7 +64,7 @@ class DashboardController extends Controller
                 (config('app.mode') == 'subdivision' && in_array($user->subdivision, $allowedSubDivisions) && $allowedSubDivisions != null)
                 || (config('app.mode') == 'division' && $user->division == config('app.owner_code'))
             )
-            && ! $user->hasActiveTrainings(true) && $user->rating > 1 && ! $user->isAtcActive() && ! $user->hasRecentlyCompletedTraining()
+            && ! $user->hasActiveTrainings(true) && $user->rating->isGreaterThan(VatsimRating::OBS) && ! $user->isAtcActive() && ! $user->hasRecentlyCompletedTraining()
         );
         $completedTrainingMessage = $user->hasRecentlyCompletedTraining();
 
@@ -81,7 +81,7 @@ class DashboardController extends Controller
 
         $oudatedVersionWarning = $user->hasPermission('system.health.view') && Setting::get('_updateAvailable');
 
-        return view('dashboard', compact('data', 'trainings', 'statuses', 'types', 'dueInterestRequest', 'atcInactiveMessage', 'completedTrainingMessage', 'activeVote', 'atcHours', 'workmailRenewal', 'studentTrainings', 'cronJobError', 'oudatedVersionWarning'));
+        return view('dashboard', compact('data', 'trainings', 'types', 'dueInterestRequest', 'atcInactiveMessage', 'completedTrainingMessage', 'activeVote', 'atcHours', 'workmailRenewal', 'studentTrainings', 'cronJobError', 'oudatedVersionWarning'));
     }
 
     /**

--- a/app/Http/Controllers/EndorsementController.php
+++ b/app/Http/Controllers/EndorsementController.php
@@ -160,7 +160,7 @@ class EndorsementController extends Controller
             $user = User::find($data['user']);
 
             // Check if user has active training
-            if (! $user->getActiveTraining(TrainingStatus::PRE_TRAINING->value)) {
+            if (! $user->getActiveTraining(TrainingStatus::PRE_TRAINING)) {
                 return back()->withInput()->withErrors($user->name . ' has no active training to link this endorsement to.');
             }
 
@@ -216,7 +216,7 @@ class EndorsementController extends Controller
             ' ― Positions: ' . $data['position']);
 
             // Log this new endorsement to the user's active training
-            TrainingActivityController::create($user->trainings->where('status', '>=', 0)->first()->id, 'ENDORSEMENT', $endorsement->id, null, Auth::user()->id, $endorsement->positions->pluck('callsign')->implode(', '));
+            TrainingActivityController::create($user->trainings->filter(fn ($training) => $training->status->isOpen())->first()->id, 'ENDORSEMENT', $endorsement->id, null, Auth::user()->id, $endorsement->positions->pluck('callsign')->implode(', '));
 
             $user->notify(new EndorsementCreatedNotification($endorsement));
 

--- a/app/Http/Controllers/MentorController.php
+++ b/app/Http/Controllers/MentorController.php
@@ -19,10 +19,9 @@ class MentorController extends Controller
     {
         $user = Auth::user();
         $trainings = $user->mentoringTrainings();
-        $statuses = TrainingController::$statuses;
         $types = TrainingController::$types;
         if ($user->hasPermission('training.mentor-dashboard.view')) {
-            return view('mentor.index', compact('trainings', 'user', 'statuses', 'types'));
+            return view('mentor.index', compact('trainings', 'user', 'types'));
         }
 
         abort(403);

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\TrainingStatus;
 use App\Models\Area;
 use App\Models\Feedback;
 use App\Models\ManagementReport;
@@ -190,7 +191,6 @@ class ReportController extends Controller
         }
 
         $entries = $entries->concat($activities)->sortByDesc('activity_date');
-        $statuses = TrainingController::$statuses;
 
         $areas = Area::all();
         $filterName = 'All Areas';
@@ -203,7 +203,6 @@ class ReportController extends Controller
 
         return view('reports.activities', [
             'entries' => $entries,
-            'statuses' => $statuses,
             'filterName' => $filterName,
             'areas' => $areas,
         ]);
@@ -235,9 +234,8 @@ class ReportController extends Controller
         $mentors = $query->get();
 
         $mentors = $mentors->sortBy('name')->unique();
-        $statuses = TrainingController::$statuses;
 
-        return view('reports.mentors', compact('mentors', 'statuses'));
+        return view('reports.mentors', compact('mentors'));
     }
 
     /**
@@ -294,11 +292,11 @@ class ReportController extends Controller
         }
 
         $stats = $query->selectRaw('
-                COUNT(CASE WHEN status = 0 THEN 1 END) as waiting,
-                COUNT(CASE WHEN status IN (1, 2) THEN 1 END) as training,
-                COUNT(CASE WHEN status = 3 THEN 1 END) as exam,
-                COUNT(CASE WHEN status = -1 AND closed_at >= ? AND closed_at <= ? THEN 1 END) as completed,
-                COUNT(CASE WHEN status = -2 AND closed_at >= ? AND closed_at <= ? THEN 1 END) as closed
+                COUNT(CASE WHEN status = ' . TrainingStatus::IN_QUEUE->value . ' THEN 1 END) as waiting,
+                COUNT(CASE WHEN status IN (' . TrainingStatus::PRE_TRAINING->value . ', ' . TrainingStatus::ACTIVE_TRAINING->value . ') THEN 1 END) as training,
+                COUNT(CASE WHEN status = ' . TrainingStatus::AWAITING_EXAM->value . ' THEN 1 END) as exam,
+                COUNT(CASE WHEN status = ' . TrainingStatus::COMPLETED->value . ' AND closed_at >= ? AND closed_at <= ? THEN 1 END) as completed,
+                COUNT(CASE WHEN status = ' . TrainingStatus::CLOSED_BY_STAFF->value . ' AND closed_at >= ? AND closed_at <= ? THEN 1 END) as closed
             ', [$start, $end, $start, $end])
             ->first();
 
@@ -400,7 +398,7 @@ class ReportController extends Controller
             ->where(function ($query) use ($queryStart, $queryEnd) {
                 $query->whereBetween('created_at', [$queryStart, $queryEnd])
                     ->orWhere(function ($subQuery) use ($queryStart, $queryEnd) {
-                        $subQuery->whereIn('status', [-1, -2])
+                        $subQuery->whereIn('status', [TrainingStatus::COMPLETED, TrainingStatus::CLOSED_BY_STAFF])
                             ->whereBetween('closed_at', [$queryStart, $queryEnd]);
                     });
             });
@@ -427,9 +425,9 @@ class ReportController extends Controller
                 if ($training->closed_at && $training->closed_at >= $queryStart && $training->closed_at <= $queryEnd) {
                     $key = $training->closed_at->format('Y-m');
                     if (isset($monthTranslator[$key])) {
-                        if ($training->status == -1) {
+                        if ($training->status === TrainingStatus::COMPLETED) {
                             $completedRequests[$rating->name][$monthTranslator[$key]]++;
-                        } elseif ($training->status == -2) {
+                        } elseif ($training->status === TrainingStatus::CLOSED_BY_STAFF) {
                             $closedRequests[$rating->name][$monthTranslator[$key]]++;
                         }
                     }

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -35,6 +35,7 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 
 /**
@@ -42,20 +43,6 @@ use Illuminate\View\View;
  */
 class TrainingController extends Controller
 {
-    /**
-     * A list of possible statuses
-     */
-    public static $statuses = [
-        -4 => ['text' => 'Closed by system', 'color' => 'danger', 'icon' => 'fa fa-ban', 'assignableByStaff' => false],
-        -3 => ['text' => 'Closed by student', 'color' => 'danger', 'icon' => 'fa fa-ban', 'assignableByStaff' => false],
-        -2 => ['text' => 'Closed by staff', 'color' => 'danger', 'icon' => 'fas fa-ban', 'assignableByStaff' => true],
-        -1 => ['text' => 'Completed', 'color' => 'success', 'icon' => 'fas fa-check', 'assignableByStaff' => true],
-        0 => ['text' => 'In queue', 'color' => 'warning', 'icon' => 'fas fa-hourglass', 'assignableByStaff' => true],
-        1 => ['text' => 'Pre-training', 'color' => 'info', 'icon' => 'fas fa-book-open', 'assignableByStaff' => true],
-        2 => ['text' => 'Active training', 'color' => 'success', 'icon' => 'fas fa-book-open', 'assignableByStaff' => true],
-        3 => ['text' => 'Awaiting exam', 'color' => 'warning', 'icon' => 'fas fa-graduation-cap', 'assignableByStaff' => true],
-    ];
-
     /**
      * A list of possible types
      */
@@ -90,18 +77,17 @@ class TrainingController extends Controller
     {
         $this->authorize('viewActiveRequests', Training::class);
 
-        $openTrainings = Auth::user()->viewableModels(Training::class, [['status', '>=', 0]], ['area', 'ratings', 'activities', 'mentors', 'user', 'user.atcActivity'])->sort(function ($a, $b) {
-            if ($a->status == $b->status) {
+        $openTrainings = Auth::user()->viewableModels(Training::class, [['status', '>=', TrainingStatus::IN_QUEUE]], ['area', 'ratings', 'activities', 'mentors', 'user', 'user.atcActivity'])->sort(function ($a, $b) {
+            if ($a->status === $b->status) {
                 return $a->created_at->timestamp - $b->created_at->timestamp;
             }
 
-            return $b->status - $a->status;
+            return $b->status->value - $a->status->value;
         });
 
-        $statuses = TrainingController::$statuses;
         $types = TrainingController::$types;
 
-        return view('training.index', compact('openTrainings', 'statuses', 'types'));
+        return view('training.index', compact('openTrainings', 'types'));
     }
 
     /**
@@ -115,12 +101,11 @@ class TrainingController extends Controller
     {
         $this->authorize('viewHistoricRequests', Training::class);
 
-        $closedTrainings = Auth::user()->viewableModels(Training::class, [['status', '<', 0]], ['area', 'reports', 'ratings', 'activities', 'mentors', 'user', 'user.roleAssignments'])->sortByDesc('closed_at');
+        $closedTrainings = Auth::user()->viewableModels(Training::class, [['status', '<', TrainingStatus::IN_QUEUE]], ['area', 'reports', 'ratings', 'activities', 'mentors', 'user', 'user.roleAssignments'])->sortByDesc('closed_at');
 
-        $statuses = TrainingController::$statuses;
         $types = TrainingController::$types;
 
-        return view('training.history', compact('closedTrainings', 'statuses', 'types'));
+        return view('training.history', compact('closedTrainings', 'types'));
     }
 
     /**
@@ -145,9 +130,9 @@ class TrainingController extends Controller
                 $reqVatRating = $rating->pivot->required_vatsim_rating;
 
                 // If the rating gives vatsim-rating higher than user already holds || OR if it's endorsement-rating AND user does not hold the endorsement
-                if ($rating->vatsim_rating > $userVatsimRating || ($rating->vatsim_rating == null && $user->hasEndorsementRating($rating) == false)) {
+                if (($rating->vatsim_rating !== null && $rating->vatsim_rating->isGreaterThan($userVatsimRating)) || ($rating->vatsim_rating === null && ! $user->hasEndorsementRating($rating))) {
                     // If the required vatsim rating for the selection is lower or equals the level user has today, make it available
-                    if ($reqVatRating <= $userVatsimRating) {
+                    if ($reqVatRating <= $userVatsimRating->value) {
                         $rating->hour_requirement = $rating->pivot->hour_requirement;
                         $availableRatings->push($rating);
                     }
@@ -192,13 +177,13 @@ class TrainingController extends Controller
         }
 
         // Is activity in area required to apply for training?
-        $atcActiveRequired = $user->rating >= VatsimRating::S1->value && Setting::get('atcActivityBasedOnTotalHours') == false;
+        $atcActiveRequired = $user->rating->isGreaterThanOrEqual(VatsimRating::S1) && Setting::get('atcActivityBasedOnTotalHours') == false;
 
         return view('training.apply', [
             'payload' => $payload,
             'atc_hours' => $vatsimStats,
             'atcActiveRequired' => $atcActiveRequired ? 1 : 0,
-            'motivation_required' => $userVatsimRating <= 2 ? 1 : 0,
+            'motivation_required' => $userVatsimRating->isLessThanOrEqual(VatsimRating::S1) ? 1 : 0,
         ]);
     }
 
@@ -250,7 +235,7 @@ class TrainingController extends Controller
             $ratings = Rating::find(explode('+', $data['training_level']));
 
             // Check if user is active in the area if required by setting
-            $atcActivityRequired = Auth::user()->rating >= VatsimRating::S1->value && Setting::get('atcActivityBasedOnTotalHours') == false;
+            $atcActivityRequired = Auth::user()->rating->isGreaterThanOrEqual(VatsimRating::S1) && Setting::get('atcActivityBasedOnTotalHours') == false;
             $activeInArea = Auth::user()->atcActivity->firstWhere('area_id', $data['training_area']);
             if ($atcActivityRequired && $activeInArea && ! $activeInArea->atc_active) {
                 return redirect()->back()->withErrors('You need to be active in the area to apply for training.');
@@ -350,7 +335,6 @@ class TrainingController extends Controller
             });
 
         $trainingMentors = $training->area->mentors->sortBy('name');
-        $statuses = TrainingController::$statuses;
         $types = TrainingController::$types;
         $experiences = TrainingController::$experiences;
         $activities = $training->activities->sortByDesc('created_at');
@@ -363,7 +347,7 @@ class TrainingController extends Controller
         $requestTypes = TaskController::getTypes();
         $requestPopularAssignees = TaskController::getPopularAssignees($training->area);
 
-        return view('training.show', compact('training', 'reportsAndExams', 'trainingMentors', 'statuses', 'types', 'experiences', 'activities', 'trainingInterests', 'activeTrainingInterest', 'relatedTasks', 'requestTypes', 'requestPopularAssignees'));
+        return view('training.show', compact('training', 'reportsAndExams', 'trainingMentors', 'types', 'experiences', 'activities', 'trainingInterests', 'activeTrainingInterest', 'relatedTasks', 'requestTypes', 'requestPopularAssignees'));
     }
 
     /**
@@ -458,7 +442,7 @@ class TrainingController extends Controller
         if (array_key_exists('status', $attributes)) {
 
             // Don't allow re-opening a training if that causes student to have multiple trainings at the same time
-            if ($attributes['status'] >= 0 && $oldStatus < 0 && $training->user->hasActiveTrainings(true)) {
+            if ($attributes['status']->isOpen() && $oldStatus->isClosed() && $training->user->hasActiveTrainings(true)) {
                 return redirect($training->path())->withErrors('Training can not be reopened. The student already has an active training request.');
             }
 
@@ -466,13 +450,13 @@ class TrainingController extends Controller
             // the rest of this request reads the new state. Everything is then
             // persisted together in the single update below, keeping the
             // activity log to one entry per request.
-            $training->fill($training->resolveStatusChanges((int) $attributes['status']));
+            $training->fill($training->resolveStatusChanges($attributes['status']));
 
-            if ($attributes['status'] != $oldStatus) {
-                if ($attributes['status'] == -2 || $attributes['status'] == -4) {
-                    TrainingActivityController::create($training->id, 'STATUS', $attributes['status'], $oldStatus, Auth::id(), $attributes['closed_reason']);
+            if ($attributes['status'] !== $oldStatus) {
+                if ($attributes['status'] === TrainingStatus::CLOSED_BY_STAFF || $attributes['status'] === TrainingStatus::CLOSED_BY_SYSTEM) {
+                    TrainingActivityController::create($training->id, 'STATUS', $attributes['status']->value, $oldStatus->value, Auth::id(), $attributes['closed_reason']);
                 } else {
-                    TrainingActivityController::create($training->id, 'STATUS', $attributes['status'], $oldStatus, Auth::id());
+                    TrainingActivityController::create($training->id, 'STATUS', $attributes['status']->value, $oldStatus->value, Auth::id());
                 }
             }
         }
@@ -514,7 +498,7 @@ class TrainingController extends Controller
         }
 
         // Update paused time for queue estimation
-        if (isset($attributes['paused_at']) && (int) $training->status >= TrainingStatus::IN_QUEUE->value) {
+        if (isset($attributes['paused_at']) && $training->status->isOpen()) {
             if (! isset($training->paused_at)) {
                 $attributes['paused_at'] = Carbon::now();
                 TrainingActivityController::create($training->id, 'PAUSE', 1, null, Auth::id());
@@ -532,8 +516,8 @@ class TrainingController extends Controller
         }
 
         // If training is closed, force to unpause
-        if ((int) $training->status != $oldStatus) {
-            if ((int) $training->status < TrainingStatus::IN_QUEUE->value) {
+        if ($training->status !== $oldStatus) {
+            if ($training->status->isClosed()) {
                 $attributes['paused_at'] = null;
                 if (isset($training->paused_at)) {
                     TrainingActivityController::create($training->id, 'PAUSE', 0, null, Auth::id());
@@ -545,18 +529,18 @@ class TrainingController extends Controller
         $training->update($attributes);
 
         ActivityLogService::warning('TRAINING', 'Updated training details ' . $training->id .
-        ' ― Old Status: ' . TrainingController::$statuses[$oldStatus]['text'] .
-        ' ― New Status: ' . TrainingController::$statuses[$training->status]['text'] .
+        ' ― Old Status: ' . $oldStatus->label() .
+        ' ― New Status: ' . $training->status->label() .
         ' ― Mentor: ' . $training->mentors->pluck('name'));
 
         // Send e-mail and store endorsements rating (non-GRP ones), if it's a new status and it goes from active to closed
-        if ((int) $training->status != $oldStatus) {
-            if ((int) $training->status < TrainingStatus::IN_QUEUE->value) {
+        if ($training->status !== $oldStatus) {
+            if ($training->status->isClosed()) {
                 // Detach all mentors
                 $training->mentors()->detach();
 
                 // If the training was completed store the relevant endorsements
-                if ((int) $training->status == TrainingStatus::COMPLETED->value) {
+                if ($training->status === TrainingStatus::COMPLETED) {
                     foreach ($training->ratings as $rating) {
                         if ($rating->vatsim_rating == null) {
                             // Revoke the old endorsement if active
@@ -593,7 +577,7 @@ class TrainingController extends Controller
                 }
 
                 // If training is completed, let's set the user to active
-                if ((int) $training->status == TrainingStatus::COMPLETED->value) {
+                if ($training->status === TrainingStatus::COMPLETED) {
                     // atcActivityBasedOnTotalHours is false OR true and type is not familiarisation
                     if (! Setting::get('atcActivityBasedOnTotalHours') || Setting::get('atcActivityBasedOnTotalHours') && $training->type <= 4) {
 
@@ -619,12 +603,12 @@ class TrainingController extends Controller
                     }
                 }
 
-                $training->user->notify(new TrainingClosedNotification($training, (int) $training->status, $training->closed_reason));
+                $training->user->notify(new TrainingClosedNotification($training, $training->status, $training->closed_reason));
 
                 return redirect($training->path())->withSuccess('Training successfully closed. E-mail confirmation sent to the student.');
             }
 
-            if ((int) $training->status == TrainingStatus::PRE_TRAINING->value) {
+            if ($training->status === TrainingStatus::PRE_TRAINING) {
                 $training->user->notify(new TrainingPreStatusNotification($training));
 
                 return redirect($training->path())->withSuccess('Training successfully updated. E-mail confirmation of pre-training sent to the student.');
@@ -650,14 +634,14 @@ class TrainingController extends Controller
     {
         $this->authorize('close', $training);
         ActivityLogService::warning('TRAINING', 'Student closed training request ' . $training->id .
-        ' ― Status: ' . TrainingController::$statuses[$training->status]['text'] .
+        ' ― Status: ' . $training->status->label() .
         ' ― Training type: ' . TrainingController::$types[$training->type]['text']);
-        TrainingActivityController::create($training->id, 'STATUS', -3, $training->status, $training->user->id);
+        TrainingActivityController::create($training->id, 'STATUS', TrainingStatus::CLOSED_BY_STUDENT->value, $training->status->value, $training->user->id);
 
         $training->mentors()->detach();
-        $training->updateStatus(-3);
+        $training->updateStatus(TrainingStatus::CLOSED_BY_STUDENT);
 
-        $training->user->notify(new TrainingClosedNotification($training, (int) $training->status));
+        $training->user->notify(new TrainingClosedNotification($training, $training->status));
 
         return redirect($training->path())->withSuccess('Training successfully closed.');
     }
@@ -738,7 +722,7 @@ class TrainingController extends Controller
             return redirect()->back()->withErrors('An error occurred while fetching data from VATSIM. Please try again later.');
         }
 
-        if ($response->status() === 404 && $user->rating == VatsimRating::OBS->value) {
+        if ($response->status() === 404 && $user->rating === VatsimRating::OBS) {
             return 0;
         }
 
@@ -801,7 +785,7 @@ class TrainingController extends Controller
      */
     protected function validateUpdateDetails()
     {
-        return request()->validate([
+        $attributes = request()->validate([
             'experience' => 'sometimes|required|integer|min:1|max:6',
             'englishOnly' => 'nullable',
             'paused_at' => 'sometimes',
@@ -812,11 +796,17 @@ class TrainingController extends Controller
             'ratings' => 'sometimes|required',
             'ratings.*' => 'integer|exists:ratings,id',
             'training_area' => 'sometimes|required',
-            'status' => 'sometimes|required|integer',
+            'status' => ['sometimes', 'required', Rule::enum(TrainingStatus::class)],
             'type' => 'sometimes|integer',
             'mentors' => 'sometimes',
             'closed_reason' => 'sometimes|max:65',
         ]);
+
+        if (array_key_exists('status', $attributes)) {
+            $attributes['status'] = TrainingStatus::from((int) $attributes['status']);
+        }
+
+        return $attributes;
     }
 
     /**

--- a/app/Http/Controllers/TrainingExaminationController.php
+++ b/app/Http/Controllers/TrainingExaminationController.php
@@ -40,7 +40,7 @@ class TrainingExaminationController extends Controller
     public function create(Request $request, Training $training)
     {
         $this->authorize('create', [TrainingExamination::class, $training]);
-        if ($training->status != TrainingStatus::AWAITING_EXAM->value) {
+        if ($training->status !== TrainingStatus::AWAITING_EXAM) {
             return redirect(null, 400)->to($training->path())->withSuccess('Training examination cannot be created for a training not awaiting exam.');
         }
 
@@ -69,7 +69,7 @@ class TrainingExaminationController extends Controller
         $pass = strtolower($data['result']) == 'passed' ? true : false;
 
         // Attempt Division API sync first if the training has VATSIM ratings and it's an S2+ examination
-        if ($request->file('files') && $training->hasVatsimRatings() && $training->getHighestVatsimRating()->vatsim_rating >= VatsimRating::S2->value) {
+        if ($request->file('files') && $training->hasVatsimRatings() && $training->getHighestVatsimRating()->vatsim_rating->isGreaterThanOrEqual(VatsimRating::S2)) {
             foreach ($request->file('files') as $file) {
                 $response = DivisionApi::uploadExamResults($training->user->id, Auth::id(), $pass, $position->callsign, $file->getRealPath());
                 if ($response && $response->failed()) {

--- a/app/Http/Controllers/TrainingReportController.php
+++ b/app/Http/Controllers/TrainingReportController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Helpers\TrainingStatus;
 use App\Models\OneTimeLink;
 use App\Models\Position;
 use App\Models\Training;
@@ -50,7 +49,7 @@ class TrainingReportController extends Controller
     public function create(Request $request, Training $training)
     {
         $this->authorize('create', [TrainingReport::class, $training]);
-        if ($training->status < TrainingStatus::PRE_TRAINING->value) {
+        if (! $training->status->isInProgress()) {
             return redirect(null, 400)->back()->withErrors('Training report cannot be created for a training not in progress.');
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -147,7 +147,6 @@ class UserController extends Controller
         ]);
 
         $trainings = $user->trainings;
-        $statuses = TrainingController::$statuses;
         $types = TrainingController::$types;
         $endorsements = $user->endorsements->whereIn('type', ['EXAMINER', 'FACILITY', 'SOLO', 'VISITING'])->sortBy([['expired', 'asc'], ['revoked', 'asc']]);
 
@@ -211,7 +210,7 @@ class UserController extends Controller
             )
         );
 
-        return view('user.show', compact('user', 'roles', 'areas', 'trainings', 'statuses', 'types', 'endorsements', 'areas', 'divisionExams', 'atcActivityHours', 'totalHours', 'recentAtcSessions'));
+        return view('user.show', compact('user', 'roles', 'areas', 'trainings', 'types', 'endorsements', 'areas', 'divisionExams', 'atcActivityHours', 'totalHours', 'recentAtcSessions'));
     }
 
     /**

--- a/app/Http/Middleware/SuspendedUser.php
+++ b/app/Http/Middleware/SuspendedUser.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Helpers\VatsimRating;
 use Closure;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -19,7 +20,7 @@ class SuspendedUser
     {
         if (\Auth::check()) {
             $user = \Auth::user();
-            if ($user->rating == 0) {
+            if ($user->rating == VatsimRating::SUS) {
                 \Auth::logout();
 
                 return redirect('/')->with('error', 'Your account has been suspended.');

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -14,6 +14,10 @@ class Position extends Model
 
     public $timestamps = false;
 
+    protected $casts = [
+        'rating' => VatsimRating::class,
+    ];
+
     /**
      * Record creates, updates and deletes to the activity log under the "sector"
      * category, with a human-readable description identifying the position.
@@ -37,10 +41,6 @@ class Position extends Model
         'area_id',
     ];
 
-    protected $casts = [
-        'rating' => VatsimRating::class,
-    ];
-
     public function bookings()
     {
         return $this->belongsToMany(Booking::class, 'id', 'position_id');
@@ -59,21 +59,5 @@ class Position extends Model
     public function requiredRating()
     {
         return $this->belongsTo(Rating::class, 'required_facility_rating_id');
-    }
-
-    /**
-     * Get the name of the VATSIM rating for this position
-     */
-    public function getRatingNameAttribute()
-    {
-        return $this->rating->name;
-    }
-
-    /**
-     * Check if the position has the given base rating
-     */
-    public function hasBaseRating(VatsimRating $rating): bool
-    {
-        return $this->rating === $rating;
     }
 }

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Helpers\VatsimRating;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -10,6 +11,10 @@ class Rating extends Model
     use HasFactory;
 
     public $timestamps = false;
+
+    protected $casts = [
+        'vatsim_rating' => VatsimRating::class,
+    ];
 
     public function trainings()
     {

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Helpers\TrainingStatus;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -33,6 +34,7 @@ class Training extends Model
     protected $casts = [
         'started_at' => 'datetime',
         'closed_at' => 'datetime',
+        'status' => TrainingStatus::class,
     ];
 
     /**
@@ -46,10 +48,10 @@ class Training extends Model
     /**
      * Update the status of the training, keeping the related timestamps consistent.
      *
-     * @param  int  $newStatus  the new status to set
+     * @param  TrainingStatus  $newStatus  the new status to set
      * @param  bool  $expiredInterest  whether this update expired an interest request
      */
-    public function updateStatus(int $newStatus, bool $expiredInterest = false): void
+    public function updateStatus(TrainingStatus $newStatus, bool $expiredInterest = false): void
     {
         $changes = $this->resolveStatusChanges($newStatus, $expiredInterest);
 
@@ -68,26 +70,26 @@ class Training extends Model
      *
      * @return array<string, mixed>
      */
-    public function resolveStatusChanges(int $newStatus, bool $expiredInterest = false): array
+    public function resolveStatusChanges(TrainingStatus $newStatus, bool $expiredInterest = false): array
     {
         $oldStatus = $this->fresh()->status;
 
-        if ($newStatus == $oldStatus) {
+        if ($newStatus === $oldStatus) {
             return [];
         }
 
         $changes = ['status' => $newStatus];
 
         // Training was put back in queue
-        if ($newStatus == 0) {
+        if ($newStatus === TrainingStatus::IN_QUEUE) {
             $changes['started_at'] = null;
             $changes['closed_at'] = null;
         }
 
         // Training is active or completed
-        if ($newStatus >= 1 || $newStatus == -1) {
+        if ($newStatus->isInProgress() || $newStatus === TrainingStatus::COMPLETED) {
             // In case someone resurrects a closed training
-            if ($oldStatus < 0) {
+            if ($oldStatus->isClosed()) {
                 $changes['closed_at'] = null;
             }
 
@@ -99,7 +101,7 @@ class Training extends Model
         }
 
         // Training is completed or closed
-        if ($newStatus < 0) {
+        if ($newStatus->isClosed()) {
             $changes['closed_at'] = now();
 
             // Expire all related interests, as they only cause problems if the training is re-opened.
@@ -167,7 +169,10 @@ class Training extends Model
      */
     public function getHighestVatsimRating(): ?Rating
     {
-        return $this->ratings->whereNotNull('vatsim_rating')->sortByDesc('vatsim_rating')->first();
+        return $this->ratings
+            ->whereNotNull('vatsim_rating')
+            ->sortByDesc(fn (Rating $rating) => $rating->vatsim_rating->value)
+            ->first();
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use anlutro\LaravelSettings\Facade as Setting;
 use App\Exceptions\PolicyMethodMissingException;
 use App\Exceptions\PolicyMissingException;
+use App\Helpers\TrainingStatus;
+use App\Helpers\VatsimRating;
 use App\Services\PermissionMatrix;
 use App\Support\AreaScope;
 use Carbon\Carbon;
@@ -25,6 +27,7 @@ class User extends Authenticatable
         'last_login' => 'datetime',
         'last_activity' => 'datetime',
         'last_inactivity_warning' => 'datetime',
+        'rating' => VatsimRating::class,
     ];
 
     /**
@@ -267,48 +270,39 @@ class User extends Authenticatable
      */
     public static function getActiveAtcMembers(array $userIds = [])
     {
-        // Return S1+ users who are VATSCA members and active as ATC
-        if (! empty($userIds)) {
-            return User::whereIn('id', $userIds)
-                ->whereHas('atcActivity', function ($query) {
-                    $query->where('atc_active', true);
-                })->get();
-        } else {
-            return User::whereHas('atcActivity', function ($query) {
+        $query = User::where('rating', '>=', VatsimRating::S1->value)
+            ->whereHas('atcActivity', function ($query) {
                 $query->where('atc_active', true);
-            })->get();
+            });
+
+        if (! empty($userIds)) {
+            $query->whereIn('id', $userIds);
         }
+
+        return $query->get();
     }
 
     /**
-     * Fetch members that are active as ATC and associated with the division.
+     * Fetch members that are active as ATC and associated with the sub-/division.
      *
      * @return EloquentCollection<User>
      */
     public static function getAssociatedActiveAtcMembers(bool $onlyCheckActiveControllers = true, array $userIds = [])
     {
-        // Return S1+ users who are VATSCA members and active as ATC
+        $query = User::where('rating', '>=', VatsimRating::S1->value)
+            ->where(config('app.mode'), config('app.owner_code'));
+
         if (! empty($userIds)) {
-            $query = User::whereIn('id', $userIds)
-                ->where(config('app.mode'), config('app.owner_code'));
-
-            if ($onlyCheckActiveControllers) {
-                $query->whereHas('atcActivity', function ($query) {
-                    $query->where('atc_active', true);
-                });
-            }
-
-            return $query->get();
-        } else {
-            $query = User::where(config('app.mode'), config('app.owner_code'));
-            if ($onlyCheckActiveControllers) {
-                $query->whereHas('atcActivity', function ($query) {
-                    $query->where('atc_active', true);
-                });
-            }
-
-            return $query->get();
+            $query->whereIn('id', $userIds);
         }
+
+        if ($onlyCheckActiveControllers) {
+            $query->whereHas('atcActivity', function ($query) {
+                $query->where('atc_active', true);
+            });
+        }
+
+        return $query->get();
     }
 
     /**
@@ -348,7 +342,7 @@ class User extends Authenticatable
      */
     public function mentoringTrainings()
     {
-        $trainings = Training::where('status', '>=', 1)->whereHas('mentors', function ($query) {
+        $trainings = Training::where('status', '>=', TrainingStatus::PRE_TRAINING)->whereHas('mentors', function ($query) {
             $query->where('user_id', $this->id);
         })->with('area', 'ratings', 'reports', 'user')->orderBy('id')->get();
 
@@ -372,49 +366,36 @@ class User extends Authenticatable
     /**
      * Return whether or not the user has active trainings.
      * A area can be provided to check if the user has an active training in the specified area.
-     *
-     * @return bool
      */
-    public function hasActiveTrainings(bool $includeWaiting, ?Area $area = null)
+    public function hasActiveTrainings(bool $includeWaiting, ?Area $area = null): bool
     {
-        $statuses = $includeWaiting ? [0, 1, 2, 3] : [1, 2, 3];
+        $minStatus = $includeWaiting ? TrainingStatus::IN_QUEUE : TrainingStatus::PRE_TRAINING;
 
         if ($this->relationLoaded('trainings')) {
-            $trainings = $this->trainings;
-            if ($area) {
-                $trainings = $trainings->where('area_id', $area->id);
-            }
+            $trainings = $area ? $this->trainings->where('area_id', $area->id) : $this->trainings;
 
-            return $trainings->whereIn('status', $statuses)->isNotEmpty();
+            return $trainings->filter(fn (Training $t) => $t->status->isGreaterThanOrEqual($minStatus))->isNotEmpty();
         }
 
-        if ($includeWaiting) {
-            if ($area == null) {
-                return $this->trainings()->whereIn('status', [0, 1, 2, 3])->exists();
-            }
+        $query = $this->trainings()->where('status', '>=', $minStatus->value);
 
-            return $this->trainings()->where('area_id', $area->id)->whereIn('status', [0, 1, 2, 3])->exists();
-        } else {
-            if ($area == null) {
-                return $this->trainings()->whereIn('status', [1, 2, 3])->exists();
-            }
-
-            return $this->trainings()->where('area_id', $area->id)->whereIn('status', [1, 2, 3])->exists();
+        if ($area) {
+            $query->where('area_id', $area->id);
         }
+
+        return $query->exists();
     }
 
     /**
      * Return the active training for the user
-     *
-     * @return Training|null
      */
-    public function getActiveTraining(int $minStatus = 0, ?Area $area = null)
+    public function getActiveTraining(TrainingStatus $minStatus = TrainingStatus::IN_QUEUE, ?Area $area = null): ?Training
     {
         if ($area == null) {
-            return $this->trainings()->where([['status', '>=', $minStatus]])->get()->first();
+            return $this->trainings()->where([['status', '>=', $minStatus->value]])->first();
         }
 
-        return $this->trainings()->where([['status', '>=', $minStatus], ['area_id', '=', $area->id]])->get()->first();
+        return $this->trainings()->where([['status', '>=', $minStatus->value], ['area_id', '=', $area->id]])->first();
     }
 
     /**
@@ -454,7 +435,7 @@ class User extends Authenticatable
      */
     public function hasRecentlyCompletedTraining()
     {
-        $training = $this->trainings->where('status', -1)->where('closed_at', '>', Carbon::now()->subDays(7))->first();
+        $training = $this->trainings->where('status', TrainingStatus::COMPLETED)->where('closed_at', '>', Carbon::now()->subDays(7))->first();
 
         if ($training == null || $training->isFacilityTraining() || $training->type != 1) {
             return false;

--- a/app/Notifications/TrainingClosedNotification.php
+++ b/app/Notifications/TrainingClosedNotification.php
@@ -3,7 +3,6 @@
 namespace App\Notifications;
 
 use App\Helpers\TrainingStatus;
-use App\Http\Controllers\TrainingController;
 use App\Mail\TrainingMail;
 use App\Models\Area;
 use App\Models\Feedback;
@@ -26,16 +25,13 @@ class TrainingClosedNotification extends Notification implements ShouldQueue
     private $reason;
 
     /**
-     * Create a new notification instance.
-     *
-     * @param  int|null  $closedBy  the training status code that indicates who closed it
      * @param  string|null  $reason  optional reason of closure communicated to the receiver
      */
-    public function __construct(Training $training, int $trainingStatus, ?string $reason = null)
+    public function __construct(Training $training, TrainingStatus $trainingStatus, ?string $reason = null)
     {
         $this->training = $training;
         $this->trainingStatus = $trainingStatus;
-        $this->closedBy = strtolower(TrainingController::$statuses[$trainingStatus]['text']);
+        $this->closedBy = strtolower($trainingStatus->label());
         $this->reason = $reason;
     }
 
@@ -69,7 +65,7 @@ class TrainingClosedNotification extends Notification implements ShouldQueue
         $feedback = $area->feedback_url;
 
         // If the training was completed and the area has a readme or feedback url to be added.
-        if ($this->trainingStatus == TrainingStatus::COMPLETED->value) {
+        if ($this->trainingStatus === TrainingStatus::COMPLETED) {
             if (isset($readme)) {
                 $textLines[] = 'Please familiarise yourself with [these instructions](' . $readme . ') prior to your first connection with your new rating.';
             }

--- a/app/Policies/BookingPolicy.php
+++ b/app/Policies/BookingPolicy.php
@@ -31,9 +31,9 @@ class BookingPolicy
     public function create(User $user)
     {
         return
-            $user->isAtcActive() && $user->rating >= VatsimRating::S1->value
+            $user->isAtcActive() && $user->rating->isGreaterThanOrEqual(VatsimRating::S1)
             || $user->hasActiveEndorsement('VISITING')
-            || $user->getActiveTraining(TrainingStatus::PRE_TRAINING->value) != null
+            || $user->getActiveTraining(TrainingStatus::PRE_TRAINING) != null
             || $user->hasPermission('bookings.manage');
     }
 
@@ -79,7 +79,7 @@ class BookingPolicy
             return true;
         }
 
-        return $user->rating >= VatsimRating::S1->value && $user->hasActiveTrainings(includeWaiting: false);
+        return $user->rating->isGreaterThanOrEqual(VatsimRating::S1) && $user->hasActiveTrainings(includeWaiting: false);
     }
 
     /**
@@ -87,7 +87,7 @@ class BookingPolicy
      */
     public function bookEventTag(User $user): bool
     {
-        return ($user->isMember() || $user->isVisiting()) && $user->rating >= VatsimRating::S1->value;
+        return ($user->isMember() || $user->isVisiting()) && $user->rating->isGreaterThanOrEqual(VatsimRating::S1);
     }
 
     /**
@@ -98,7 +98,7 @@ class BookingPolicy
     public function bookExamTag(User $user): bool
     {
 
-        return $user->isMember() && ($user->rating >= VatsimRating::C1->value || $user->hasPermission('bookings.manage'));
+        return $user->isMember() && ($user->rating->isGreaterThanOrEqual(VatsimRating::C1) || $user->hasPermission('bookings.manage'));
     }
 
     /**
@@ -109,10 +109,10 @@ class BookingPolicy
     public function position(User $user, Booking $booking)
     {
         // TODO: Make it easier to read the order of checks
-        if (($booking->position->rating->value > $user->rating || $user->rating < VatsimRating::S1->value) && ! $user->hasPermission('bookings.manage')) {
+        if (($booking->position->rating->isGreaterThan($user->rating) || $user->rating->isLessThan(VatsimRating::S1)) && ! $user->hasPermission('bookings.manage')) {
             if (
-                $user->getActiveTraining(TrainingStatus::PRE_TRAINING->value) &&
-                $user->getActiveTraining()->getHighestVatsimRating()?->vatsim_rating >= $booking->position->rating->value &&
+                $user->getActiveTraining(TrainingStatus::PRE_TRAINING) &&
+                $user->getActiveTraining()->getHighestVatsimRating()?->vatsim_rating?->isGreaterThanOrEqual($booking->position->rating) &&
                 $user->getActiveTraining()->area->id === $booking->position->area->id
             ) {
                 return true;

--- a/app/Policies/OneTimeLinkPolicy.php
+++ b/app/Policies/OneTimeLinkPolicy.php
@@ -22,7 +22,7 @@ class OneTimeLinkPolicy
     {
         // Only allow examination link generation if the training is awaiting exam
         if ($type == OneTimeLink::TRAINING_EXAMINATION_TYPE) {
-            return $training->status == TrainingStatus::AWAITING_EXAM->value && ($training->mentors->contains($user) || $user->hasPermission('training.update', $training->area));
+            return $training->status === TrainingStatus::AWAITING_EXAM && ($training->mentors->contains($user) || $user->hasPermission('training.update', $training->area));
         }
 
         return $training->mentors->contains($user) || $user->hasPermission('training.update', $training->area);

--- a/app/Policies/TrainingPolicy.php
+++ b/app/Policies/TrainingPolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use anlutro\LaravelSettings\Facade as Setting;
 use App\Helpers\TrainingStatus;
+use App\Helpers\VatsimRating;
 use App\Models\Area;
 use App\Models\Training;
 use App\Models\User;
@@ -53,7 +54,7 @@ class TrainingPolicy
      */
     public function close(User $user, Training $training)
     {
-        return $user->is($training->user) && $training->status == TrainingStatus::IN_QUEUE->value;
+        return $user->is($training->user) && $training->status === TrainingStatus::IN_QUEUE;
     }
 
     /**
@@ -63,7 +64,7 @@ class TrainingPolicy
      */
     public function togglePreTrainingCompleted(User $user, Training $training)
     {
-        return $training->status == TrainingStatus::PRE_TRAINING->value &&
+        return $training->status === TrainingStatus::PRE_TRAINING &&
                 ($training->pre_training_completed == false || $user->hasPermission('training.update', $training->area));
     }
 
@@ -104,7 +105,7 @@ class TrainingPolicy
         }
 
         // Not active users are forced to ask for a manual creation of refresh
-        if (! $user->hasActiveTrainings(true) && $user->rating > 1 && ! $user->isAtcActive()) {
+        if (! $user->hasActiveTrainings(true) && $user->rating->isGreaterThan(VatsimRating::OBS) && ! $user->isAtcActive()) {
             return Response::deny("Your ATC rating is inactive in {$divisionName}");
         }
 

--- a/app/Services/BookingService.php
+++ b/app/Services/BookingService.php
@@ -47,19 +47,22 @@ class BookingService
         // Users with a rating of S1 or above can book positions up to their rating
         $positions = new Collection();
 
-        if ($user->rating >= VatsimRating::S1->value) {
+        if ($user->rating->isGreaterThanOrEqual(VatsimRating::S1)) {
             if (Setting::get('atcActivityBasedOnTotalHours')) {
-                $positions = Position::where('rating', '<=', $user->rating)->get();
+                $positions = Position::where('rating', '<=', $user->rating->value)->get();
             } else {
                 $activeAreas = $user->atcActivity->pluck('area_id');
-                $positionsInAreas = Position::whereIn('area_id', $activeAreas)->where('rating', '<=', $user->rating)->get();
+                $positionsInAreas = Position::whereIn('area_id', $activeAreas)->where('rating', '<=', $user->rating->value)->get();
                 $positions = $positions->merge($positionsInAreas);
             }
         }
 
-        if ($user->getActiveTraining(TrainingStatus::PRE_TRAINING->value)) {
+        if ($user->getActiveTraining(TrainingStatus::PRE_TRAINING)) {
+            $highestRating = $user->getActiveTraining()->getHighestVatsimRating()?->vatsim_rating;
             $positions = $positions->merge(
-                $user->getActiveTraining()->area->positions->where('rating', '<=', $user->getActiveTraining()->getHighestVatsimRating()?->vatsim_rating)
+                $user->getActiveTraining()->area->positions->filter(
+                    fn (Position $position) => $highestRating !== null && $position->rating->isLessThanOrEqual($highestRating)
+                )
             );
         }
 
@@ -145,7 +148,7 @@ class BookingService
             return false;
         }
 
-        if ($booking->position->rating->value > $bookingUser->rating) {
+        if ($booking->position->rating->isGreaterThan($bookingUser->rating)) {
             return true;
         }
 

--- a/app/Services/DivisionApi/Adapters/VATEUD.php
+++ b/app/Services/DivisionApi/Adapters/VATEUD.php
@@ -100,7 +100,7 @@ class VATEUD implements DivisionApiContract
     public function assignExaminer(User $user, Rating $rating, int $requesterId)
     {
         // Only assign if the user is S3 or higher, this is VATEUD's definition of examiner
-        if ($user->rating >= VatsimRating::S3->value) {
+        if ($user->rating->isGreaterThanOrEqual(VatsimRating::S3)) {
             return $this->callApi('/facility/training/assign/' . $user->id . '/examiner', 'POST', [
                 'user_cid' => $requesterId,
             ]);
@@ -117,7 +117,7 @@ class VATEUD implements DivisionApiContract
     public function removeExaminer(User $user, Endorsement $endorsement, int $requesterId)
     {
         // Only revoke if the endorsement rating is S3 or higher, this is VATEUD's definition of examiner
-        if ($endorsement->ratings->first()->vatsim_rating >= VatsimRating::S3->value) {
+        if ($endorsement->ratings->first()->vatsim_rating->isGreaterThanOrEqual(VatsimRating::S3)) {
             return $this->callApi('/facility/training/remove/' . $user->id . '/examiner', 'POST', [
                 'user_cid' => $requesterId,
             ]);

--- a/app/Traits/ComparableIntEnum.php
+++ b/app/Traits/ComparableIntEnum.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Traits;
+
+trait ComparableIntEnum
+{
+    public function isGreaterThan(self $other): bool
+    {
+        return $this->value > $other->value;
+    }
+
+    public function isGreaterThanOrEqual(self $other): bool
+    {
+        return $this->value >= $other->value;
+    }
+
+    public function isLessThan(self $other): bool
+    {
+        return $this->value < $other->value;
+    }
+
+    public function isLessThanOrEqual(self $other): bool
+    {
+        return $this->value <= $other->value;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,9 @@
         ],
         "phpstan": [
             "./vendor/bin/phpstan analyse --memory-limit=512M"
+        ],
+        "ide-helper": [
+            "@php artisan ide-helper:generate"
         ]
     }
 }

--- a/database/factories/PositionFactory.php
+++ b/database/factories/PositionFactory.php
@@ -31,7 +31,7 @@ class PositionFactory extends Factory
                 $this->faker->randomElement([0, 5, 10, 15, 25, 30, 35, 40, 50, 55, 60, 65, 75, 80, 85, 90])
             ),
             'fir' => strtoupper($this->faker->lexify('????')),
-            'rating' => $this->faker->randomElement(VatsimRating::getControllerRatings()),
+            'rating' => $this->faker->randomElement(VatsimRating::CONTROLLER_RATINGS),
             'area_id' => Area::factory(),
         ];
     }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Helpers\FactoryHelper;
+use App\Helpers\VatsimRating;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -39,7 +40,7 @@ class UserFactory extends Factory
 
         // users rating id
 
-        $rating = $this->faker->numberBetween(1, 12);
+        $rating = $this->faker->randomElement(VatsimRating::CONTROLLER_RATINGS);
 
         return [
             'first_name' => fake()->firstName(),
@@ -47,7 +48,7 @@ class UserFactory extends Factory
             'email' => fake()->unique()->safeEmail(),
 
             'rating' => $rating,
-            'rating_short' => FactoryHelper::shortRating($rating),
+            'rating_short' => $rating->name,
             'rating_long' => FactoryHelper::longRating($rating),
 
             'region' => $region,

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Helpers\FactoryHelper;
 use App\Helpers\TrainingStatus;
+use App\Helpers\VatsimRating;
 use App\Models\Endorsement;
 use App\Models\Feedback;
 use App\Models\Position;
@@ -99,7 +100,7 @@ class DatabaseSeeder extends Seeder
                 'last_name' => $name_last,
                 'rating' => $rating_id,
                 'rating_short' => FactoryHelper::shortRating($rating_id),
-                'rating_long' => FactoryHelper::longRating($rating_id),
+                'rating_long' => FactoryHelper::longRating(VatsimRating::from($rating_id)),
                 'region' => 'EMEA',
                 'division' => 'EUD',
                 'subdivision' => 'SCA',

--- a/resources/views/admin/positions/index.blade.php
+++ b/resources/views/admin/positions/index.blade.php
@@ -59,13 +59,13 @@
                                 @foreach ($positions as $position)
                                     <tr data-callsign="{{ $position->callsign }}" data-name="{{ $position->name }}"
                                         data-frequency="{{ $position->frequency }}" data-fir="{{ $position->fir }}"
-                                        data-rating_name="{{ $position->rating_name }}"
+                                        data-rating_name="{{ $position->rating->name }}"
                                         data-area_name="{{ $position->area->name }}">
                                         <td><span class="badge bg-primary">{{ $position->callsign }}</span></td>
                                         <td>{{ $position->name }}</td>
                                         <td><code>{{ $position->frequency }}</code></td>
                                         <td>{{ $position->fir }}</td>
-                                        <td>{{ $position->rating_name }}</td>
+                                        <td>{{ $position->rating->name }}</td>
                                         <td>{{ $position->requiredRating ? $position->requiredRating->name : 'N/A' }}</td>
                                         <td>{{ $position->area->name }}</td>
                                         <td class="text-nowrap">
@@ -186,7 +186,7 @@
                                             <input type="radio" class="btn-check"
                                                 id="edit_rating_{{ $position->id }}_{{ $rating->name }}" name="rating"
                                                 value="{{ $rating->value }}"
-                                                {{ $position->hasBaseRating($rating) ? 'checked' : '' }}>
+                                                {{ $position->rating == $rating ? 'checked' : '' }}>
                                             <label class="btn btn-outline-primary"
                                                 for="edit_rating_{{ $position->id }}_{{ $rating->name }}">{{ $rating->name }}</label>
                                         @endforeach

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -174,7 +174,7 @@
                                 </td>
                                 <td>{{ $training->area->name }}</td>
                                 <td>
-                                    <i class="{{ $statuses[$training->status]["icon"] }} text-{{ $statuses[$training->status]["color"] }}"></i>&ensp;{{ $statuses[$training->status]["text"] }}{{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
+                                    <i class="{{ $training->status->icon() }} text-{{ $training->status->color() }}"></i>&ensp;{{ $training->status->label() }}{{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
                                 </td>
                                 <td>
                                     @if($training->reports->count() > 0)
@@ -184,13 +184,13 @@
                                         @endphp
                                         <span title="{{ $reportDate->toEuropeanDate() }}">
                                             @if($reportDate->isToday())
-                                            <span class="{{ ($trainingIntervalExceeded && $training->status != \App\Helpers\TrainingStatus::AWAITING_EXAM->value && !$training->paused_at) ? 'text-danger' : '' }}">Today</span>
+                                            <span class="{{ ($trainingIntervalExceeded && $training->status !== \App\Helpers\TrainingStatus::AWAITING_EXAM && !$training->paused_at) ? 'text-danger' : '' }}">Today</span>
                                             @elseif($reportDate->isYesterday())
-                                            <span class="{{ ($trainingIntervalExceeded && $training->status != \App\Helpers\TrainingStatus::AWAITING_EXAM->value && !$training->paused_at) ? 'text-danger' : '' }}">Yesterday</span>
+                                            <span class="{{ ($trainingIntervalExceeded && $training->status !== \App\Helpers\TrainingStatus::AWAITING_EXAM && !$training->paused_at) ? 'text-danger' : '' }}">Yesterday</span>
                                             @elseif($reportDate->diffInDays() <= 7)
-                                            <span class="{{ ($trainingIntervalExceeded && $training->status != \App\Helpers\TrainingStatus::AWAITING_EXAM->value && !$training->paused_at) ? 'text-danger' : '' }}">{{ $reportDate->diffForHumans(['parts' => 1]) }}</span>
+                                            <span class="{{ ($trainingIntervalExceeded && $training->status !== \App\Helpers\TrainingStatus::AWAITING_EXAM && !$training->paused_at) ? 'text-danger' : '' }}">{{ $reportDate->diffForHumans(['parts' => 1]) }}</span>
                                             @else
-                                            <span class="{{ ($trainingIntervalExceeded && $training->status != \App\Helpers\TrainingStatus::AWAITING_EXAM->value && !$training->paused_at) ? 'text-danger' : '' }}">{{ $reportDate->diffForHumans(['parts' => 2]) }}</span>
+                                            <span class="{{ ($trainingIntervalExceeded && $training->status !== \App\Helpers\TrainingStatus::AWAITING_EXAM && !$training->paused_at) ? 'text-danger' : '' }}">{{ $reportDate->diffForHumans(['parts' => 2]) }}</span>
                                             @endif
                                             
                                         </span>
@@ -256,7 +256,7 @@
                                     @endif
                                 </td>
                                 <td>
-                                    <i class="{{ $statuses[$training->status]["icon"] }} text-{{ $statuses[$training->status]["color"] }}"></i>&ensp;{{ $statuses[$training->status]["text"] }}{{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
+                                    <i class="{{ $training->status->icon() }} text-{{ $training->status->color() }}"></i>&ensp;{{ $training->status->label() }}{{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
                                 </td>
                             </tr>
                             @endforeach

--- a/resources/views/mentor/index.blade.php
+++ b/resources/views/mentor/index.blade.php
@@ -40,7 +40,7 @@
                             @foreach($trainings as $training)
                             <tr>
                                 <td>
-                                    <i class="{{ $statuses[$training->status]["icon"] }} text-{{ $statuses[$training->status]["color"] }}"></i>&ensp;<a href="/training/{{ $training->id }}">{{ $statuses[$training->status]["text"] }}</a>{{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
+                                    <i class="{{ $training->status->icon() }} text-{{ $training->status->color() }}"></i>&ensp;<a href="/training/{{ $training->id }}">{{ $training->status->label() }}</a>{{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
                                 </td>
                                 @can('users.manage')
                                     <td><a href="{{ route('user.show', $training->user->id) }}">{{ $training->user->id }}</a></td>
@@ -88,13 +88,13 @@
 
                                         <span title="{{ $reportDate->toEuropeanDate() }}">
                                             @if($reportDate->isToday())
-                                            <span class="{{ ($trainingIntervalExceeded && $training->status != \App\Helpers\TrainingStatus::AWAITING_EXAM->value && !$training->paused_at) ? 'text-danger' : '' }}">Today</span>
+                                            <span class="{{ ($trainingIntervalExceeded && $training->status !== \App\Helpers\TrainingStatus::AWAITING_EXAM && !$training->paused_at) ? 'text-danger' : '' }}">Today</span>
                                             @elseif($reportDate->isYesterday())
-                                            <span class="{{ ($trainingIntervalExceeded && $training->status != \App\Helpers\TrainingStatus::AWAITING_EXAM->value && !$training->paused_at) ? 'text-danger' : '' }}">Yesterday</span>
+                                            <span class="{{ ($trainingIntervalExceeded && $training->status !== \App\Helpers\TrainingStatus::AWAITING_EXAM && !$training->paused_at) ? 'text-danger' : '' }}">Yesterday</span>
                                             @elseif($reportDate->diffInDays() <= 7)
-                                            <span class="{{ ($trainingIntervalExceeded && $training->status != \App\Helpers\TrainingStatus::AWAITING_EXAM->value && !$training->paused_at) ? 'text-danger' : '' }}">{{ $reportDate->diffForHumans(['parts' => 1]) }}</span>
+                                            <span class="{{ ($trainingIntervalExceeded && $training->status !== \App\Helpers\TrainingStatus::AWAITING_EXAM && !$training->paused_at) ? 'text-danger' : '' }}">{{ $reportDate->diffForHumans(['parts' => 1]) }}</span>
                                             @else
-                                            <span class="{{ ($trainingIntervalExceeded && $training->status != \App\Helpers\TrainingStatus::AWAITING_EXAM->value && !$training->paused_at) ? 'text-danger' : '' }}">{{ $reportDate->diffForHumans(['parts' => 2]) }}</span>
+                                            <span class="{{ ($trainingIntervalExceeded && $training->status !== \App\Helpers\TrainingStatus::AWAITING_EXAM && !$training->paused_at) ? 'text-danger' : '' }}">{{ $reportDate->diffForHumans(['parts' => 2]) }}</span>
                                             @endif
                                             
                                         </span>

--- a/resources/views/reports/activities.blade.php
+++ b/resources/views/reports/activities.blade.php
@@ -53,7 +53,7 @@
                             @foreach($entries as $activity)
                                 <tr>
                                     <td>
-                                        <i class="{{ $statuses[$activity->training->status]["icon"] }} text-{{  $statuses[$activity->training->status]["color"] }}"></i>
+                                        <i class="{{ $activity->training->status->icon() }} text-{{ $activity->training->status->color() }}"></i>
                                         <a href="{{ route('training.show', $activity->training) }}">{{ $activity->training->user->name }}'s {{ $activity->training->getInlineRatings() }}</a>
                                     </td>
                                     <td>
@@ -93,12 +93,12 @@
 
                                             @if($activity->type == "STATUS")
                                                 @if(($activity->new_data == -2 || $activity->new_data == -4) && isset($activity->comment))
-                                                    Status changed from <span class="badge text-bg-light text-primary">{{ \App\Http\Controllers\TrainingController::$statuses[$activity->old_data]["text"] }}</span>
-                                                to <span class="badge text-bg-light">{{ \App\Http\Controllers\TrainingController::$statuses[$activity->new_data]["text"] }}</span>
+                                                    Status changed from <span class="badge text-bg-light text-primary">{{ \App\Helpers\TrainingStatus::from((int) $activity->old_data)->label() }}</span>
+                                                to <span class="badge text-bg-light">{{ \App\Helpers\TrainingStatus::from((int) $activity->new_data)->label() }}</span>
                                                 with reason <span class="badge text-bg-light">{{ $activity->comment }}</span>
                                                 @else
-                                                    Status changed from <span class="badge text-bg-light">{{ \App\Http\Controllers\TrainingController::$statuses[$activity->old_data]["text"] }}</span>
-                                                to <span class="badge text-bg-light">{{ \App\Http\Controllers\TrainingController::$statuses[$activity->new_data]["text"] }}</span>
+                                                    Status changed from <span class="badge text-bg-light">{{ \App\Helpers\TrainingStatus::from((int) $activity->old_data)->label() }}</span>
+                                                to <span class="badge text-bg-light">{{ \App\Helpers\TrainingStatus::from((int) $activity->new_data)->label() }}</span>
                                                 @endif
                                             @elseif($activity->type == "TYPE")
                                                 Training type changed from <span class="badge text-bg-light">{{ \App\Http\Controllers\TrainingController::$types[$activity->old_data]["text"] }}</span>

--- a/resources/views/reports/mentors.blade.php
+++ b/resources/views/reports/mentors.blade.php
@@ -70,7 +70,7 @@
                                         @foreach($mentor->teaches as $training)
                                             <div>
 
-                                                <i class="{{ $statuses[$training->status]["icon"] }} text-{{  $statuses[$training->status]["color"] }}"></i>
+                                                <i class="{{ $training->status->icon() }} text-{{ $training->status->color() }}"></i>
                                                 @isset($training->paused_at)
                                                     <i class="fas fa-pause"></i>
                                                 @endisset
@@ -84,13 +84,13 @@
                                                     @endphp
                                                     <span data-bs-toggle="tooltip" data-bs-placement="top" title="{{ $reportDate->toEuropeanDate() }}">
                                                         @if($reportDate->isToday())
-                                                            <span class="{{ ($trainingIntervalExceeded && $training->status != \App\Helpers\TrainingStatus::AWAITING_EXAM->value && !$training->paused_at) ? 'text-danger' : '' }}">Today</span>
+                                                            <span class="{{ ($trainingIntervalExceeded && $training->status !== \App\Helpers\TrainingStatus::AWAITING_EXAM && !$training->paused_at) ? 'text-danger' : '' }}">Today</span>
                                                         @elseif($reportDate->isYesterday())
-                                                            <span class="{{ ($trainingIntervalExceeded && $training->status != \App\Helpers\TrainingStatus::AWAITING_EXAM->value && !$training->paused_at) ? 'text-danger' : '' }}">Yesterday</span>
+                                                            <span class="{{ ($trainingIntervalExceeded && $training->status !== \App\Helpers\TrainingStatus::AWAITING_EXAM && !$training->paused_at) ? 'text-danger' : '' }}">Yesterday</span>
                                                         @elseif($reportDate->diffInDays() <= 7)
-                                                            <span class="{{ ($trainingIntervalExceeded && $training->status != \App\Helpers\TrainingStatus::AWAITING_EXAM->value && !$training->paused_at) ? 'text-danger' : '' }}">{{ $reportDate->diffForHumans(['parts' => 1]) }}</span>
+                                                            <span class="{{ ($trainingIntervalExceeded && $training->status !== \App\Helpers\TrainingStatus::AWAITING_EXAM && !$training->paused_at) ? 'text-danger' : '' }}">{{ $reportDate->diffForHumans(['parts' => 1]) }}</span>
                                                         @else
-                                                            <span class="{{ ($trainingIntervalExceeded && $training->status != \App\Helpers\TrainingStatus::AWAITING_EXAM->value && !$training->paused_at) ? 'text-danger' : '' }}">{{ $reportDate->diffForHumans(['parts' => 2]) }}</span>
+                                                            <span class="{{ ($trainingIntervalExceeded && $training->status !== \App\Helpers\TrainingStatus::AWAITING_EXAM && !$training->paused_at) ? 'text-danger' : '' }}">{{ $reportDate->diffForHumans(['parts' => 2]) }}</span>
                                                         @endif                                        
                                                     </span>
                                                 @else

--- a/resources/views/training/history.blade.php
+++ b/resources/views/training/history.blade.php
@@ -43,11 +43,10 @@
                             </tr>
                         </thead>
                         <tbody>
-
                             @foreach($closedTrainings as $training)
                             <tr>
                                 <td>
-                                    <i class="{{ $statuses[$training->status]["icon"] }} text-{{ $statuses[$training->status]["color"] }}"></i>&ensp;<a href="/training/{{ $training->id }}">{{ $statuses[$training->status]["text"] }}</a> {{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
+                                    <i class="{{ $training->status->icon() }} text-{{ $training->status->color() }}"></i>&ensp;<a href="/training/{{ $training->id }}">{{ $training->status->label() }}</a> {{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
                                 </td>
                                 <td><a href="{{ route('user.show', $training->user->id) }}">{{ $training->user->id }}</a></td>
                                 <td><a href="{{ route('user.show', $training->user->id) }}">{{ $training->user->name }}</a></td>

--- a/resources/views/training/index.blade.php
+++ b/resources/views/training/index.blade.php
@@ -51,8 +51,8 @@
                             @foreach($openTrainings as $training)
                             <tr>
                                 <td>
-                                    <i class="{{ $statuses[$training->status]["icon"] }} text-{{ $statuses[$training->status]["color"] }}"></i>
-                                    @if($training->status == \App\Helpers\TrainingStatus::PRE_TRAINING->value && $training->pre_training_completed )
+                                    <i class="{{ $training->status->icon() }} text-{{ $training->status->color() }}"></i>
+                                    @if($training->status === \App\Helpers\TrainingStatus::PRE_TRAINING && $training->pre_training_completed)
                                         <i class="fas fa-check text-success"></i>
                                     @endif
 
@@ -73,11 +73,11 @@
                                             data-bs-placement="right" 
                                             title="{{ str_replace(["\r\n", "\r", "\n"], '&#013;', $notes) }}"
                                             >
-                                            {{ $statuses[$training->status]["text"] }}
+                                            {{ $training->status->label() }}
                                         </a>
                                     @else
                                         <a href="/training/{{ $training->id }}">
-                                            {{ $statuses[$training->status]["text"] }}
+                                            {{ $training->status->label() }}
                                         </a>
                                     @endif
                                     

--- a/resources/views/training/show.blade.php
+++ b/resources/views/training/show.blade.php
@@ -17,7 +17,7 @@
 @endsection
 @section('content')
 
-@if($training->status < \App\Helpers\TrainingStatus::COMPLETED->value && $training->status != \App\Helpers\TrainingStatus::CLOSED_BY_STUDENT->value)
+@if($training->status === \App\Helpers\TrainingStatus::CLOSED_BY_SYSTEM || $training->status === \App\Helpers\TrainingStatus::CLOSED_BY_STAFF)
     <div class="alert alert-warning" role="alert">
         <b>Training is closed with reason: </b>
         @if(isset($training->closed_reason))
@@ -28,7 +28,7 @@
     </div>
 @endif
 
-@if($training->status == \App\Helpers\TrainingStatus::CLOSED_BY_STUDENT->value)
+@if($training->status === \App\Helpers\TrainingStatus::CLOSED_BY_STUDENT)
     <div class="alert alert-warning" role="alert">
         <b>Training closed by student</b>
     </div>
@@ -78,11 +78,11 @@
                 <dl class="copyable">
                     <dt>State</dt>
                     <dd>
-                        <i class="{{ $statuses[$training->status]["icon"] }} text-{{ $statuses[$training->status]["color"] }}"></i>
-                        @if($training->status == \App\Helpers\TrainingStatus::PRE_TRAINING->value && $training->pre_training_completed )
+                        <i class="{{ $training->status->icon() }} text-{{ $training->status->color() }}"></i>
+                        @if($training->status === \App\Helpers\TrainingStatus::PRE_TRAINING && $training->pre_training_completed)
                             <i class="fas fa-check text-success"></i>
                         @endif
-                        {{ $statuses[$training->status]["text"] }}
+                        {{ $training->status->label() }}
                         {{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
                     </dd>
 
@@ -175,13 +175,9 @@
 
                             <label class="form-label" for="trainingStateSelect">Select training state</label>
                             <select class="form-select" name="status" id="trainingStateSelect" @if(Auth::user()->cannot('update', $training)) disabled @endif>
-                                @foreach($statuses as $id => $data)
-                                    @if($data["assignableByStaff"])
-                                        @if($id == $training->status)
-                                            <option value="{{ $id }}" selected>{{ $data["text"] }}</option>
-                                        @else
-                                            <option value="{{ $id }}">{{ $data["text"] }}</option>
-                                        @endif
+                                @foreach(\App\Helpers\TrainingStatus::cases() as $status)
+                                    @if($status->isAssignableByStaff())
+                                        <option value="{{ $status->value }}" @selected($training->status === $status)>{{ $status->label() }}</option>
                                     @endif
                                 @endforeach
                             </select>
@@ -284,12 +280,12 @@
 
                                     @if($activity->type == "STATUS")
                                         @if(($activity->new_data == -2 || $activity->new_data == -4) && isset($activity->comment))
-                                            Status changed from <span class="badge text-bg-light">{{ \App\Http\Controllers\TrainingController::$statuses[$activity->old_data]["text"] }}</span>
-                                        to <span class="badge text-bg-light">{{ \App\Http\Controllers\TrainingController::$statuses[$activity->new_data]["text"] }}</span>
+                                            Status changed from <span class="badge text-bg-light">{{ \App\Helpers\TrainingStatus::from((int) $activity->old_data)->label() }}</span>
+                                        to <span class="badge text-bg-light">{{ \App\Helpers\TrainingStatus::from((int) $activity->new_data)->label() }}</span>
                                         with reason <span class="badge text-bg-light">{{ $activity->comment }}</span>
                                         @else
-                                            Status changed from <span class="badge text-bg-light">{{ \App\Http\Controllers\TrainingController::$statuses[$activity->old_data]["text"] }}</span>
-                                        to <span class="badge text-bg-light">{{ \App\Http\Controllers\TrainingController::$statuses[$activity->new_data]["text"] }}</span>
+                                            Status changed from <span class="badge text-bg-light">{{ \App\Helpers\TrainingStatus::from((int) $activity->old_data)->label() }}</span>
+                                        to <span class="badge text-bg-light">{{ \App\Helpers\TrainingStatus::from((int) $activity->new_data)->label() }}</span>
                                         @endif
                                     @elseif($activity->type == "TYPE")
                                         Training type changed from <span class="badge text-bg-light">{{ \App\Http\Controllers\TrainingController::$types[$activity->old_data]["text"] }}</span>
@@ -419,7 +415,7 @@
         <div class="card shadow mb-4 ">
             <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
 
-                @if($training->status >= \App\Helpers\TrainingStatus::PRE_TRAINING->value && $training->status <= \App\Helpers\TrainingStatus::AWAITING_EXAM->value)
+                @if($training->status->isInProgress())
                     <h6 class="m-0 fw-bold text-white">
                 @else
                     <h6 class="m-0 mt-1 mb-2 fw-bold text-white">
@@ -430,7 +426,7 @@
                 @if(
                     \Auth::user()->can('create', [\App\Models\OneTimeLink::class, $training, \App\Models\OneTimeLink::TRAINING_REPORT_TYPE]) ||
                     \Auth::user()->can('create', [\App\Models\OneTimeLink::class, $training, \App\Models\OneTimeLink::TRAINING_EXAMINATION_TYPE]) ||
-                    ($training->status >= \App\Helpers\TrainingStatus::PRE_TRAINING->value && $training->status <= \App\Helpers\TrainingStatus::AWAITING_EXAM->value)
+                    $training->status->isInProgress()
                 )
                     <div class="dropdown" style="display: inline;">
                         <button class="btn btn-light btn-icon dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -439,7 +435,7 @@
                     
                         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                             @can('create', [\App\Models\TrainingReport::class, $training])
-                                @if($training->status >= \App\Helpers\TrainingStatus::PRE_TRAINING->value)
+                                @if($training->status->isInProgress())
                                     <a class="dropdown-item" href="{{ route('training.report.create', ['training' => $training->id]) }}"><i class="fas fa-file"></i> Training Report</a>
                                 @endif
                             @else
@@ -447,7 +443,7 @@
                             @endcan
 
                             @can('create', [\App\Models\TrainingExamination::class, $training])
-                                @if($training->status == \App\Helpers\TrainingStatus::AWAITING_EXAM->value)
+                                @if($training->status === \App\Helpers\TrainingStatus::AWAITING_EXAM)
                                     <a class="dropdown-item" href="{{ route('training.examination.create', ['training' => $training->id]) }}"><i class="fas fa-file"></i> Exam Report</a>
                                 @endif
                             @else

--- a/resources/views/user/index.blade.php
+++ b/resources/views/user/index.blade.php
@@ -45,7 +45,7 @@
                                         <td>{{ $user['name_first'] }}</td>
                                         <td>{{ $user['name_last'] }}</td>
                                         <td>Yes</td>
-                                        <td>{{ App\Helpers\VatsimRating::from($user['rating'])->name }}</td>
+                                        <td>{{ \App\Helpers\VatsimRating::from($user['rating'])->name }}</td>
                                         <td><i class="fas fa-{{ $user['active'] ? 'check' : 'times' }}"></i> {{ $user['active'] ? 'Yes' : 'No' }}</td>
                                         <td>{{ isset($user['hours']) ? round($user['hours']) : 'N/A' }}</td>
                                         <td>{{ isset($user['lastratingchange']) ? Carbon\Carbon::create($user['lastratingchange'])->toEuropeanDate() : 'N/A' }}</td>
@@ -55,7 +55,7 @@
                                         <td>{{ $user['name_first'] }}</td>
                                         <td>{{ $user['name_last'] }}</td>
                                         <td>No</td>
-                                        <td>{{ App\Helpers\VatsimRating::from($user['rating'])->name }}</td>
+                                        <td>{{ \App\Helpers\VatsimRating::from($user['rating'])->name }}</td>
                                         <td>N/A</td>
                                         <td>N/A</td>
                                         <td>{{ isset($user['lastratingchange']) ? Carbon\Carbon::create($user['lastratingchange'])->toEuropeanDate() : 'N/A' }}</td>

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -213,7 +213,7 @@
                                         @foreach($trainings as $training)
                                         <tr>
                                             <td>
-                                                <i class="{{ $statuses[$training->status]["icon"] }} text-{{ $statuses[$training->status]["color"] }}"></i>&ensp;<a href="/training/{{ $training->id }}">{{ $statuses[$training->status]["text"] }}</a>{{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
+                                                <i class="{{ $training->status->icon() }} text-{{ $training->status->color() }}"></i>&ensp;<a href="/training/{{ $training->id }}">{{ $training->status->label() }}</a>{{ isset($training->paused_at) ? ' (PAUSED)' : '' }}
                                             </td>
                                             <td>
                                                 @if ( is_iterable($ratings = $training->ratings->toArray()) )

--- a/tests/Feature/BookingTest.php
+++ b/tests/Feature/BookingTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
+use anlutro\LaravelSettings\Facade as Setting;
 use App\Helpers\VatsimRating;
+use App\Http\Middleware\ApiToken;
 use App\Models\Area;
 use App\Models\Booking;
 use App\Models\Endorsement;
@@ -10,6 +12,7 @@ use App\Models\Position;
 use App\Models\Rating;
 use App\Models\Training;
 use App\Models\User;
+use App\Services\BookingService;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -64,7 +67,7 @@ class BookingTest extends TestCase
     public function controllers_with_activity_can_create_bookings(VatsimRating $rating, callable $setup): void
     {
         $controller = User::factory()->create([
-            'rating' => $rating->value,
+            'rating' => $rating,
         ]);
 
         $controller->atcActivity()->create([
@@ -80,17 +83,17 @@ class BookingTest extends TestCase
         // If there's training available, let's try to create a booking for the training
         if ($highestTraining) {
             $rating = $highestTraining->getHighestVatsimRating()->vatsim_rating;
-            $position = Position::with('area')->where('rating', '<=', $rating)
+            $position = Position::with('area')->where('rating', '<=', $rating->value)
                 ->whereBelongsTo($controller->atcActivity->first()->area)
                 ->whereNotNull('name')->orderByDesc('rating')->first();
-            $this->assertGreaterThan($controller->rating, $rating);
+            $this->assertTrue($rating->isGreaterThan($controller->rating));
             $this->assertCreateBookingAvailable($controller, $position);
             $this->createBooking($controller, $position)->assertValid()->assertSeeText('training tag');
         }
 
         $rating = $controller->rating;
         // Select a high position given the status we have
-        $position = Position::with('area')->where('rating', '<=', $rating)
+        $position = Position::with('area')->where('rating', '<=', $rating->value)
             ->whereBelongsTo($controller->atcActivity->first()->area)
             ->whereNotNull('name')->inRandomOrder()->orderByDesc('rating')->first();
         $this->assertCreateBookingAvailable($controller, $position);
@@ -241,7 +244,7 @@ class BookingTest extends TestCase
     public function controller_cannot_create_booking_with_same_start_and_end_time(): void
     {
         $controller = User::factory()->create([
-            'rating' => VatsimRating::C1->value,
+            'rating' => VatsimRating::C1,
         ]);
 
         $controller->atcActivity()->create([
@@ -306,6 +309,118 @@ class BookingTest extends TestCase
         $booking = Booking::factory()->create(['user_id' => User::factory()->create()->id, 'source' => 'CC']);
 
         $this->assertFalse($mentor->can('update', $booking));
+    }
+
+    #[Test]
+    public function should_force_training_tag_returns_true_when_position_rating_exceeds_user_rating(): void
+    {
+        $area = Area::factory()->create();
+
+        $position = Position::factory()->create([
+            'area_id' => $area->id,
+            'rating' => VatsimRating::S2->value,
+        ]);
+
+        $booking = Booking::factory()->create([
+            'position_id' => $position->id,
+        ]);
+
+        $user = User::factory()->create(['rating' => VatsimRating::S1->value]);
+
+        $service = new BookingService();
+        $result = $service->shouldForceTrainingTag($booking, $position, $user);
+
+        $this->assertTrue($result);
+    }
+
+    #[Test]
+    public function get_bookable_positions_returns_positions_for_s1_rated_user(): void
+    {
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $area = Area::factory()->create();
+        $position = Position::factory()->create([
+            'area_id' => $area->id,
+            'rating' => VatsimRating::S1->value,
+        ]);
+
+        $user = User::factory()->create(['rating' => VatsimRating::S1->value]);
+        $user->atcActivity()->create([
+            'user_id' => $user->id,
+            'area_id' => $area->id,
+            'atc_active' => true,
+            'hours' => 20,
+        ]);
+
+        $service = new BookingService();
+        $positions = $service->getBookablePositions($user);
+
+        $this->assertNotEmpty($positions);
+        $this->assertTrue($positions->contains('id', $position->id));
+    }
+
+    #[Test]
+    public function api_store_booking_forces_training_tag_when_position_rating_exceeds_user(): void
+    {
+        $area = Area::factory()->create();
+        $s2Position = Position::factory()->create([
+            'area_id' => $area->id,
+            'rating' => VatsimRating::S2->value,
+            'callsign' => 'TEST_GND',
+        ]);
+        $s1User = User::factory()->create(['rating' => VatsimRating::S1->value]);
+
+        $startDate = Carbon::tomorrow()->addHours(10);
+        $response = $this->withoutMiddleware(ApiToken::class)->postJson(route('api.booking.store'), [
+            'cid' => $s1User->id,
+            'date' => $startDate->format('d/m/Y'),
+            'start_at' => '10:00',
+            'end_at' => '12:00',
+            'position' => $s2Position->callsign,
+            'source' => 'TEST',
+        ]);
+
+        $response->assertSuccessful();
+        $this->assertDatabaseHas('bookings', [
+            'position_id' => $s2Position->id,
+            'training' => 1,
+        ]);
+    }
+
+    #[Test]
+    public function api_update_booking_forces_training_tag_when_position_rating_exceeds_user(): void
+    {
+        $area = Area::factory()->create();
+        $s2Position = Position::factory()->create([
+            'area_id' => $area->id,
+            'rating' => VatsimRating::S2->value,
+            'callsign' => 'TEST_TWR',
+        ]);
+        $s1User = User::factory()->create(['rating' => VatsimRating::S1->value]);
+
+        $startDate = Carbon::tomorrow()->addHours(10);
+        $booking = Booking::factory()->create([
+            'user_id' => $s1User->id,
+            'position_id' => $s2Position->id,
+            'callsign' => $s2Position->callsign,
+            'time_start' => $startDate->copy()->subHours(3),
+            'time_end' => $startDate->copy()->subHours(1),
+        ]);
+
+        $response = $this->withoutMiddleware(ApiToken::class)->patchJson(route('api.booking.update', $booking), [
+            'cid' => $s1User->id,
+            'date' => $startDate->format('d/m/Y'),
+            'start_at' => '10:00',
+            'end_at' => '12:00',
+            'position' => $s2Position->callsign,
+        ]);
+
+        $response->assertSuccessful();
+        $this->assertDatabaseHas('bookings', [
+            'id' => $booking->id,
+            'position_id' => $s2Position->id,
+            'training' => 1,
+        ]);
     }
 
     #[Test]

--- a/tests/Feature/TrainingExaminationsTest.php
+++ b/tests/Feature/TrainingExaminationsTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Helpers\TrainingStatus;
+use App\Helpers\VatsimRating;
 use App\Models\Area;
 use App\Models\Endorsement;
 use App\Models\OneTimeLink;
@@ -13,6 +15,7 @@ use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Notification;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -421,5 +424,70 @@ class TrainingExaminationsTest extends TestCase
         $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $otherArea->id]);
 
         $this->assertFalse($moderator->can('view', $examination));
+    }
+
+    #[Test]
+    public function create_exam_is_accessible_when_training_awaiting_exam(): void
+    {
+        $this->training->update(['status' => TrainingStatus::AWAITING_EXAM->value]);
+
+        $response = $this->actingAs($this->examiner)
+            ->get(route('training.examination.create', $this->training));
+
+        $response->assertStatus(200);
+    }
+
+    #[Test]
+    public function create_exam_is_blocked_when_training_not_awaiting_exam(): void
+    {
+        $this->training->update(['status' => TrainingStatus::ACTIVE_TRAINING->value]);
+
+        $response = $this->actingAs($this->examiner)
+            ->get(route('training.examination.create', $this->training));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success', 'Training examination cannot be created for a training not awaiting exam.');
+    }
+
+    #[Test]
+    public function store_exam_does_not_crash_for_s2_rated_training(): void
+    {
+        // Ensure training is in AWAITING_EXAM status and has an S2 VATSIM rating
+        $this->training->update(['status' => TrainingStatus::AWAITING_EXAM->value]);
+
+        // Attach an S2 rating to the training
+        $rating = Rating::factory()->create(['vatsim_rating' => VatsimRating::S2->value]);
+        $this->training->ratings()->attach($rating->id);
+
+        $file = UploadedFile::fake()->create('exam.pdf', 100, 'application/pdf');
+
+        // Create a position belonging to the same area as the training
+        $position = Position::factory()->create(['area_id' => $this->training->area_id]);
+
+        $response = $this->actingAs($this->examiner)
+            ->post(route('training.examination.store', $this->training), [
+                'examination_date' => now()->format('d/m/Y'),
+                'position' => $position->callsign,
+                'result' => 'FAILED',
+                'files' => [$file],
+            ]);
+
+        // Should not throw a TypeError — any redirect (pass or fail) is acceptable
+        $response->assertRedirect();
+    }
+
+    #[Test]
+    public function examiner_can_create_examination_link_for_awaiting_exam_training(): void
+    {
+        $this->training->update(['status' => TrainingStatus::AWAITING_EXAM->value]);
+        $this->training->mentors()->attach($this->examiner->id, ['expire_at' => now()->addMonths(6)]);
+
+        $response = $this->actingAs($this->examiner)
+            ->post(route('training.onetimelink.store', $this->training), [
+                'type' => OneTimeLink::TRAINING_EXAMINATION_TYPE,
+            ]);
+
+        // Should not be forbidden — the policy gate should pass
+        $response->assertRedirect();
     }
 }

--- a/tests/Feature/TrainingReportsTest.php
+++ b/tests/Feature/TrainingReportsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Helpers\TrainingStatus;
 use App\Models\Area;
 use App\Models\OneTimeLink;
 use App\Models\Training;
@@ -298,6 +299,20 @@ class TrainingReportsTest extends TestCase
 
         $this->assertDatabaseHas('training_reports', ['id' => $report->id]);
         $this->assertDatabaseHas('training_reports', ['id' => $ownReport->id]);
+    }
+
+    #[Test]
+    public function create_report_returns_error_for_queued_training(): void
+    {
+        $training = Training::factory()->create([
+            'user_id' => User::factory()->create()->id,
+            'status' => TrainingStatus::IN_QUEUE->value,
+        ]);
+        $mentor = $this->makeMentor($training);
+
+        $this->actingAs($mentor)
+            ->get(route('training.report.create', $training))
+            ->assertSessionHasErrors();
     }
 
     #[Test]

--- a/tests/Feature/TrainingsTest.php
+++ b/tests/Feature/TrainingsTest.php
@@ -2,19 +2,59 @@
 
 namespace Tests\Feature;
 
+use anlutro\LaravelSettings\Facade as Setting;
+use App\Helpers\TrainingStatus;
 use App\Helpers\VatsimRating;
 use App\Models\Area;
+use App\Models\AtcActivity;
 use App\Models\Rating;
 use App\Models\Training;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class TrainingsTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
+
+    private Training $training;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->training = Training::factory()->create([
+            'user_id' => User::factory()->create()->id,
+        ]);
+    }
+
+    #[Test]
+    public function student_can_close_their_in_queue_training(): void
+    {
+        Notification::fake();
+        $this->training->update(['status' => TrainingStatus::IN_QUEUE->value]);
+
+        $response = $this->actingAs($this->training->user)
+            ->get(route('training.action.close', $this->training));
+
+        $response->assertRedirect();
+        $this->training->refresh();
+        $this->assertEquals(TrainingStatus::CLOSED_BY_STUDENT, $this->training->status);
+    }
+
+    #[Test]
+    public function student_cannot_close_active_training(): void
+    {
+        $this->training->update(['status' => TrainingStatus::ACTIVE_TRAINING->value]);
+
+        $response = $this->actingAs($this->training->user)
+            ->get(route('training.action.close', $this->training));
+
+        $response->assertForbidden();
+    }
 
     //    #[Test]
     //    public function user_can_create_a_training_request()
@@ -61,6 +101,26 @@ class TrainingsTest extends TestCase
             ->assertSeeText('Rating Upgrade')
             ->assertSeeText('Theoretical Exam Access')
             ->assertSee('for <b>TST-S2</b> rating', false);
+    }
+
+    #[Test]
+    public function get_highest_vatsim_rating_returns_rating_with_highest_vatsim_rating(): void
+    {
+        $training = Training::factory()->create([
+            'user_id' => User::factory()->create()->id,
+        ]);
+
+        // Attach two ratings with different VATSIM ratings to the training
+        $ratingS1 = Rating::factory()->create(['vatsim_rating' => VatsimRating::S1->value]);
+        $ratingS2 = Rating::factory()->create(['vatsim_rating' => VatsimRating::S2->value]);
+
+        $training->ratings()->attach([$ratingS1->id, $ratingS2->id]);
+        $training->load('ratings'); // Reload relation
+
+        $highest = $training->getHighestVatsimRating();
+
+        $this->assertNotNull($highest);
+        $this->assertEquals(VatsimRating::S2, $highest->vatsim_rating);
     }
 
     #[Test]
@@ -240,5 +300,73 @@ class TrainingsTest extends TestCase
             ->assertStatus(302);
 
         $this->assertNotTrue($training->mentors->contains($mentor));
+    }
+
+    #[Test]
+    public function obs_user_gets_zero_vatsim_hours_on_api_404(): void
+    {
+        Http::fake([
+            'api.vatsim.net/*' => Http::response([], 404),
+        ]);
+
+        Setting::set('trainingEnabled', true);
+        Setting::set('trainingSubDivisions', 'SCA');
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $obsUser = User::factory()->create([
+            'rating' => VatsimRating::OBS->value,
+            'division' => config('app.owner_code'),
+            'subdivision' => 'SCA',
+        ]);
+
+        $response = $this->actingAs($obsUser)->get(route('training.apply'));
+
+        // With the fix, the page loads without an error redirect
+        $response->assertSuccessful();
+    }
+
+    #[Test]
+    public function apply_page_shows_available_ratings_for_s1_user(): void
+    {
+        Http::fake([
+            'api.vatsim.net/*' => Http::response(['s1' => 10], 200),
+        ]);
+
+        Setting::set('trainingEnabled', true);
+        Setting::set('trainingSubDivisions', 'SCA');
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $area = Area::factory()->create();
+        $rating = Rating::factory()->create(['vatsim_rating' => VatsimRating::S2->value]);
+
+        // Attach to area with required_vatsim_rating = S1 (value 2) so an S1 user qualifies
+        $area->ratings()->attach($rating->id, [
+            'required_vatsim_rating' => VatsimRating::S1->value,
+            'allow_bundling' => false,
+            'hour_requirement' => 0,
+            'queue_length_low' => 0,
+            'queue_length_high' => 0,
+        ]);
+
+        $s1User = User::factory()->create([
+            'rating' => VatsimRating::S1->value,
+            'division' => config('app.owner_code'),
+            'subdivision' => 'SCA',
+        ]);
+
+        // S1 user needs to be ATC active to pass TrainingPolicy (S1 > OBS triggers the check)
+        AtcActivity::create([
+            'user_id' => $s1User->id,
+            'area_id' => $area->id,
+            'atc_active' => true,
+            'hours' => 0,
+            'hours_in_period' => 0,
+        ]);
+
+        $response = $this->actingAs($s1User)->get(route('training.apply'));
+
+        $response->assertSuccessful();
+        // The S2 rating should appear as available for the S1 user
+        $response->assertSee($rating->name);
     }
 }

--- a/tests/Feature/UpdateAtcHoursTest.php
+++ b/tests/Feature/UpdateAtcHoursTest.php
@@ -55,7 +55,7 @@ class UpdateAtcHoursTest extends TestCase
             'rating' => 4,
         ]);
 
-        $user = User::factory()->create(['rating' => VatsimRating::C1->value]);
+        $user = User::factory()->create(['rating' => VatsimRating::C1]);
 
         Config::set('app.mode', 'division');
         Config::set('app.owner_code', 'VATSCA');

--- a/tests/Feature/UpdateQueueCalculationTest.php
+++ b/tests/Feature/UpdateQueueCalculationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Helpers\TrainingStatus;
+use App\Models\Area;
+use App\Models\Rating;
+use App\Models\Training;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class UpdateQueueCalculationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function command_records_wait_time_for_in_queue_trainings(): void
+    {
+        // Create a user
+        $user = User::factory()->create();
+
+        // Create an area and a rating with vatsim_rating
+        $area = Area::factory()->create();
+        $rating = Rating::factory()->create(['vatsim_rating' => 2]); // S1
+
+        // Link area and rating together
+        $area->ratings()->attach($rating->id);
+
+        // Create 4 IN_QUEUE trainings in the same area, all with the same rating
+        for ($i = 0; $i < 4; $i++) {
+            $training = Training::factory()->create([
+                'user_id' => $user->id,
+                'status' => TrainingStatus::IN_QUEUE->value,
+                'area_id' => $area->id,
+                'created_at' => now()->subDays(10),
+                'paused_at' => null,
+                'paused_length' => 0,
+            ]);
+            // Attach rating to training
+            $training->ratings()->attach($rating->id);
+        }
+
+        // Verify before running the command: queue_length_low/high should be null (or not set)
+        $pivotBefore = $area->ratings()->where('rating_id', $rating->id)->first()->pivot;
+        $this->assertNull($pivotBefore->queue_length_low);
+        $this->assertNull($pivotBefore->queue_length_high);
+
+        // Run the command
+        $this->artisan('update:queuecalculation')->assertExitCode(0);
+
+        // Verify that queue_length_low and queue_length_high are now recorded (non-null and > 0)
+        $pivotAfter = $area->ratings()->where('rating_id', $rating->id)->first()->pivot;
+        $this->assertNotNull($pivotAfter->queue_length_low, 'queue_length_low should be recorded for 4 IN_QUEUE trainings');
+        $this->assertNotNull($pivotAfter->queue_length_high, 'queue_length_high should be recorded for 4 IN_QUEUE trainings');
+        $this->assertGreaterThan(0, $pivotAfter->queue_length_low, 'queue_length_low should be > 0');
+        $this->assertGreaterThan(0, $pivotAfter->queue_length_high, 'queue_length_high should be > 0');
+    }
+}

--- a/tests/Feature/VATEUDAdapterTest.php
+++ b/tests/Feature/VATEUDAdapterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Helpers\VatsimRating;
+use App\Models\Endorsement;
+use App\Models\Rating;
+use App\Models\User;
+use App\Services\DivisionApi\Adapters\VATEUD;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class VATEUDAdapterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function remove_examiner_calls_api_for_s3_rated_endorsement(): void
+    {
+        Http::fake([
+            '*' => Http::response(['status' => 'ok'], 200),
+        ]);
+
+        $user = User::factory()->create();
+        $requester = User::factory()->create();
+
+        $rating = Rating::factory()->create(['vatsim_rating' => VatsimRating::S3->value]);
+        $endorsement = Endorsement::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'EXAMINER',
+        ]);
+        $endorsement->ratings()->attach($rating->id);
+        $endorsement->load('ratings');
+
+        $adapter = new VATEUD();
+        $result = $adapter->removeExaminer($user, $endorsement, $requester->id);
+
+        $this->assertNotFalse($result);
+    }
+
+    #[Test]
+    public function remove_examiner_calls_api_for_c1_rated_endorsement(): void
+    {
+        Http::fake([
+            '*' => Http::response(['status' => 'ok'], 200),
+        ]);
+
+        $user = User::factory()->create();
+        $requester = User::factory()->create();
+
+        // C1 (value 5) is higher than S3 (value 4), so the API should be called
+        $rating = Rating::factory()->create(['vatsim_rating' => VatsimRating::C1->value]);
+        $endorsement = Endorsement::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'EXAMINER',
+        ]);
+        $endorsement->ratings()->attach($rating->id);
+        $endorsement->load('ratings');
+
+        $adapter = new VATEUD();
+        $result = $adapter->removeExaminer($user, $endorsement, $requester->id);
+
+        $this->assertNotFalse($result);
+    }
+
+    #[Test]
+    public function remove_examiner_skips_api_for_s2_rated_endorsement(): void
+    {
+        $user = User::factory()->create();
+        $requester = User::factory()->create();
+
+        $rating = Rating::factory()->create(['vatsim_rating' => VatsimRating::S2->value]);
+        $endorsement = Endorsement::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'EXAMINER',
+        ]);
+        $endorsement->ratings()->attach($rating->id);
+        $endorsement->load('ratings');
+
+        $adapter = new VATEUD();
+        $result = $adapter->removeExaminer($user, $endorsement, $requester->id);
+
+        $this->assertFalse($result);
+    }
+}

--- a/tests/Unit/TrainingStatusTest.php
+++ b/tests/Unit/TrainingStatusTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Helpers\TrainingStatus;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class TrainingStatusTest extends TestCase
+{
+    #[Test]
+    public function label_returns_human_readable_text(): void
+    {
+        $this->assertSame('In queue', TrainingStatus::IN_QUEUE->label());
+        $this->assertSame('Active training', TrainingStatus::ACTIVE_TRAINING->label());
+        $this->assertSame('Closed by system', TrainingStatus::CLOSED_BY_SYSTEM->label());
+        $this->assertSame('Awaiting exam', TrainingStatus::AWAITING_EXAM->label());
+    }
+
+    #[Test]
+    public function color_returns_bootstrap_color_class(): void
+    {
+        $this->assertSame('danger', TrainingStatus::CLOSED_BY_SYSTEM->color());
+        $this->assertSame('success', TrainingStatus::COMPLETED->color());
+        $this->assertSame('warning', TrainingStatus::IN_QUEUE->color());
+        $this->assertSame('info', TrainingStatus::PRE_TRAINING->color());
+    }
+
+    #[Test]
+    public function icon_returns_fa_class_string(): void
+    {
+        $this->assertSame('fas fa-graduation-cap', TrainingStatus::AWAITING_EXAM->icon());
+        $this->assertSame('fas fa-check', TrainingStatus::COMPLETED->icon());
+    }
+
+    #[Test]
+    public function is_assignable_by_staff_returns_false_for_system_closed_statuses(): void
+    {
+        $this->assertFalse(TrainingStatus::CLOSED_BY_SYSTEM->isAssignableByStaff());
+        $this->assertFalse(TrainingStatus::CLOSED_BY_STUDENT->isAssignableByStaff());
+    }
+
+    #[Test]
+    public function is_assignable_by_staff_returns_true_for_staff_assignable_statuses(): void
+    {
+        $this->assertTrue(TrainingStatus::CLOSED_BY_STAFF->isAssignableByStaff());
+        $this->assertTrue(TrainingStatus::IN_QUEUE->isAssignableByStaff());
+        $this->assertTrue(TrainingStatus::ACTIVE_TRAINING->isAssignableByStaff());
+    }
+}


### PR DESCRIPTION
After adding Eloquent enum casts, the codebase still treated training
statuses and VATSIM ratings as raw integers — magic numbers like -4,
->value comparisons in PHP logic, == instead of ===, and hardcoded
integer lists that would silently exclude any new cases.

TrainingStatus gains domain predicates (isOpen, isClosed, isInProgress)
and display helpers (label, color, icon, isAssignableByStaff). Ordering
comparisons are extracted into a shared ComparableIntEnum trait used by
both enums. updateStatus/resolveStatusChanges are promoted from int to
TrainingStatus, eliminating raw integer literals at every call site.

All PHP-level comparisons across controllers, models, policies, commands,
notifications, and Blade templates are updated to use these methods.
DB query sites and TrainingActivityController::create(?int) arguments
retain ->value where the boundary requires it.

Tests covering the new enum behaviour, booking logic, examination flows,
and queue calculation are added alongside.

## Summary by Sourcery

Replace raw integer training statuses and VATSIM ratings with strongly-typed enums across the application, centralizing status display metadata and rating comparisons while tightening related policies and flows.

New Features:
- Expose enum-based helpers on TrainingStatus for labels, colors, icons and staff-assignability to drive UI and logging.
- Introduce a ComparableIntEnum trait for consistent, type-safe ordering comparisons on TrainingStatus and VatsimRating.
- Cast user, position, rating and training model fields to VatsimRating and TrainingStatus enums for domain-level semantics in business logic.

Enhancements:
- Refactor controllers, policies, services, notifications, console commands and Blade views to use enum predicates and comparison helpers instead of magic integers for training and rating logic.
- Simplify mentor, dashboard, report and API views by removing controller-level status maps and relying on enum-derived metadata.
- Adjust factory and seeder helpers to generate and describe ratings via the VatsimRating enum rather than numeric codes.

Build:
- Add a composer script for generating IDE helper metadata to support enum-based model casting.

Tests:
- Add feature tests covering training close behavior, available ratings on apply, booking training tag enforcement, bookable positions, and examination flows under the new enum semantics.
- Add tests for queue length calculation for in-queue trainings and VATEUD adapter behavior for examiner assignment/removal based on rating thresholds.
- Add unit tests for TrainingStatus helper methods to validate labels, colors, icons and staff-assignability.