### PR TITLE
feat(theme): add a header theme toggle & activate Bootstrap dark cascade

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -451,6 +451,22 @@ class UserController extends Controller
     }
 
     /**
+     * Persist only the theme preference (used by the header theme toggle).
+     */
+    public function settings_update_theme(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'setting_theme' => 'required|in:light,dark,system',
+        ]);
+
+        $user = Auth::user();
+        $user->setting_theme = $data['setting_theme'];
+        $user->save();
+
+        return response()->json(['setting_theme' => $user->setting_theme]);
+    }
+
+    /**
      * Display a listing of user's reports
      *
      * @return Response

--- a/resources/js/theme.js
+++ b/resources/js/theme.js
@@ -9,11 +9,23 @@
     const THEME_STORAGE_KEY = 'user_theme_preference';
     const THEME_ATTRIBUTE = 'data-theme';
     const BS_THEME_ATTRIBUTE = 'data-bs-theme';
-    // Also the click-cycle order for the header toggle.
-    const VALID_PREFERENCES = ['system', 'light', 'dark'];
+
+    // Single source of truth for the three preferences. Insertion order is also
+    // the header toggle's click-cycle order (system -> light -> dark -> system).
+    const PREFERENCES = {
+        system: { icon: 'fa-desktop', label: 'System' },
+        light: { icon: 'fa-sun', label: 'Light' },
+        dark: { icon: 'fa-moon', label: 'Dark' },
+    };
+    const PREFERENCE_ORDER = Object.keys(PREFERENCES);
+    const THEME_ICON_CLASSES = PREFERENCE_ORDER.map((preference) => PREFERENCES[preference].icon);
+
     // Delay before a preference is persisted to the profile, so rapid clicks
     // through the cycle only result in a single request for the final choice.
     const PERSIST_DELAY = 2000;
+
+    // Cached once; `.matches` always reflects the current system setting.
+    const DARK_MEDIA_QUERY = window.matchMedia('(prefers-color-scheme: dark)');
 
     /**
      * Return a debounced wrapper that delays calling fn until `wait` ms after
@@ -25,21 +37,28 @@
     function debounce(fn, wait) {
         let timeout;
 
-        return function (...args) {
+        return function(...args) {
             clearTimeout(timeout);
             timeout = setTimeout(() => fn.apply(this, args), wait);
         };
     }
 
     /**
-     * Get the effective theme based on preference
+     * The stored preference, defaulting to 'system'.
+     * @returns {string} - 'light', 'dark', or 'system'
+     */
+    function getStoredPreference() {
+        return localStorage.getItem(THEME_STORAGE_KEY) || 'system';
+    }
+
+    /**
+     * Resolve a preference to the effective theme.
      * @param {string} preference - 'light', 'dark', or 'system'
      * @returns {string} - 'light' or 'dark'
      */
     function getEffectiveTheme(preference) {
         if (preference === 'system') {
-            // Detect system preference
-            return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            return DARK_MEDIA_QUERY.matches ? 'dark' : 'light';
         }
         return preference;
     }
