### PR TITLE
ci(docs): remove non-existant _theme override directory

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -21,7 +21,6 @@ site_dir: ../docs_site
 
 theme:
   name: 'material'
-  custom_dir: '_theme'
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update docs MkDocs configuration to stop overriding the theme with a non-existent _theme directory.