### PR TITLE
refactor: re-use examination reports component

### DIFF
--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -321,7 +321,7 @@ class TrainingController extends Controller
 
         // The view policy walks training.user/mentors/area for every entry, so eager load it.
         $policyContext = ['training.user', 'training.mentors', 'training.area', 'attachments.file'];
-        $examinations = TrainingExamination::where('training_id', $training->id)->with([...$policyContext, 'examiner'])->get();
+        $examinations = TrainingExamination::where('training_id', $training->id)->with([...$policyContext, 'examiner', 'position'])->get();
         $reports = TrainingReport::where('training_id', $training->id)->with([...$policyContext, 'author'])->get();
 
         $reportsAndExams = collect($reports)->merge($examinations)

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -477,7 +477,7 @@ class UserController extends Controller
 
         $viewingUser = Auth::user();
         $trainingContext = ['training.area', 'training.user', 'training.ratings', 'training.mentors', 'attachments.file'];
-        $examinations = $viewingUser->viewableModels(TrainingExamination::class, [['examiner_id', '=', $user->id]], [...$trainingContext, 'examiner']);
+        $examinations = $viewingUser->viewableModels(TrainingExamination::class, [['examiner_id', '=', $user->id]], [...$trainingContext, 'examiner', 'position']);
         $reports = $viewingUser->viewableModels(TrainingReport::class, [['written_by_id', '=', $user->id]], [...$trainingContext, 'author']);
 
         $reportsAndExams = collect($reports)->merge($examinations);

--- a/resources/views/components/training/exam-report.blade.php
+++ b/resources/views/components/training/exam-report.blade.php
@@ -1,3 +1,74 @@
 @props([
-    'report' => null,
+    'report',
+    // Set when the exam is shown outside its own training page: adds whose
+    // training it belongs to and links out to it, rather than offering Delete.
+    'showContext' => false,
 ])
+
+@can('view', $report)
+
+    @php
+        $panelId = "training-exam-{$report->id}";
+
+        $resultVariants = [
+            'PASSED' => 'success',
+            'FAILED' => 'danger',
+            'INCOMPLETE' => 'primary',
+            'POSTPONED' => 'warning',
+        ];
+    @endphp
+
+    <div class="card">
+        <div class="card-header p-0">
+            <h5 class="mb-0 bg-lightorange">
+                <button class="btn btn-link collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#{{ $panelId }}" aria-expanded="false" aria-controls="{{ $panelId }}">
+                    <i class="fas fa-fw fa-chevron-right me-2"></i>
+                    {{ $report->examination_date->toEuropeanDate() }}
+                    @if($showContext)
+                        | {{ $report->training->user?->first_name ?? 'Unknown' }}'s
+                        {{ $report->training->ratings->pluck('name')->implode(' + ') }}
+                        Exam
+                    @endif
+                </button>
+            </h5>
+        </div>
+
+        <div id="{{ $panelId }}" class="collapse" data-bs-parent="#reportAccordion">
+            <article class="card-body">
+
+                <small class="text-muted">
+                    @if($report->position !== null)
+                        <i class="fas fa-map-marker-alt"></i> {{ $report->position->callsign }}&emsp;
+                    @endif
+                    <i class="fas fa-user-edit"></i> {{ $report->examiner?->name ?? 'Unknown' }}
+                    @if($showContext)
+                        @can('view', $report->training)
+                            <a class="float-end" href="{{ route('training.show', $report->training->id) }}"><i class="fa fa-eye"></i><span class="ms-1">View training</span></a>
+                        @endcan
+                    @else
+                        @can('delete', $report)
+                            <a class="float-end" href="{{ route('training.examination.delete', $report->id) }}" onclick="return confirm('Are you sure you want to delete this examination?')"><i class="fa fa-trash"></i><span class="ms-1">Delete</span></a>
+                        @endcan
+                    @endif
+                </small>
+
+                <div class="mt-2">
+                    @if(isset($resultVariants[$report->result]))
+                        <span class="badge bg-{{ $resultVariants[$report->result] }}">{{ $report->result }}</span>
+                    @endif
+                </div>
+
+                @if($report->attachments->count())
+                    @foreach($report->attachments as $attachment)
+                        <div>
+                            <a href="{{ route('training.object.attachment.show', ['attachment' => $attachment]) }}" target="_blank">
+                                <i class="fa fa-file"></i><span class="ms-1">{{ $attachment->file->name }}</span>
+                            </a>
+                        </div>
+                    @endforeach
+                @endif
+
+            </article>
+        </div>
+    </div>
+@endcan