@@ -61,17 +80,15 @@
      * This function reconciles and sets up dynamic behavior
      */
     function initializeTheme() {
-        // Get stored preference
-        let storedPreference = localStorage.getItem(THEME_STORAGE_KEY) ||
-                              document.documentElement.getAttribute('data-user-theme') || 
-                              'system';
+        const storedPreference = localStorage.getItem(THEME_STORAGE_KEY) ||
+            document.documentElement.getAttribute('data-user-theme') ||
+            'system';
 
         // Store the preference for consistency
         localStorage.setItem(THEME_STORAGE_KEY, storedPreference);
 
         // Apply theme (inline script has already done initial set, this ensures correctness)
-        const effectiveTheme = getEffectiveTheme(storedPreference);
-        applyTheme(effectiveTheme);
+        applyTheme(getEffectiveTheme(storedPreference));
     }
 
     /**
@@ -80,22 +97,18 @@
      * @param {boolean} persist - also save to the user profile (debounced)
      */
     function setThemePreference(preference, persist = false) {
-        if (!VALID_PREFERENCES.includes(preference)) {
+        if (!PREFERENCES[preference]) {
             return;
         }
 
         localStorage.setItem(THEME_STORAGE_KEY, preference);
-        const effectiveTheme = getEffectiveTheme(preference);
-        applyTheme(effectiveTheme);
+        applyTheme(getEffectiveTheme(preference));
         updateToggleUI(preference);
 
         if (persist) {
             debouncedPersist(preference);
         }
     }
-
-    // Persist only the final choice a couple of seconds after the last click.
-    const debouncedPersist = debounce(persistPreference, PERSIST_DELAY);
 
     /**
      * Persist the preference to the user profile so it syncs across devices
@@ -110,7 +123,12 @@
             return;
         }
 
-        fetch('/settings/theme', {
+        // Prefer the server-generated route (handles subdirectory deploys); the
+        // literal path is a fallback if the toggle isn't on the page.
+        const toggle = document.getElementById('theme-toggle');
+        const url = toggle?.dataset.themeUrl || '/settings/theme';
+
+        fetch(url, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -121,6 +139,9 @@
         }).catch(() => { /* preference is kept in localStorage regardless */ });
     }
 
+    // Persist only the final choice a couple of seconds after the last click.
+    const debouncedPersist = debounce(persistPreference, PERSIST_DELAY);
+
     /**
      * Reflect the active preference on the header toggle: swap the icon and
      * label. Driven by the 3-way preference (not the resolved theme) so
@@ -129,25 +150,26 @@
      */
     function updateToggleUI(preference) {
         const toggle = document.getElementById('theme-toggle');
+        const config = PREFERENCES[preference];
 
-        if (!toggle) {
+        if (!toggle || !config) {
             return;
         }
 
         const icon = toggle.querySelector('[data-theme-icon]');
 
         if (icon) {
-            const iconClass = { system: 'fa-desktop', light: 'fa-sun', dark: 'fa-moon' }[preference];
-            icon.className = 'fas fa-fw ' + iconClass;
+            // Swap only the theme icon class so sizing/utility classes survive.
+            icon.classList.remove(...THEME_ICON_CLASSES);
+            icon.classList.add(config.icon);
         }
 
-        const label = { system: 'System', light: 'Light', dark: 'Dark' }[preference];
-        toggle.setAttribute('title', 'Theme: ' + label + ' (click to change)');
+        toggle.setAttribute('title', `Theme: ${config.label} (click to change)`);
     }
 
     /**
      * Wire the header theme toggle: each click advances to the next preference
-     * in VALID_PREFERENCES (system -> light -> dark -> system).
+     * (system -> light -> dark -> system).
      */
     function watchThemeToggle() {
         const toggle = document.getElementById('theme-toggle');
@@ -158,28 +180,23 @@
 
         toggle.addEventListener('click', (e) => {
             e.preventDefault();
-            const current = localStorage.getItem(THEME_STORAGE_KEY) || 'system';
-            const next = VALID_PREFERENCES[(VALID_PREFERENCES.indexOf(current) + 1) % VALID_PREFERENCES.length];
+            const current = getStoredPreference();
+            const next = PREFERENCE_ORDER[(PREFERENCE_ORDER.indexOf(current) + 1) % PREFERENCE_ORDER.length];
             setThemePreference(next, true);
         });
 
         // Reflect the current preference on load.
-        updateToggleUI(localStorage.getItem(THEME_STORAGE_KEY) || 'system');
+        updateToggleUI(getStoredPreference());
     }
 
     /**
      * Listen for system theme changes when in system mode
      */
     function watchSystemTheme() {
-        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-        
-        mediaQuery.addEventListener('change', (e) => {
-            const currentPreference = localStorage.getItem(THEME_STORAGE_KEY) || 'system';
-            
+        DARK_MEDIA_QUERY.addEventListener('change', (e) => {
             // Only react if we're in system mode
-            if (currentPreference === 'system') {
-                const effectiveTheme = e.matches ? 'dark' : 'light';
-                applyTheme(effectiveTheme);
+            if (getStoredPreference() === 'system') {
+                applyTheme(e.matches ? 'dark' : 'light');
             }
         });
     }
@@ -189,13 +206,21 @@
      */
     function watchThemeSelector() {
         const themeSelector = document.getElementById('setting_theme');
-        
+
         if (themeSelector) {
             themeSelector.addEventListener('change', (e) => {
-                const newPreference = e.target.value;
-                setThemePreference(newPreference);
+                setThemePreference(e.target.value);
             });
         }
+    }
+
+    /**
+     * Attach all runtime listeners. Safe to call once the DOM is ready.
+     */
+    function setupWatchers() {
+        watchSystemTheme();
+        watchThemeSelector();
+        watchThemeToggle();
     }
 
     // Initialize theme immediately (before DOM ready to prevent flash)
@@ -203,26 +228,16 @@
 
     // Set up watchers when DOM is ready
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', () => {
-            watchSystemTheme();
-            watchThemeSelector();
-            watchThemeToggle();
-        });
+        document.addEventListener('DOMContentLoaded', setupWatchers);
     } else {
-        watchSystemTheme();
-        watchThemeSelector();
-        watchThemeToggle();
+        setupWatchers();
     }
 
     // Expose API for manual theme changes
     window.ThemeManager = {
         setTheme: setThemePreference,
-        getTheme: () => localStorage.getItem(THEME_STORAGE_KEY) || 'system',
-        getEffectiveTheme: () => {
-            const preference = localStorage.getItem(THEME_STORAGE_KEY) || 'system';
-            return getEffectiveTheme(preference);
-        }
+        getTheme: getStoredPreference,
+        getEffectiveTheme: () => getEffectiveTheme(getStoredPreference()),
     };
 
 })();
