### PR TITLE
fix(vateud): use enum-backed int for rating comparisons

### DIFF
--- a/app/Services/DivisionApi/Adapters/VATEUD.php
+++ b/app/Services/DivisionApi/Adapters/VATEUD.php
@@ -270,7 +270,7 @@ class VATEUD implements DivisionApiContract
         $availableExams = $this->callApi('/facility/training/exams', 'GET')->json()['data'];
         foreach ($availableExams as $exam) {
             // If the flag exam type is the same as the rating - 1, assign it. This is because VATEUD calls S2 = 2 instead of 3 like VATSIM does.
-            if ($exam['flag_exam_type'] == $rating->vatsim_rating - 1) {
+            if ($exam['flag_exam_type'] == $rating->vatsim_rating->value - 1) {
                 return $this->callApi('/facility/training/exams/assign', 'POST', [
                     'user_cid' => $user->id,
                     'exam_id' => $exam['id'],
@@ -335,7 +335,7 @@ class VATEUD implements DivisionApiContract
         $exams = $this->getUserExams($user);
         if ($exams && $exams->successful()) {
             foreach ($exams->json()['data']['results'] as $exam) {
-                if ($exam['flag_exam_type'] == $rating->vatsim_rating - 1 && $exam['passed'] == true) {
+                if ($exam['flag_exam_type'] == $rating->vatsim_rating->value - 1 && $exam['passed'] == true) {
                     return true;
                 }
             }

--- a/tests/Feature/VATEUDAdapterTest.php
+++ b/tests/Feature/VATEUDAdapterTest.php
@@ -84,4 +84,44 @@ class VATEUDAdapterTest extends TestCase
 
         $this->assertFalse($result);
     }
+
+    #[Test]
+    public function assign_theory_exam_matches_exam_type_to_rating(): void
+    {
+        Http::fake([
+            '*exams/assign' => Http::response(['status' => 'ok'], 200),
+            '*exams' => Http::response(['data' => [
+                ['id' => 99, 'flag_exam_type' => VatsimRating::S3->value - 1],
+                ['id' => 42, 'flag_exam_type' => VatsimRating::S2->value - 1],
+            ]], 200),
+        ]);
+
+        $user = User::factory()->create();
+        $requester = User::factory()->create();
+        $rating = Rating::factory()->create(['vatsim_rating' => VatsimRating::S2->value]);
+
+        $adapter = new VATEUD();
+        $result = $adapter->assignTheoryExam($user, $rating, $requester->id);
+
+        $this->assertNotNull($result);
+        Http::assertSent(fn ($request) => str_contains($request->url(), 'exams/assign')
+            && $request['exam_id'] === 42);
+    }
+
+    #[Test]
+    public function user_has_passed_theory_exam_returns_true_for_matching_passed_exam(): void
+    {
+        Http::fake([
+            '*exams' => Http::response(['data' => ['results' => [
+                ['flag_exam_type' => VatsimRating::S2->value - 1, 'passed' => true],
+            ]]], 200),
+        ]);
+
+        $user = User::factory()->create();
+        $rating = Rating::factory()->create(['vatsim_rating' => VatsimRating::S2->value]);
+
+        $adapter = new VATEUD();
+
+        $this->assertTrue($adapter->userHasPassedTheoryExam($user, $rating));
+    }
 }


### PR DESCRIPTION
'cause I introduced a regression in the ol' TrainingStatus and VatsimRating refactor that I couldn't cover due to lack of local tests.

## Summary by Sourcery

Fix VATEUD theory exam rating comparisons when using enum-backed VATSIM ratings and add coverage for exam assignment and pass checks.

Bug Fixes:
- Correct rating-to-exam comparison to use enum-backed VATSIM rating values when matching VATEUD exam types.

Tests:
- Add feature tests to verify theory exam assignment selects the correct exam ID for a given rating.
- Add feature test to confirm userHasPassedTheoryExam returns true when a matching exam is passed.