### PR TITLE
perf: collapse queries for examination and training reports

### DIFF
--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -319,8 +319,10 @@ class TrainingController extends Controller
     {
         $this->authorize('view', $training);
 
-        $examinations = TrainingExamination::where('training_id', $training->id)->get();
-        $reports = TrainingReport::where('training_id', $training->id)->get();
+        // The view policy walks training.user/mentors/area for every entry, so eager load it.
+        $policyContext = ['training.user', 'training.mentors', 'training.area', 'attachments.file'];
+        $examinations = TrainingExamination::where('training_id', $training->id)->with([...$policyContext, 'examiner'])->get();
+        $reports = TrainingReport::where('training_id', $training->id)->with([...$policyContext, 'author'])->get();
 
         $reportsAndExams = collect($reports)->merge($examinations)
             ->filter(fn ($item) => Gate::allows('view', $item))

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -476,8 +476,9 @@ class UserController extends Controller
         $this->authorize('viewReports', $user);
 
         $viewingUser = Auth::user();
-        $examinations = $viewingUser->viewableModels(TrainingExamination::class, [['examiner_id', '=', $user->id]], ['training']);
-        $reports = $viewingUser->viewableModels(TrainingReport::class, [['written_by_id', '=', $user->id]], ['training']);
+        $trainingContext = ['training.area', 'training.user', 'training.ratings', 'training.mentors', 'attachments.file'];
+        $examinations = $viewingUser->viewableModels(TrainingExamination::class, [['examiner_id', '=', $user->id]], [...$trainingContext, 'examiner']);
+        $reports = $viewingUser->viewableModels(TrainingReport::class, [['written_by_id', '=', $user->id]], [...$trainingContext, 'author']);
 
         $reportsAndExams = collect($reports)->merge($examinations);
         $reportsAndExams = $reportsAndExams->sort(function ($a, $b) {

--- a/resources/views/components/training/training-report.blade.php
+++ b/resources/views/components/training/training-report.blade.php
@@ -18,7 +18,7 @@
                     <i class="fas fa-fw fa-chevron-right me-2"></i>
                     {{ $report->report_date->toEuropeanDate() }}
                     @if($showContext)
-                        | {{ isset(\App\Models\User::find($report->training->user->id)->first_name) ? \App\Models\User::find($report->training->user->id)->first_name : "Unknown"  }}'s
+                        | {{ $report->training->user?->first_name ?? 'Unknown' }}'s
                         {{ $report->training->ratings->pluck('name')->implode(' + ') }}
                         Training
                     @endif
@@ -36,7 +36,7 @@
                     @if(filled($report->position))
                         <i class="fas fa-map-marker-alt"></i> {{ $report->position }}&emsp;
                     @endif
-                    <i class="fas fa-user-edit"></i> {{ isset(\App\Models\User::find($report->written_by_id)->name) ? \App\Models\User::find($report->written_by_id)->name : "Unknown"  }}
+                    <i class="fas fa-user-edit"></i> {{ $report->author?->name ?? 'Unknown' }}
                     @if($showContext)
                         @can('view', $report->training)
                             <a class="float-end" href="{{ route('training.show', $report->training->id) }}"><i class="fa fa-eye"></i><span class="ms-1">View training</span></a>


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
perf(training): collapse queries for examination and training reports
END_COMMIT_OVERRIDE

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary by Sourcery

Optimize loading of training examinations and reports and simplify related user lookups in training report views.

Enhancements:
- Eager load training, user, mentor, area, attachment, and author/examiner relationships for training examinations and reports to reduce query overhead and policy-related N+1 lookups.
- Simplify training report Blade component by using already-related user and author models instead of performing new user lookups.