-

--- a/resources/js/theme.js
+++ b/resources/js/theme.js
@@ -8,6 +8,28 @@
 
     const THEME_STORAGE_KEY = 'user_theme_preference';
     const THEME_ATTRIBUTE = 'data-theme';
+    const BS_THEME_ATTRIBUTE = 'data-bs-theme';
+    // Also the click-cycle order for the header toggle.
+    const VALID_PREFERENCES = ['system', 'light', 'dark'];
+    // Delay before a preference is persisted to the profile, so rapid clicks
+    // through the cycle only result in a single request for the final choice.
+    const PERSIST_DELAY = 2000;
+
+    /**
+     * Return a debounced wrapper that delays calling fn until `wait` ms after
+     * its last invocation.
+     * @param {Function} fn
+     * @param {number} wait
+     * @returns {Function}
+     */
+    function debounce(fn, wait) {
+        let timeout;
+
+        return function (...args) {
+            clearTimeout(timeout);
+            timeout = setTimeout(() => fn.apply(this, args), wait);
+        };
+    }
 
     /**
      * Get the effective theme based on preference
@@ -27,7 +49,10 @@
      * @param {string} theme - 'light' or 'dark'
      */
     function applyTheme(theme) {
+        // data-bs-theme mirrors data-theme (both hold the effective light/dark
+        // value) so Bootstrap's dark cascade tracks our own theme attribute.
         document.documentElement.setAttribute(THEME_ATTRIBUTE, theme);
+        document.documentElement.setAttribute(BS_THEME_ATTRIBUTE, theme);
     }
 
     /**
@@ -52,11 +77,94 @@
     /**
      * Update theme preference
      * @param {string} preference - 'light', 'dark', or 'system'
+     * @param {boolean} persist - also save to the user profile (debounced)
      */