--- a/resources/views/training/show.blade.php
+++ b/resources/views/training/show.blade.php
@@ -474,60 +474,8 @@
                                 @if(is_a($reportModel, '\App\Models\TrainingReport'))
                                     <x-training.training-report :report="$reportModel" />
                                 @else
-                                    @php
-                                        $uuid = "instance-".Ramsey\Uuid\Uuid::uuid4();
-                                    @endphp
-
-                                    <div class="card">
-                                        <div class="card-header p-0">
-                                            <h5 class="mb-0 bg-lightorange">
-                                                <button class="btn btn-link" type="button" data-bs-toggle="collapse" data-bs-target="#{{ $uuid }}" aria-expanded="true">
-                                                    <i class="fas fa-fw fa-chevron-right me-2"></i>{{ $reportModel->examination_date->toEuropeanDate() }}
-                                                </button>
-                                            </h5>
-                                        </div>
-
-                                        <div id="{{ $uuid }}" class="collapse" data-bs-parent="#reportAccordion">
-                                            <div class="card-body">
-
-                                                <small class="text-muted">
-                                                    @if(isset($reportModel->position))
-                                                        <i class="fas fa-map-marker-alt"></i> {{ \App\Models\Position::find($reportModel->position_id)->callsign }}&emsp;
-                                                    @endif
-                                                    <i class="fas fa-user-edit"></i> {{ isset(\App\Models\User::find($reportModel->examiner_id)->name) ? \App\Models\User::find($reportModel->examiner_id)->name : "Unknown" }}
-                                                    @can('delete', [\App\Models\TrainingExamination::class, $reportModel])
-                                                        <a class="float-end" href="{{ route('training.examination.delete', $reportModel->id) }}" onclick="return confirm('Are you sure you want to delete this examination?')"><i class="fa fa-trash"></i> Delete</a>
-                                                    @endcan
-                                                </small>
-
-                                                <div class="mt-2">
-                                                    @if($reportModel->result == "PASSED")
-                                                        <span class='badge bg-success'>PASSED</span>
-                                                    @elseif($reportModel->result == "FAILED")
-                                                        <span class='badge bg-danger'>FAILED</span>
-                                                    @elseif($reportModel->result == "INCOMPLETE")
-                                                        <span class='badge bg-primary'>INCOMPLETE</span>
-                                                    @elseif($reportModel->result == "POSTPONED")
-                                                        <span class='badge bg-warning'>POSTPONED</span>
-                                                    @endif
-                                                </div>
-
-                                                @if($reportModel->attachments->count() > 0)
-                                                    @foreach($reportModel->attachments as $attachment)
-                                                        <div>
-                                                            <a href="{{ route('training.object.attachment.show', ['attachment' => $attachment]) }}" target="_blank">
-                                                                <i class="fa fa-file"></i>&nbsp;{{ $attachment->file->name }}
-                                                            </a>
-                                                        </div>
-                                                    @endforeach
-                                                @endif
-
-                                            </div>
-                                        </div>
-                                    </div>
+                                    <x-training.exam-report :report="$reportModel" />
                                 @endif
-
-
                             @endforeach
                         @endif
                     </div>

--- a/resources/views/user/reports.blade.php
+++ b/resources/views/user/reports.blade.php
@@ -23,72 +23,8 @@
                             @if(is_a($reportModel, '\App\Models\TrainingReport'))
                                 <x-training.training-report :report="$reportModel" show-context />
                             @else
