### PR TITLE
refactor(ratings): introduce trainable ratings

### DIFF
--- a/app/Helpers/VatsimRating.php
+++ b/app/Helpers/VatsimRating.php
@@ -43,6 +43,14 @@ enum VatsimRating: int
         self::I3,
     ];
 
+    public const TRAINABLE_RATINGS = [
+        self::S1,
+        self::S2,
+        self::S3,
+        self::C1,
+        self::C3,
+    ];
+
     public static function getControllerRatings()
     {
         return collect(self::CONTROLLER_RATINGS)->mapWithKeys(function ($rating) {

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -155,7 +155,7 @@ class DatabaseSeeder extends Seeder
         // Populate trainings and other of the Scandinavian users
         for ($i = 1; $i <= rand(100, 125); $i++) {
             $training = Training::factory()->create();
-            $training->ratings()->attach(Rating::where('vatsim_rating', '>', 1)->inRandomOrder()->first());
+            $training->ratings()->attach(Rating::whereIn('vatsim_rating', VatsimRating::TRAINABLE_RATINGS)->inRandomOrder()->first());
 
             // Give all non-queued trainings a mentor
             if ($training->status != TrainingStatus::IN_QUEUE->value) {
@@ -182,7 +182,7 @@ class DatabaseSeeder extends Seeder
                     ]);
 
                     // Add position for solo
-                    $soloEndorsement->positions()->save(Position::where('rating', '>', 1)->inRandomOrder()->first());
+                    $soloEndorsement->positions()->save(Position::whereIn('rating', VatsimRating::getPositionRatingValues())->inRandomOrder()->first());
                 }
 
                 // And some a exam result


### PR DESCRIPTION
Used in the seeder and elsewhere.

tests: limit factory to S1 through C3 for simplicity

## Summary by Sourcery

Refine rating handling by introducing a dedicated set of trainable ratings and updating seed data generation to use rating helpers for trainings and solo endorsement positions.

Enhancements:
- Add a TRAINABLE_RATINGS constant to the VatsimRating helper to clearly define which ratings can be trained.
- Use VatsimRating helper methods in the database seeder when assigning ratings to trainings and solo endorsement positions for more accurate, constrained random selection.

Tests:
- Adjust test factories to only generate ratings from S1 through C3 to align with the defined trainable ratings.