-    function setThemePreference(preference) {
+    function setThemePreference(preference, persist = false) {
+        if (!VALID_PREFERENCES.includes(preference)) {
+            return;
+        }
+
         localStorage.setItem(THEME_STORAGE_KEY, preference);
         const effectiveTheme = getEffectiveTheme(preference);
         applyTheme(effectiveTheme);
+        updateToggleUI(preference);
+
+        if (persist) {
+            debouncedPersist(preference);
+        }
+    }
+
+    // Persist only the final choice a couple of seconds after the last click.
+    const debouncedPersist = debounce(persistPreference, PERSIST_DELAY);
+
+    /**
+     * Persist the preference to the user profile so it syncs across devices
+     * and matches the settings page. Fails silently: localStorage already holds
+     * the preference, so the UI stays correct even if the request fails.
+     * @param {string} preference - 'light', 'dark', or 'system'
+     */
+    function persistPreference(preference) {
+        const token = document.querySelector('meta[name="csrf-token"]');
+
+        if (!token) {
+            return;
+        }
+
+        fetch('/settings/theme', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': token.getAttribute('content'),
+                'Accept': 'application/json',
+            },
+            body: JSON.stringify({ setting_theme: preference }),
+        }).catch(() => { /* preference is kept in localStorage regardless */ });
+    }
+
+    /**
+     * Reflect the active preference on the header toggle: swap the icon and
+     * label. Driven by the 3-way preference (not the resolved theme) so
+     * "system" is visible as its own state.
+     * @param {string} preference - 'light', 'dark', or 'system'
+     */
+    function updateToggleUI(preference) {
+        const toggle = document.getElementById('theme-toggle');
+
+        if (!toggle) {
+            return;
+        }
+
+        const icon = toggle.querySelector('[data-theme-icon]');
+
+        if (icon) {
+            const iconClass = { system: 'fa-desktop', light: 'fa-sun', dark: 'fa-moon' }[preference];
+            icon.className = 'fas fa-fw ' + iconClass;
+        }
+
+        const label = { system: 'System', light: 'Light', dark: 'Dark' }[preference];
+        toggle.setAttribute('title', 'Theme: ' + label + ' (click to change)');
+    }
+
+    /**
+     * Wire the header theme toggle: each click advances to the next preference
+     * in VALID_PREFERENCES (system -> light -> dark -> system).
+     */
+    function watchThemeToggle() {
+        const toggle = document.getElementById('theme-toggle');
+
+        if (!toggle) {
+            return;
+        }
+
+        toggle.addEventListener('click', (e) => {
+            e.preventDefault();
+            const current = localStorage.getItem(THEME_STORAGE_KEY) || 'system';
+            const next = VALID_PREFERENCES[(VALID_PREFERENCES.indexOf(current) + 1) % VALID_PREFERENCES.length];
+            setThemePreference(next, true);
+        });
+
+        // Reflect the current preference on load.
+        updateToggleUI(localStorage.getItem(THEME_STORAGE_KEY) || 'system');
     }
 
     /**
@@ -98,10 +206,12 @@
         document.addEventListener('DOMContentLoaded', () => {
             watchSystemTheme();
             watchThemeSelector();
+            watchThemeToggle();
         });
     } else {
         watchSystemTheme();
         watchThemeSelector();
+        watchThemeToggle();
     }
 
     // Expose API for manual theme changes

--- a/resources/views/layouts/header.blade.php
+++ b/resources/views/layouts/header.blade.php
@@ -15,15 +15,15 @@
                           document.documentElement.getAttribute('data-user-theme') ||
                           'system';
 
-    // Only apply non-system preferences to avoid FOUC
-    // System preference detection is handled by theme.js after load
-    if (storedPreference === 'light' || storedPreference === 'dark') {
-        document.documentElement.setAttribute('data-theme', storedPreference);
-    } else {
-        // For 'system', detect but let theme.js handle the watching
-        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
-    }
+    // Resolve to the effective (light/dark) theme. 'system' is watched by
+    // theme.js after load; here we just detect once to avoid FOUC.
+    var effective = (storedPreference === 'light' || storedPreference === 'dark')
+        ? storedPreference
+        : (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+
+    // data-bs-theme mirrors data-theme so Bootstrap's dark cascade applies.
+    document.documentElement.setAttribute('data-theme', effective);
+    document.documentElement.setAttribute('data-bs-theme', effective);
 })();
 </script>
 

--- a/resources/views/layouts/topbar.blade.php
+++ b/resources/views/layouts/topbar.blade.php
@@ -59,7 +59,7 @@
 
         {{-- Nav Item - Theme Toggle (cycles system -> light -> dark) --}}
         <li class="nav-item no-arrow">
-            <button type="button" class="nav-link" id="theme-toggle" title="Theme preference">
+            <button type="button" class="nav-link" id="theme-toggle" title="Theme preference" data-theme-url="{{ route('user.settings.theme') }}">
                 <i class="fas fa-fw fa-desktop" data-theme-icon></i>
                 <span class="visually-hidden">Change theme</span>
             </button>

--- a/resources/views/layouts/topbar.blade.php
+++ b/resources/views/layouts/topbar.blade.php
@@ -57,6 +57,14 @@
 
         @endcan
 
+        {{-- Nav Item - Theme Toggle (cycles system -> light -> dark) --}}
+        <li class="nav-item no-arrow">
+            <button type="button" class="nav-link" id="theme-toggle" title="Theme preference">
+                <i class="fas fa-fw fa-desktop" data-theme-icon></i>
+                <span class="visually-hidden">Change theme</span>
+            </button>
+        </li>
+
         <div class="topbar-divider d-none d-lg-block"></div>
 
         {{-- Nav Item - User Information --}}

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,6 +82,7 @@ Route::middleware(['auth', 'activity', 'suspended'])->group(function () {
         Route::get('/user/{user}/reports', 'reports')->name('user.reports');
         Route::get('/settings', 'settings')->name('user.settings');
         Route::post('/settings', 'settings_update')->name('user.settings.store');
+        Route::post('/settings/theme', 'settings_update_theme')->name('user.settings.theme');
         Route::get('/settings/extendworkmail', 'extendWorkmail')->name('user.settings.extendworkmail');
 
         // Internal user search

--- a/tests/Feature/UpdateThemePreferenceTest.php
+++ b/tests/Feature/UpdateThemePreferenceTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UpdateThemePreferenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_persist_theme_preference_from_toggle(): void
+    {
+        $user = User::factory()->create(['setting_theme' => 'system']);
+
+        $response = $this->actingAs($user)->post(route('user.settings.theme'), [
+            'setting_theme' => 'dark',
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['setting_theme' => 'dark']);
+        $this->assertEquals('dark', $user->fresh()->setting_theme);
+    }
+
+    public function test_theme_preference_rejects_invalid_value(): void
+    {
+        $user = User::factory()->create(['setting_theme' => 'light']);
+
+        $response = $this->actingAs($user)->postJson(route('user.settings.theme'), [
+            'setting_theme' => 'sepia',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertEquals('light', $user->fresh()->setting_theme);
+    }
+
+    public function test_guest_cannot_persist_theme_preference(): void
+    {
+        $response = $this->post(route('user.settings.theme'), [
+            'setting_theme' => 'dark',
+        ]);
+
+        $response->assertRedirect();
+    }
+}


### PR DESCRIPTION
Adds data-bs-theme alongside data-theme (effective light/dark value) so
Bootstrap dark components apply.

Adds a header toggle button that cycles between system, light, and dark.
Each click applies the theme immediately via localStorage; the choice is
persisted to the user profile on a debounce so rapid clicking sends a
single request for the final selection.

## Summary by Sourcery

Introduce a header theme toggle that cycles between system, light, and dark preferences while wiring Bootstrap’s dark theme cascade to the app’s existing theme system.

New Features:
- Add a header theme toggle control that cycles between system, light, and dark preferences and updates the UI immediately.
- Persist theme preference changes from the header toggle to the user profile via a dedicated settings endpoint so preferences sync across devices.

Enhancements:
- Mirror the effective light/dark theme onto Bootstrap’s data-bs-theme attribute so Bootstrap dark components follow the app theme.
- Improve initial theme application in the header to resolve the effective theme once and avoid FOUC while supporting system preference.
- Debounce theme preference persistence so only the final selection after rapid toggling is sent to the server.

Tests:
- Add feature tests to cover persisting theme preferences via the new endpoint, rejecting invalid values, and blocking unauthenticated access.