-
-
-                                @php
-                                    $uuid = "instance-".Ramsey\Uuid\Uuid::uuid4();
-                                @endphp
-
-                                <div class="card">
-                                    <div class="card-header p-0">
-                                        <h5 class="mb-0 bg-lightorange">
-                                            <button class="btn btn-link" type="button" data-bs-toggle="collapse" data-bs-target="#{{ $uuid }}" aria-expanded="true">
-                                                <i class="fas fa-fw fa-chevron-right me-2"></i>
-                                                {{ $reportModel->examination_date->toEuropeanDate() }}
-                                                | {{ isset(\App\Models\User::find($reportModel->training->user->id)->first_name) ? \App\Models\User::find($reportModel->training->user->id)->first_name : "Unknown"  }}'s
-                                                @foreach($reportModel->training->ratings as $rating)
-                                                    @if ($loop->last)
-                                                        {{ $rating->name }}
-                                                    @else
-                                                        {{ $rating->name . " + " }}
-                                                    @endif
-                                                @endforeach
-                                                Exam
-                                            </button>
-                                        </h5>
-                                    </div>
-
-                                    <div id="{{ $uuid }}" class="collapse" data-bs-parent="#reportAccordion">
-                                        <div class="card-body">
-
-                                            <small class="text-muted">
-                                                @if(isset($reportModel->position))
-                                                    <i class="fas fa-map-marker-alt"></i> {{ \App\Models\Position::find($reportModel->position_id)->callsign }}&emsp;
-                                                @endif
-                                                <i class="fas fa-user-edit"></i> {{ isset(\App\Models\User::find($reportModel->examiner_id)->name) ? \App\Models\User::find($reportModel->examiner_id)->name : "Unknown" }}
-                                                @can('view', [\App\Models\Training::class, $reportModel->training])
-                                                    <a class="float-end" href="{{ route('training.show', $reportModel->training->id) }}"><i class="fa fa-eye"></i> View training</a>
-                                                @endcan
-                                            </small>
-
-                                            <div class="mt-2">
-                                                @if($reportModel->result == "PASSED")
-                                                    <span class='badge bg-success'>PASSED</span>
-                                                @elseif($reportModel->result == "FAILED")
-                                                    <span class='badge bg-danger'>FAILED</span>
-                                                @elseif($reportModel->result == "INCOMPLETE")
-                                                    <span class='badge bg-primary'>INCOMPLETE</span>
-                                                @elseif($reportModel->result == "POSTPONED")
-                                                    <span class='badge bg-warning'>POSTPONED</span>
-                                                @endif
-                                            </div>
-
-                                            @if($reportModel->attachments->count() > 0)
-                                                @foreach($reportModel->attachments as $attachment)
-                                                    <div>
-                                                        <a href="{{ route('training.object.attachment.show', ['attachment' => $attachment]) }}" target="_blank">
-                                                            <i class="fa fa-file"></i>&nbsp;{{ $attachment->file->name }}
-                                                        </a>
-                                                    </div>
-                                                @endforeach
-                                            @endif
-
-                                        </div>
-                                    </div>
-                                </div>
+                                <x-training.exam-report :report="$reportModel" show-context />
                             @endif
-
-
                         @endforeach
                     @endif
                 </div>

--- a/tests/Feature/TrainingReportsTest.php
+++ b/tests/Feature/TrainingReportsTest.php
@@ -7,6 +7,7 @@ use App\Models\Area;
 use App\Models\OneTimeLink;
 use App\Models\Rating;
 use App\Models\Training;
+use App\Models\TrainingExamination;
 use App\Models\TrainingReport;
 use App\Models\User;
 use App\Notifications\TrainingReportNotification;
@@ -338,11 +339,16 @@ class TrainingReportsTest extends TestCase
     }
 
     #[Test]
-    public function the_reports_archive_shows_which_training_each_report_belongs_to()
+    public function the_reports_archive_shows_which_training_each_report_and_exam_belongs_to()
     {
         $training = $this->makeTraining();
         $mentor = $this->makeMentor($training);
         $this->makeReport($training, ['written_by_id' => $mentor->id]);
+        TrainingExamination::factory()->create([
+            'training_id' => $training->id,
+            'examiner_id' => $mentor->id,
+            'result' => 'PASSED',
+        ]);
         $training->ratings()->attach([
             Rating::factory()->create(['name' => 'Faketown TWR'])->id,
             Rating::factory()->create(['name' => 'Faketown APP'])->id,
@@ -352,6 +358,7 @@ class TrainingReportsTest extends TestCase
             ->get(route('user.reports', $mentor))
             ->assertOk()
             ->assertSee('Faketown TWR + Faketown APP')
+            ->assertSee('<span class="badge bg-success">PASSED</span>', false)
             ->assertSee(route('training.show', $training->id), false);
     }
 }


### PR DESCRIPTION
Fixes #1566.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary by Sourcery

Extract examination report display into a reusable Blade component and use it consistently for training pages and the reports archive.

New Features:
- Introduce a training exam report Blade component that can optionally show the parent training context when rendered outside the training page.

Enhancements:
- Unify examination report UI and behavior between the training detail view and the user reports archive, including badges and attachments.
- Eager-load examination position relationships in controllers to support position display in the shared component.

Tests:
- Extend the reports archive feature test to cover examination reports, including result badges and training context.