### PR TITLE
fix(psql): Training interest expiry should be stored as integer

### DIFF
--- a/app/Console/Commands/SendTrainingInterestNotifications.php
+++ b/app/Console/Commands/SendTrainingInterestNotifications.php
@@ -8,6 +8,7 @@ use App\Models\Training;
 use App\Models\TrainingInterest;
 use App\Notifications\TrainingClosedNotification;
 use App\Notifications\TrainingInterestNotification;
+use App\Helpers\InterestStatus;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 
@@ -69,7 +70,7 @@ class SendTrainingInterestNotifications extends Command
                 $requestConfirmed = $lastInterestRequest->confirmed_at;
                 $requestUpdated = $lastInterestRequest->updated_at;
 
-                if ($requestDeadline->diffInMinutes(now(), false) >= 0 && $requestConfirmed == null && $lastInterestRequest->expired == false) {
+                if ($requestDeadline->diffInMinutes(now(), false) >= 0 && $requestConfirmed == null && $lastInterestRequest->expired === InterestStatus::NOT_EXPIRED->value) {
                     // If it's 14 days passed deadline, close the training
                     $this->info('Closing training ' . $training->id);
 
@@ -85,7 +86,7 @@ class SendTrainingInterestNotifications extends Command
                     $training->save();
                     $training->user->notify(new TrainingClosedNotification($training, TrainingStatus::CLOSED_BY_SYSTEM, 'Continued training interest was not confirmed within deadline.'));
                     TrainingActivityController::create($training->id, 'STATUS', TrainingStatus::CLOSED_BY_SYSTEM->value, $oldStatus->value, null, 'Continued training interest was not confirmed within deadline.');
-                } elseif ($requestDeadline->diffInDays(now(), true) == 6 && $requestUpdated->diffInDays(now(), true) != 0 && $lastInterestRequest->expired == false && $requestConfirmed == null) {
+                } elseif ($requestDeadline->diffInDays(now(), true) == 6 && $requestUpdated->diffInDays(now(), true) != 0 && $lastInterestRequest->expired === InterestStatus::NOT_EXPIRED->value && $requestConfirmed == null) {
                     // If the interest is not confirmed after 6 days, we remind
                     $this->info('Reminding training ' . $training->id);
 
@@ -93,7 +94,7 @@ class SendTrainingInterestNotifications extends Command
                     $lastInterestRequest->save();
 
                     $training->user->notify(new TrainingInterestNotification($training, $lastInterestRequest, true));
-                } elseif ($lastInterestRequest->created_at->diffInDays(now(), true) >= 30 && $lastInterestRequest->expired == true) {
+                } elseif ($lastInterestRequest->created_at->diffInDays(now(), true) >= 30 && $lastInterestRequest->expired !== InterestStatus::NOT_EXPIRED->value) {
                     // The training has been previously notified, after 30 days it's time for a new request
                     // Generate training interest key and store it in the request
                     $key = sha1($training->id . now()->format('Ymd_His') . rand(0, 9999));

--- a/app/Console/Commands/SendTrainingInterestNotifications.php
+++ b/app/Console/Commands/SendTrainingInterestNotifications.php
@@ -2,13 +2,13 @@
 
 namespace App\Console\Commands;
 
+use App\Helpers\InterestStatus;
 use App\Helpers\TrainingStatus;
 use App\Http\Controllers\TrainingActivityController;
 use App\Models\Training;
 use App\Models\TrainingInterest;
 use App\Notifications\TrainingClosedNotification;
 use App\Notifications\TrainingInterestNotification;
-use App\Helpers\InterestStatus;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 

--- a/app/Console/Commands/SendTrainingInterestNotifications.php
+++ b/app/Console/Commands/SendTrainingInterestNotifications.php
@@ -70,7 +70,7 @@ class SendTrainingInterestNotifications extends Command
                 $requestConfirmed = $lastInterestRequest->confirmed_at;
                 $requestUpdated = $lastInterestRequest->updated_at;
 
-                if ($requestDeadline->diffInMinutes(now(), false) >= 0 && $requestConfirmed == null && $lastInterestRequest->expired === InterestStatus::NOT_EXPIRED->value) {
+                if ($requestDeadline->diffInMinutes(now(), false) >= 0 && $requestConfirmed == null && $lastInterestRequest->expired === InterestStatus::NOT_EXPIRED) {
                     // If it's 14 days passed deadline, close the training
                     $this->info('Closing training ' . $training->id);
 
@@ -86,7 +86,7 @@ class SendTrainingInterestNotifications extends Command
                     $training->save();
                     $training->user->notify(new TrainingClosedNotification($training, TrainingStatus::CLOSED_BY_SYSTEM, 'Continued training interest was not confirmed within deadline.'));
                     TrainingActivityController::create($training->id, 'STATUS', TrainingStatus::CLOSED_BY_SYSTEM->value, $oldStatus->value, null, 'Continued training interest was not confirmed within deadline.');
-                } elseif ($requestDeadline->diffInDays(now(), true) == 6 && $requestUpdated->diffInDays(now(), true) != 0 && $lastInterestRequest->expired === InterestStatus::NOT_EXPIRED->value && $requestConfirmed == null) {
+                } elseif ($requestDeadline->diffInDays(now(), true) == 6 && $requestUpdated->diffInDays(now(), true) != 0 && $lastInterestRequest->expired === InterestStatus::NOT_EXPIRED && $requestConfirmed == null) {
                     // If the interest is not confirmed after 6 days, we remind
                     $this->info('Reminding training ' . $training->id);
 
@@ -94,7 +94,7 @@ class SendTrainingInterestNotifications extends Command
                     $lastInterestRequest->save();
 
                     $training->user->notify(new TrainingInterestNotification($training, $lastInterestRequest, true));
-                } elseif ($lastInterestRequest->created_at->diffInDays(now(), true) >= 30 && $lastInterestRequest->expired !== InterestStatus::NOT_EXPIRED->value) {
+                } elseif ($lastInterestRequest->created_at->diffInDays(now(), true) >= 30 && $lastInterestRequest->expired !== InterestStatus::NOT_EXPIRED) {
                     // The training has been previously notified, after 30 days it's time for a new request
                     // Generate training interest key and store it in the request
                     $key = sha1($training->id . now()->format('Ymd_His') . rand(0, 9999));

--- a/app/Helpers/InterestStatus.php
+++ b/app/Helpers/InterestStatus.php
@@ -5,7 +5,8 @@ namespace App\Helpers;
 /**
  * Enum representing the status of a training interest.
  */
-enum InterestStatus: int {
+enum InterestStatus: int
+{
     case NOT_EXPIRED = 0;
     case CLOSED = 1;
     case EXPIRED = 2;

--- a/app/Helpers/InterestStatus.php
+++ b/app/Helpers/InterestStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Helpers;
+
+/**
+ * Enum representing the status of a training interest.
+ */
+enum InterestStatus: int {
+    case NOT_EXPIRED = 0;
+    case CLOSED = 1;
+    case EXPIRED = 2;
+}

--- a/app/Helpers/InterestStatus.php
+++ b/app/Helpers/InterestStatus.php
@@ -2,11 +2,14 @@
 
 namespace App\Helpers;
 
+use App\Traits\ComparableIntEnum;
+
 /**
  * Enum representing the status of a training interest.
  */
 enum InterestStatus: int
 {
+    use ComparableIntEnum;
     case NOT_EXPIRED = 0;
     case CLOSED = 1;
     case EXPIRED = 2;

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use anlutro\LaravelSettings\Facade as Setting;
 use App;
+use App\Helpers\InterestStatus;
 use App\Helpers\VatsimRating;
 use App\Models\TrainingInterest;
 use App\Models\TrainingReport;
@@ -55,7 +56,7 @@ class DashboardController extends Controller
         $trainings = $user->trainings;
         $types = TrainingController::$types;
 
-        $dueInterestRequest = TrainingInterest::whereIn('training_id', $user->trainings->pluck('id'))->where('expired', 0)->first();
+        $dueInterestRequest = TrainingInterest::whereIn('training_id', $user->trainings->pluck('id'))->where('expired', InterestStatus::NOT_EXPIRED->value)->first();
 
         // If the user belongs to our subdivision, doesn't have any training requests, has S2+ rating and is marked as inactive -> show notice
         $allowedSubDivisions = explode(',', Setting::get('trainingSubDivisions'));

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -55,7 +55,7 @@ class DashboardController extends Controller
         $trainings = $user->trainings;
         $types = TrainingController::$types;
 
-        $dueInterestRequest = TrainingInterest::whereIn('training_id', $user->trainings->pluck('id'))->where('expired', false)->first();
+        $dueInterestRequest = TrainingInterest::whereIn('training_id', $user->trainings->pluck('id'))->where('expired', 0)->first();
 
         // If the user belongs to our subdivision, doesn't have any training requests, has S2+ rating and is marked as inactive -> show notice
         $allowedSubDivisions = explode(',', Setting::get('trainingSubDivisions'));

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -56,7 +56,7 @@ class DashboardController extends Controller
         $trainings = $user->trainings;
         $types = TrainingController::$types;
 
-        $dueInterestRequest = TrainingInterest::whereIn('training_id', $user->trainings->pluck('id'))->where('expired', InterestStatus::NOT_EXPIRED->value)->first();
+        $dueInterestRequest = TrainingInterest::whereIn('training_id', $user->trainings->pluck('id'))->where('expired', InterestStatus::NOT_EXPIRED)->first();
 
         // If the user belongs to our subdivision, doesn't have any training requests, has S2+ rating and is marked as inactive -> show notice
         $allowedSubDivisions = explode(',', Setting::get('trainingSubDivisions'));

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -690,13 +690,13 @@ class TrainingController extends Controller
                 return redirect($training->path())->withSuccess('You have already confirmed your interest for this training.');
             }
 
-            if ($interest->expired) {
+            if ($interest->expired !== InterestStatus::NOT_EXPIRED->value) {
                 return redirect($training->path())->withErrors('This training interest link has expired. Please contact staff.');
             }
 
             $interest->confirmed_at = now();
             $interest->updated_at = now();
-            $interest->expired = true;
+            $interest->expired = InterestStatus::CLOSED->value;
             $interest->save();
 
             ActivityLogService::info('TRAINING', 'Training interest confirmed.');

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -7,6 +7,7 @@ use App;
 use App\Exceptions\PolicyMethodMissingException;
 use App\Exceptions\PolicyMissingException;
 use App\Facades\DivisionApi;
+use App\Helpers\InterestStatus;
 use App\Helpers\TrainingStatus;
 use App\Helpers\VatsimRating;
 use App\Models\Area;
@@ -690,13 +691,13 @@ class TrainingController extends Controller
                 return redirect($training->path())->withSuccess('You have already confirmed your interest for this training.');
             }
 
-            if ($interest->expired !== InterestStatus::NOT_EXPIRED->value) {
+            if ($interest->expired !== InterestStatus::NOT_EXPIRED) {
                 return redirect($training->path())->withErrors('This training interest link has expired. Please contact staff.');
             }
 
             $interest->confirmed_at = now();
             $interest->updated_at = now();
-            $interest->expired = InterestStatus::CLOSED->value;
+            $interest->expired = InterestStatus::CLOSED;
             $interest->save();
 
             ActivityLogService::info('TRAINING', 'Training interest confirmed.');

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Helpers\InterestStatus;
 use App\Helpers\TrainingStatus;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -125,7 +126,7 @@ class Training extends Model
     protected function expireInterests(bool $expiredInterest): void
     {
         TrainingInterest::where([['training_id', $this->id], ['expired', false]])
-            ->update(['updated_at' => now(), 'expired' => $expiredInterest ? 2 : 1]);
+            ->update(['updated_at' => now(), 'expired' => $expiredInterest ? InterestStatus::EXPIRED : InterestStatus::CLOSED]);
     }
 
     /**

--- a/app/Models/TrainingInterest.php
+++ b/app/Models/TrainingInterest.php
@@ -11,10 +11,12 @@ class TrainingInterest extends Model
 
     protected $guarded = [];
 
-    protected $casts = [
-        'deadline' => 'datetime',
-        'confirmed_at' => 'datetime',
-    ];
+        protected $casts = [
+            'deadline' => 'datetime',
+            'confirmed_at' => 'datetime',
+            'expired' => 'integer',
+        ];
+
 
     public function training()
     {

--- a/app/Models/TrainingInterest.php
+++ b/app/Models/TrainingInterest.php
@@ -11,12 +11,11 @@ class TrainingInterest extends Model
 
     protected $guarded = [];
 
-        protected $casts = [
-            'deadline' => 'datetime',
-            'confirmed_at' => 'datetime',
-            'expired' => 'integer',
-        ];
-
+    protected $casts = [
+        'deadline' => 'datetime',
+        'confirmed_at' => 'datetime',
+        'expired' => 'integer',
+    ];
 
     public function training()
     {

--- a/app/Models/TrainingInterest.php
+++ b/app/Models/TrainingInterest.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Helpers\InterestStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -14,7 +15,7 @@ class TrainingInterest extends Model
     protected $casts = [
         'deadline' => 'datetime',
         'confirmed_at' => 'datetime',
-        'expired' => 'integer',
+        'expired' => InterestStatus::class,
     ];
 
     public function training()

--- a/database/migrations/2026_06_29_230942_alter_training_interests_expire_type.php
+++ b/database/migrations/2026_06_29_230942_alter_training_interests_expire_type.php
@@ -1,9 +1,9 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/database/migrations/2026_06_29_230942_alter_training_interests_expire_type.php
+++ b/database/migrations/2026_06_29_230942_alter_training_interests_expire_type.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $driver = DB::getDriverName();
+
+        if ($driver === 'pgsql') {
+            // 1. Drop old boolean default
+            DB::statement('ALTER TABLE training_interests ALTER COLUMN expired DROP DEFAULT');
+
+            // 2. Coerce type to smallint
+            DB::statement('ALTER TABLE training_interests ALTER COLUMN expired TYPE smallint USING (CASE WHEN expired THEN 1 ELSE 0 END)::smallint');
+
+            // 3. Apply new smallint default
+            DB::statement('ALTER TABLE training_interests ALTER COLUMN expired SET DEFAULT 0');
+        } else {
+            Schema::table('training_interests', function (Blueprint $table): void {
+                $table->unsignedTinyInteger('expired')->default(0)->change();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        $driver = DB::getDriverName();
+
+        if ($driver === 'pgsql') {
+            // 1. Drop smallint default
+            DB::statement('ALTER TABLE training_interests ALTER COLUMN expired DROP DEFAULT');
+
+            // 2. Coerce type back to boolean
+            DB::statement('ALTER TABLE training_interests ALTER COLUMN expired TYPE boolean USING (expired <> 0)');
+
+            // 3. Apply old boolean default
+            DB::statement('ALTER TABLE training_interests ALTER COLUMN expired SET DEFAULT FALSE');
+        } else {
+            Schema::table('training_interests', function (Blueprint $table): void {
+                $table->boolean('expired')->default(false)->change();
+            });
+        }
+    }
+};


### PR DESCRIPTION
Follow up on #1469, this change widens the column and uses an enum to name the magic numbers.

As I'm not professionally involved with Laravel/PHP full disclosure:
Assisted-By: gpt-oss (bulk of the change), gemini 3.1 pro (correct db migration)

## Summary by Sourcery

Store training interest expiry as an integer status instead of a boolean and update application logic accordingly.

New Features:
- Introduce an InterestStatus enum to represent training interest expiry states (not expired, closed, expired).

Bug Fixes:
- Ensure training interest expiry checks and queries use explicit integer status values instead of boolean comparisons to prevent type mismatch issues.

Enhancements:
- Cast the TrainingInterest expired attribute as an integer and adjust controllers and console commands to rely on the new InterestStatus enum values for expiry handling.

Build:
- Add a database migration to convert the training_interests.expired column from boolean to an integer type with appropriate defaults for PostgreSQL and other drivers.