### PR TITLE
refactor: re-use training reports component

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -476,8 +476,8 @@ class UserController extends Controller
         $this->authorize('viewReports', $user);
 
         $viewingUser = Auth::user();
-        $examinations = $viewingUser->viewableModels(TrainingExamination::class, [['examiner_id', '=', $user->id]]);
-        $reports = $viewingUser->viewableModels(TrainingReport::class, [['written_by_id', '=', $user->id]]);
+        $examinations = $viewingUser->viewableModels(TrainingExamination::class, [['examiner_id', '=', $user->id]], ['training']);
+        $reports = $viewingUser->viewableModels(TrainingReport::class, [['written_by_id', '=', $user->id]], ['training']);
 
         $reportsAndExams = collect($reports)->merge($examinations);
         $reportsAndExams = $reportsAndExams->sort(function ($a, $b) {

--- a/resources/views/components/training/exam-report.blade.php
+++ b/resources/views/components/training/exam-report.blade.php
@@ -1,0 +1,3 @@
+@props([
+    'report' => null,
+])

--- a/resources/views/components/training/training-report.blade.php
+++ b/resources/views/components/training/training-report.blade.php
@@ -1,0 +1,79 @@
+@props([
+    'report',
+    // Set when the report is shown outside its own training page: adds whose
+    // training it belongs to and links out to it, rather than offering Edit.
+    'showContext' => false,
+])
+
+@can('view', $report)
+
+    @php
+        $panelId = "training-report-{$report->id}";
+    @endphp
+
+    <div class="card">
+        <div class="card-header p-0">
+            <h5 class="mb-0">
+                <button class="btn btn-link collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#{{ $panelId }}" aria-expanded="false" aria-controls="{{ $panelId }}">
+                    <i class="fas fa-fw fa-chevron-right me-2"></i>
+                    {{ $report->report_date->toEuropeanDate() }}
+                    @if($showContext)
+                        | {{ isset(\App\Models\User::find($report->training->user->id)->first_name) ? \App\Models\User::find($report->training->user->id)->first_name : "Unknown"  }}'s
+                        {{ $report->training->ratings->pluck('name')->implode(' + ') }}
+                        Training
+                    @endif
+                    @if($report->draft)
+                        <span class="badge bg-danger">Draft</span>
+                    @endif
+                </button>
+            </h5>
+        </div>
+
+        <div id="{{ $panelId }}" class="collapse" data-bs-parent="#reportAccordion">
+            <article class="card-body">
+
+                <small class="text-muted">
+                    @if(filled($report->position))
+                        <i class="fas fa-map-marker-alt"></i> {{ $report->position }}&emsp;
+                    @endif
+                    <i class="fas fa-user-edit"></i> {{ isset(\App\Models\User::find($report->written_by_id)->name) ? \App\Models\User::find($report->written_by_id)->name : "Unknown"  }}
+                    @if($showContext)
+                        @can('view', $report->training)
+                            <a class="float-end" href="{{ route('training.show', $report->training->id) }}"><i class="fa fa-eye"></i><span class="ms-1">View training</span></a>
+                        @endcan
+                    @else
+                        @can('update', $report)
+                            <a class="float-end" href="{{ route('training.report.edit', $report->id) }}"><i class="fa fa-pen-square"></i><span class="ms-1">Edit</span></a>
+                        @endcan
+                    @endif
+                </small>
+
+                <div class="mt-2 markdown-content">
+                    @markdown($report->content)
+                </div>
+
+                @if(filled($report->contentimprove))
+                    <hr>
+                    <p class="fw-bold text-primary-emphasis">
+                        <i class="fas fa-clipboard-check"></i><span class="mx-1">Areas to improve</span>
+                    </p>
+                    <div class="markdown-improve">
+                        @markdown($report->contentimprove)
+                    </div>
+                @endif
+
+                @if($report->attachments->count())
+                    <hr>
+                    @foreach($report->attachments as $attachment)
+                        <div>
+                            <a href="{{ route('training.object.attachment.show', ['attachment' => $attachment]) }}" target="_blank">
+                                <i class="fa fa-file"></i><span class="ms-1">{{ $attachment->file->name }}</span>
+                            </a>
+                        </div>
+                    @endforeach
+                @endif
+
+            </article>
+        </div>
+    </div>
+@endcan

--- a/resources/views/training/show.blade.php
+++ b/resources/views/training/show.blade.php
@@ -472,73 +472,8 @@
 
                             @foreach($reportsAndExams as $reportModel)
                                 @if(is_a($reportModel, '\App\Models\TrainingReport'))
-
-                                    @can('view', $reportModel)
-
-                                        @php
-                                            $uuid = "instance-".Ramsey\Uuid\Uuid::uuid4();
-                                        @endphp
-
-                                        <div class="card">
-                                            <div class="card-header p-0">
-                                                <h5 class="mb-0">
-                                                    <button class="btn btn-link" type="button" data-bs-toggle="collapse" data-bs-target="#{{ $uuid }}" aria-expanded="true">
-                                                        <i class="fas fa-fw fa-chevron-right me-2"></i>{{ $reportModel->report_date->toEuropeanDate() }}
-                                                        @if($reportModel->draft)
-                                                            <span class='badge bg-danger'>Draft</span>
-                                                        @endif
-                                                    </button>
-                                                </h5>
-                                            </div>
-
-                                            <div id="{{ $uuid }}" class="collapse" data-bs-parent="#reportAccordion">
-                                                <div class="card-body">
-
-                                                    <small class="text-muted">
-                                                        @if(isset($reportModel->position))
-                                                            <i class="fas fa-map-marker-alt"></i> {{ $reportModel->position }}&emsp;
-                                                        @endif
-                                                        <i class="fas fa-user-edit"></i> {{ isset(\App\Models\User::find($reportModel->written_by_id)->name) ? \App\Models\User::find($reportModel->written_by_id)->name : "Unknown"  }}
-                                                        @can('update', $reportModel)
-                                                            <a class="float-end" href="{{ route('training.report.edit', $reportModel->id) }}"><i class="fa fa-pen-square"></i> Edit</a>
-                                                        @endcan
-                                                    </small>
-
-                                                    <div class="mt-2" id="markdown-content">
-                                                        @markdown($reportModel->content)
-                                                    </div>
-
-                                                    @if(isset($reportModel->contentimprove) && !empty($reportModel->contentimprove))
-                                                        <hr>
-                                                        <p class="fw-bold text-primary-emphasis">
-                                                            <i class="fas fa-clipboard-check"></i>&nbsp;Areas to improve
-                                                        </p>
-                                                        <div id="markdown-improve">
-                                                            @markdown($reportModel->contentimprove)
-                                                        </div>
-                                                    @endif
-
-                                                    @if($reportModel->attachments->count() > 0)
-                                                        <hr>
-                                                        @foreach($reportModel->attachments as $attachment)
-                                                            <div>
-                                                                <a href="{{ route('training.object.attachment.show', ['attachment' => $attachment]) }}" target="_blank">
-                                                                    <i class="fa fa-file"></i>&nbsp;{{ $attachment->file->name }}
-                                                                </a>
-                                                            </div>
-                                                        @endforeach
-                                                    @endif
-
-                                                </div>
-                                            </div>
-                                        </div>
-
-                                    @endcan
-
-
+                                    <x-training.training-report :report="$reportModel" />
                                 @else
-
-
                                     @php
                                         $uuid = "instance-".Ramsey\Uuid\Uuid::uuid4();
                                     @endphp

--- a/resources/views/user/reports.blade.php
+++ b/resources/views/user/reports.blade.php
@@ -9,7 +9,7 @@
 
         <div class="card shadow mb-4">
             <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
-                <h6 class="m-0 fw-bold text-white">{{ $user->first_name }}'s Reports</h6> 
+                <h6 class="m-0 fw-bold text-white">{{ $user->first_name }}'s Reports</h6>
             </div>
             <div class="card-body p-0">
                 <div class="accordion" id="reportAccordion">
@@ -21,80 +21,7 @@
 
                         @foreach($reportsAndExams as $reportModel)
                             @if(is_a($reportModel, '\App\Models\TrainingReport'))
-
-                                @if(!$reportModel->draft || Auth::user()->can('view', $reportModel))
-
-                                    @php
-                                        $uuid = "instance-".Ramsey\Uuid\Uuid::uuid4();
-                                    @endphp
-
-                                    <div class="card">
-                                        <div class="card-header p-0">
-                                            <h5 class="mb-0">
-                                                <button class="btn btn-link" type="button" data-bs-toggle="collapse" data-bs-target="#{{ $uuid }}" aria-expanded="true">
-                                                    <i class="fas fa-fw fa-chevron-right me-2"></i>
-                                                    {{ $reportModel->report_date->toEuropeanDate() }}
-                                                    | {{ isset(\App\Models\User::find($reportModel->training->user->id)->first_name) ? \App\Models\User::find($reportModel->training->user->id)->first_name : "Unknown"  }}'s
-                                                    @foreach($reportModel->training->ratings as $rating)
-                                                        @if ($loop->last)
-                                                            {{ $rating->name }}
-                                                        @else
-                                                            {{ $rating->name . " + " }}
-                                                        @endif
-                                                    @endforeach
-                                                    Training
-                                                    @if($reportModel->draft)
-                                                        <span class='badge bg-danger'>Draft</span>
-                                                    @endif
-                                                </button>
-                                            </h5>
-                                        </div>
-
-                                        <div id="{{ $uuid }}" class="collapse" data-bs-parent="#reportAccordion">
-                                            <div class="card-body">
-
-                                                <small class="text-muted">
-                                                    @if(isset($reportModel->position))
-                                                        <i class="fas fa-map-marker-alt"></i> {{ $reportModel->position }}&emsp;
-                                                    @endif
-                                                    <i class="fas fa-user-edit"></i> {{ isset(\App\Models\User::find($reportModel->written_by_id)->name) ? \App\Models\User::find($reportModel->written_by_id)->name : "Unknown"  }}
-                                                    @can('view', [\App\Models\Training::class, $reportModel->training])
-                                                        <a class="float-end" href="{{ route('training.show', $reportModel->training->id) }}"><i class="fa fa-eye"></i> View training</a>
-                                                    @endcan
-                                                </small>
-
-                                                <div class="mt-2" id="markdown-content">
-                                                    @markdown($reportModel->content)
-                                                </div>
-
-                                                @if(isset($reportModel->contentimprove) && !empty($reportModel->contentimprove))
-                                                    <hr>
-                                                    <p class="fw-bold text-primary-emphasis">
-                                                        <i class="fas fa-clipboard-list-check"></i>&nbsp;Areas to improve
-                                                    </p>
-                                                    <div id="markdown-improve">
-                                                        @markdown($reportModel->contentimprove)
-                                                    </div>
-                                                @endif
-
-                                                @if($reportModel->attachments->count() > 0)
-                                                    <hr>
-                                                    @foreach($reportModel->attachments as $attachment)
-                                                        <div>
-                                                            <a href="{{ route('training.object.attachment.show', ['attachment' => $attachment]) }}" target="_blank">
-                                                                <i class="fa fa-file"></i>&nbsp;{{ $attachment->file->name }}
-                                                            </a>
-                                                        </div>
-                                                    @endforeach
-                                                @endif
-
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                @endif
-
-
+                                <x-training.training-report :report="$reportModel" show-context />
                             @else
 
 
@@ -160,8 +87,8 @@
                                     </div>
                                 </div>
                             @endif
-                        
-                        
+
+
                         @endforeach
                     @endif
                 </div>

--- a/tests/Feature/TrainingReportsTest.php
+++ b/tests/Feature/TrainingReportsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Helpers\TrainingStatus;
 use App\Models\Area;
 use App\Models\OneTimeLink;
+use App\Models\Rating;
 use App\Models\Training;
 use App\Models\TrainingReport;
 use App\Models\User;
@@ -334,5 +335,23 @@ class TrainingReportsTest extends TestCase
         $otherDirector->roleAssignments()->create(['role' => 'director', 'area_id' => Area::factory()->create()->id]);
 
         $this->assertFalse($otherDirector->can('update', $report));
+    }
+
+    #[Test]
+    public function the_reports_archive_shows_which_training_each_report_belongs_to()
+    {
+        $training = $this->makeTraining();
+        $mentor = $this->makeMentor($training);
+        $this->makeReport($training, ['written_by_id' => $mentor->id]);
+        $training->ratings()->attach([
+            Rating::factory()->create(['name' => 'Faketown TWR'])->id,
+            Rating::factory()->create(['name' => 'Faketown APP'])->id,
+        ]);
+
+        $this->actingAs($mentor)
+            ->get(route('user.reports', $mentor))
+            ->assertOk()
+            ->assertSee('Faketown TWR + Faketown APP')
+            ->assertSee(route('training.show', $training->id), false);
     }
 }


### PR DESCRIPTION
Fixes #1566.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary by Sourcery

Extract a reusable training report view component and use it in both the user reports archive and individual training pages to standardize how training reports are displayed.

Enhancements:
- Introduce a shared training report Blade component that supports both training page and cross-training archive contexts.
- Update the user reports controller to eager-load related training data for reports and examinations to support contextual display.

Tests:
- Add a feature test to verify the reports archive shows the owning training and combined ratings, with a link to the training detail page.