### PR TITLE
feat(roles): replace access matrix with UserRoles component

### DIFF
--- a/app/Actions/GrantRole.php
+++ b/app/Actions/GrantRole.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Actions;
+
+use App\Facades\DivisionApi;
+use App\Models\Area;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+class GrantRole
+{
+    /**
+     * Grant $role (optionally scoped to $area) to $user on behalf of $actor.
+     *
+     * @return string|null Error message on Division API failure, otherwise null.
+     */
+    public function __invoke(User $actor, User $user, string $role, ?Area $area): ?string
+    {
+        Gate::forUser($actor)->authorize('updateRole', [$user, $role, $area]);
+
+        if ($role === 'mentor') {
+            $response = DivisionApi::assignMentor($user, $actor->id);
+
+            if ($response && $response->failed()) {
+                return 'Request failed due to error in ' . DivisionApi::getName()
+                    . ' API: ' . $response->json()['message'];
+            }
+        }
+
+        $user->roleAssignments()->firstOrCreate([
+            'role' => $role,
+            'area_id' => $area?->id,
+        ]);
+
+        return null;
+    }
+}

--- a/app/Actions/RevokeRole.php
+++ b/app/Actions/RevokeRole.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Actions;
+
+use App\Facades\DivisionApi;
+use App\Models\Area;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+class RevokeRole
+{
+    /**
+     * Revoke $role (optionally scoped to $area) from $user on behalf of $actor.
+     *
+     * @return string|null Error message on Division API failure, otherwise null.
+     */
+    public function __invoke(User $actor, User $user, string $role, ?Area $area): ?string
+    {
+        Gate::forUser($actor)->authorize('updateRole', [$user, $role, $area]);
+
+        if ($role === 'mentor') {
+            // Call before deleting: removeMentor()'s "last area" check counts the
+            // still-present assignment row.
+            $response = DivisionApi::removeMentor($user, $actor->id);
+
+            if ($response && $response->failed()) {
+                return 'Request failed due to error in ' . DivisionApi::getName()
+                    . ' API: ' . $response->json()['message'];
+            }
+        }
+
+        // Delete per-model so each revocation fires the activity-log event.
+        $user->roleAssignments()
+            ->where('role', $role)
+            ->when($area === null,
+                fn ($q) => $q->whereNull('area_id'),
+                fn ($q) => $q->where('area_id', $area->id))
+            ->get()
+            ->each->delete();
+
+        // Refresh the loaded relationship so hasRole() reflects the deletion.
+        $user->unsetRelation('roleAssignments');
+
+        if ($area !== null) {
+            $teachesIds = $user->teaches()->where('area_id', $area->id)->pluck('id');
+
+            if ($teachesIds->isNotEmpty() && ! $user->hasRole('mentor')) {
+                $user->teaches()->detach($teachesIds->all());
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -25,10 +25,8 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Http;
 use Illuminate\View\View;
-use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 /**
  * Controller to handle user views
@@ -300,97 +298,6 @@ class UserController extends Controller
                 'status' => $e->getHttpStatus() ?: 500,
             ], $e->getHttpStatus() ?: 500);
         }
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @throws AuthorizationException
-     */
-    public function update(Request $request, User $user): SymfonyResponse
-    {
-        $this->authorize('update', $user);
-        $permissions = [];
-
-        // Generate a list of possible validations: one key per area/role cell,
-        // plus the global row (area-less assignments) keyed as global_{role}
-        foreach (Area::all() as $area) {
-            foreach (config('roles.roles') as $roleKey => $role) {
-                // Only process ranks the user is allowed to change
-                if (! Gate::inspect('updateRole', [$user, $roleKey, $area])->allowed()) {
-                    continue;
-                }
-
-                $key = $area->id . '_' . $roleKey;
-                $permissions[$key] = '';
-            }
-        }
-
-        foreach (config('roles.roles') as $roleKey => $role) {
-            if (! Gate::inspect('updateRole', [$user, $roleKey, null])->allowed()) {
-                continue;
-            }
-
-            $permissions['global_' . $roleKey] = '';
-        }
-
-        // Valiate and allow these fields, then loop through permissions to set the final data set
-        $data = $request->validate($permissions);
-        foreach ($permissions as $key => $value) {
-            isset($data[$key]) ? $permissions[$key] = true : $permissions[$key] = false;
-        }
-
-        // Check and update the permissions
-        foreach ($permissions as $key => $value) {
-            [$scopeKey, $roleKey] = explode('_', $key, 2);
-            $area = $scopeKey === 'global' ? null : Area::find($scopeKey);
-
-            $assignments = $user->roleAssignments()->where('role', $roleKey)->when(
-                $area === null,
-                fn ($query) => $query->whereNull('area_id'),
-                fn ($query) => $query->where('area_id', $area->id),
-            );
-
-            // Check if permission is not set, and set it or other way around.
-            if ($assignments->count() == 0) {
-                if ($value == true) {
-                    $this->authorize('updateRole', [$user, $roleKey, $area]);
-
-                    // Call the division API to assign mentor
-                    if ($roleKey == 'mentor') {
-                        $response = DivisionApi::assignMentor($user, Auth::id());
-                        if ($response && $response->failed()) {
-                            return back()->withErrors('Request failed due to error in ' . DivisionApi::getName() . ' API: ' . $response->json()['message']);
-                        }
-                    }
-
-                    // Attach the new permission
-                    $user->roleAssignments()->create(['role' => $roleKey, 'area_id' => $area?->id]);
-                }
-            } else {
-                if ($value == false) {
-                    $this->authorize('updateRole', [$user, $roleKey, $area]);
-
-                    // Call the division API to assign mentor
-                    if ($roleKey == 'mentor') {
-                        $response = DivisionApi::removeMentor($user, Auth::id());
-                        if ($response && $response->failed()) {
-                            return back()->withErrors('Request failed due to error in ' . DivisionApi::getName() . ' API: ' . $response->json()['message']);
-                        }
-                    }
-
-                    // Detach the permission (delete per-model so the revocation is logged)
-                    $assignments->get()->each->delete();
-                }
-            }
-
-            // Check and detach trainings from mentor
-            if ($area !== null && $user->teaches()->where('area_id', $area->id)->count() > 0 && ! $user->hasRole('mentor') && $value == false) {
-                $user->teaches()->detach($user->teaches->where('area_id', $area->id));
-            }
-        }
-
-        return redirect(route('user.show', $user))->with('success', 'User access settings successfully updated.');
     }
 
     /**

--- a/app/Livewire/UserRoles.php
+++ b/app/Livewire/UserRoles.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Actions\GrantRole;
+use App\Actions\RevokeRole;
+use App\Models\Area;
+use App\Models\User;
+use Illuminate\Contracts\View\View;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+class UserRoles extends Component
+{
+    use AuthorizesRequests;
+
+    public User $user;
+
+    public bool $showAddModal = false;
+
+    public ?string $selectedRole = null;
+
+    /** @var array<int, int> */
+    public array $selectedAreaIds = [];
+
+    public bool $selectedGlobal = false;
+
+    /** @var array{role: string, area_id: ?int}|null */
+    public ?array $pendingRemoval = null;
+
+    public ?string $status = null;
+
+    public ?string $error = null;
+
+    private ?Collection $areasCache = null;
+
+    public function mount(User $user): void
+    {
+        $this->authorize('viewAccess', $user);
+        $this->user = $user;
+    }
+
+    /**
+     * All areas, memoized for the duration of the request to avoid N+1 lookups.
+     */
+    protected function allAreas(): Collection
+    {
+        return $this->areasCache ??= Area::orderBy('name')->get();
+    }
+
+    /**
+     * Whether the acting user may grant/revoke $role in $areaId (null = global).
+     */
+    public function canManage(string $role, ?int $areaId): bool
+    {
+        $area = $areaId === null ? null : $this->allAreas()->firstWhere('id', $areaId);
+
+        return Gate::inspect('updateRole', [$this->user, $role, $area])->allowed();
+    }
+
+    public function openAddModal(): void
+    {
+        $this->reset(['selectedRole', 'selectedAreaIds', 'selectedGlobal']);
+        $this->showAddModal = true;
+    }
+
+    public function closeAddModal(): void
+    {
+        $this->showAddModal = false;
+    }
+
+    public function updatedSelectedRole(): void
+    {
+        $this->selectedAreaIds = [];
+        $this->selectedGlobal = false;
+    }
+
+    /**
+     * Roles the acting user may grant to this user in at least one still-available
+     * scope/area. Keyed by role => display name. Excludes admin.
+     *
+     * @return array<string, string>
+     */
+    public function grantableRoles(): array
+    {
+        $result = [];
+
+        foreach (config('roles.roles') as $role => $def) {
+            if ($role === 'admin') {
+                continue;
+            }
+
+            $canGlobal = $this->globalOptionFor($role)['enabled'];
+            $hasArea = collect($this->areaOptionsFor($role))->contains(fn (array $opt) => $opt['enabled']);
+
+            if ($canGlobal || $hasArea) {
+                $result[$role] = $def['name'];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Whether $role may be granted globally to this user, and why not if it can't.
+     *
+     * @return array{applicable: bool, enabled: bool, reason: ?string}
+     */
+    public function globalOptionFor(string $role): array
+    {
+        $scope = config("roles.roles.{$role}.scope");
+
+        if (! in_array($scope, ['global', 'both'], true)) {
+            return ['applicable' => false, 'enabled' => false, 'reason' => 'Not available for this role'];
+        }
+
+        if ($this->user->roleAssignments->where('role', $role)->whereNull('area_id')->isNotEmpty()) {
+            return ['applicable' => true, 'enabled' => false, 'reason' => 'Already assigned'];
+        }
+
+        if (! $this->canManage($role, null)) {
+            return ['applicable' => true, 'enabled' => false, 'reason' => "You can't grant this globally"];
+        }
+
+        return ['applicable' => true, 'enabled' => true, 'reason' => null];
+    }
+
+    /**
+     * Per-area grant options for $role: one entry per area, each describing
+     * whether the actor may grant $role there and why not if it can't.
+     *
+     * @return array<int, array{area: Area, enabled: bool, reason: ?string}>
+     */
+    public function areaOptionsFor(string $role): array
+    {
+        $scope = config("roles.roles.{$role}.scope");
+
+        $held = $this->user->roleAssignments->where('role', $role)
+            ->whereNotNull('area_id')->pluck('area_id')->all();
+
+        return $this->allAreas()->map(function (Area $area) use ($role, $scope, $held) {
+            if (! in_array($scope, ['area', 'both'], true)) {
+                return ['area' => $area, 'enabled' => false, 'reason' => 'Not available for this role'];
+            }
+
+            if (in_array($area->id, $held, true)) {
+                return ['area' => $area, 'enabled' => false, 'reason' => 'Already assigned'];
+            }
+
+            if (! $this->canManage($role, $area->id)) {
+                return ['area' => $area, 'enabled' => false, 'reason' => "You can't grant this here"];
+            }
+
+            return ['area' => $area, 'enabled' => true, 'reason' => null];
+        })->values()->all();
+    }
+
+    public function grant(GrantRole $grantRole): void
+    {
+        if ($this->selectedRole === null) {
+            return;
+        }
+
+        $role = $this->selectedRole;
+        $actor = auth()->user();
+
+        // Build the list of targets from the explicit selections.
+        $targets = [];
+        if ($this->selectedGlobal) {
+            $targets[] = null;
+        }
+        // whereIn silently drops unknown/stale IDs so a bad selection can never
+        // resolve to null and be mistaken for a global grant.
+        foreach ($this->allAreas()->whereIn('id', $this->selectedAreaIds) as $area) {
+            $targets[] = $area;
+        }
+
+        if ($targets === []) {
+            $this->error = 'Select at least one option to grant.';
+            $this->status = null;
+
+            return;
+        }
+
+        if ($role === 'mentor') {
+            // Per-area best-effort: each area is an independent external API call, so
+            // no cross-area transaction — collect per-target errors and keep the rest.
+            $errors = [];
+            foreach ($targets as $area) {
+                $errors[] = $grantRole($actor, $this->user, $role, $area);
+            }
+            $errors = array_filter($errors);
+        } else {
+            // Non-mentor grants have no external dependency → all-or-nothing.
+            $errors = [];
+            try {
+                DB::transaction(function () use ($grantRole, $actor, $role, $targets) {
+                    foreach ($targets as $area) {
+                        $grantRole($actor, $this->user, $role, $area);
+                    }
+                });
+            } catch (\Throwable $e) {
+                $errors[] = $e->getMessage();
+            }
+        }
+
+        $this->error = $errors === [] ? null : implode(' ', $errors);
+        $this->status = $errors === [] ? 'Role granted.' : null;
+        $this->showAddModal = false;
+    }
+
+    public function confirmRemoval(string $role, ?int $areaId): void
+    {
+        $this->pendingRemoval = ['role' => $role, 'area_id' => $areaId];
+    }
+
+    public function cancelRemoval(): void
+    {
+        $this->pendingRemoval = null;
+    }
+
+    /**
+     * Number of trainings the user teaches in the pending removal's area
+     * (used to spell out the mentor-removal consequence).
+     */
+    public function removalTrainingCount(): int
+    {
+        if ($this->pendingRemoval === null || $this->pendingRemoval['area_id'] === null) {
+            return 0;
+        }
+
+        return $this->user->teaches()->where('area_id', $this->pendingRemoval['area_id'])->count();
+    }
+
+    /**
+     * Whether the pending removal will actually cause RevokeRole to detach the
+     * user's trainings in the area: only true for a mentor area assignment
+     * when the user holds no other mentor assignment anywhere.
+     */
+    public function removalWillDetach(): bool
+    {
+        if ($this->pendingRemoval === null
+            || $this->pendingRemoval['role'] !== 'mentor'
+            || $this->pendingRemoval['area_id'] === null) {
+            return false;
+        }
+
+        return ! $this->user->roleAssignments()
+            ->where('role', 'mentor')
+            ->where('area_id', '!=', $this->pendingRemoval['area_id'])
+            ->exists();
+    }
+
+    /**
+     * Name of the area for the pending removal, or null for a global removal.
+     */
+    public function pendingRemovalAreaName(): ?string
+    {
+        if ($this->pendingRemoval === null || $this->pendingRemoval['area_id'] === null) {
+            return null;
+        }
+
+        return $this->allAreas()->firstWhere('id', $this->pendingRemoval['area_id'])?->name;
+    }
+
+    public function remove(RevokeRole $revokeRole): void
+    {
+        if ($this->pendingRemoval === null) {
+            return;
+        }
+
+        $role = $this->pendingRemoval['role'];
+        $areaId = $this->pendingRemoval['area_id'];
+        $area = $areaId === null ? null : $this->allAreas()->firstWhere('id', $areaId);
+
+        $error = $revokeRole(auth()->user(), $this->user, $role, $area);
+
+        $this->pendingRemoval = null;
+        $this->error = $error;
+        $this->status = $error === null ? 'Role revoked.' : null;
+    }
+
+    public function render(): View
+    {
+        $this->user->load('roleAssignments.area');
+
+        return view('livewire.user-roles', [
+            'roles' => config('roles.roles'),
+            'globalAssignments' => $this->user->roleAssignments->whereNull('area_id'),
+            'areaGroups' => $this->user->roleAssignments->whereNotNull('area_id')
+                ->groupBy(fn ($a) => $a->area->name),
+        ]);
+    }
+}

--- a/resources/views/livewire/user-roles.blade.php
+++ b/resources/views/livewire/user-roles.blade.php
@@ -1,0 +1,198 @@
+<div class="card shadow mb-4">
+    <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
+        <h6 class="m-0 fw-bold text-white">
+            Access
+        </h6>
+        @if (count($this->grantableRoles()) > 0)
+            <button type="button" class="btn btn-icon btn-light" wire:click="openAddModal"><i class="fas fa-plus"></i> Add role</button>
+        @endif
+    </div>
+    <div class="card-body">
+    @if ($status)
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            {{ $status }}
+            <button type="button" class="btn-close" wire:click="$set('status', null)"></button>
+        </div>
+    @endif
+    @if ($error)
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            {{ $error }}
+            <button type="button" class="btn-close" wire:click="$set('error', null)"></button>
+        </div>
+    @endif
+
+    @php($displayName = fn ($role) => $roles[$role]['name'] ?? $role)
+
+    {{-- Global roles: always shown, one per line, with an empty-state note --}}
+    <div class="mb-3">
+        <strong>Global</strong>
+        @forelse ($globalAssignments as $a)
+            @php($manageable = $this->canManage($a->role, null))
+            <span class="badge {{ $manageable ? 'bg-primary' : 'bg-secondary' }} d-flex justify-content-between align-items-center w-100 mt-1"
+                  wire:key="g-{{ $a->role }}">
+                <span>{{ $displayName($a->role) }}</span>
+                @if ($manageable)
+                    <button type="button" class="btn-close btn-close-white"
+                            style="font-size:.6rem"
+                            aria-label="Remove role"
+                            title="Remove {{ $displayName($a->role) }}"
+                            wire:click="confirmRemoval('{{ $a->role }}', null)"></button>
+                @endif
+            </span>
+        @empty
+            <div class="text-muted mt-1">No global roles assigned</div>
+        @endforelse
+    </div>
+
+    {{-- Area roles: one section per area, one role per line --}}
+    @forelse ($areaGroups as $areaName => $assignments)
+        <div class="mb-3" wire:key="area-{{ $areaName }}">
+            <strong>{{ $areaName }}</strong>
+            @foreach ($assignments as $a)
+                @php($manageable = $this->canManage($a->role, $a->area_id))
+                <span class="badge {{ $manageable ? 'bg-primary' : 'bg-secondary' }} d-flex justify-content-between align-items-center w-100 mt-1"
+                      wire:key="a-{{ $a->role }}-{{ $a->area_id }}">
+                    <span>
+                        {{ $displayName($a->role) }}
+                        @if ($a->role === 'mentor')<em class="ms-1 text-white-50">via Division API</em>@endif
+                    </span>
+                    @if ($manageable)
+                        <button type="button" class="btn-close btn-close-white"
+                                style="font-size:.6rem"
+                                aria-label="Remove role"
+                                title="Remove {{ $displayName($a->role) }}"
+                                wire:click="confirmRemoval('{{ $a->role }}', {{ $a->area_id }})"></button>
+                    @endif
+                </span>
+            @endforeach
+        </div>
+    @empty
+        <div class="mb-3">
+            <strong>Areas</strong>
+            <div class="text-muted mt-1">No area roles assigned</div>
+        </div>
+    @endforelse
+
+    </div>{{-- /card-body --}}
+
+    @if ($showAddModal)
+        <div class="modal fade show d-block" tabindex="-1" style="background:rgba(0,0,0,.5)">
+            <div class="modal-dialog modal-lg modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Add role</h5>
+                        <button type="button" class="btn-close" wire:click="closeAddModal"></button>
+                    </div>
+                    <div class="modal-body">
+                      <div class="row g-4 gx-lg-5">
+                        <div class="col-12 col-lg-6">
+                        {{-- Step 1: choose the role --}}
+                        <div class="mb-3">
+                            <label class="form-label fw-semibold mb-0">1. Select a role</label>
+                            <p class="text-muted small mb-2">Choose the role you want to grant.</p>
+                            @foreach ($this->grantableRoles() as $key => $name)
+                                <div class="form-check" wire:key="role-{{ $key }}">
+                                    <input class="form-check-input" type="radio" name="selectedRole"
+                                           id="role-{{ $key }}" value="{{ $key }}"
+                                           wire:model.live="selectedRole">
+                                    <label class="form-check-label" for="role-{{ $key }}">
+                                        {{ $name }}
+                                        @if (! empty($roles[$key]['description']))
+                                            <span class="d-block text-muted small">{{ $roles[$key]['description'] }}</span>
+                                        @endif
+                                    </label>
+                                </div>
+                            @endforeach
+                        </div>
+                        </div>{{-- /col step 1 --}}
+
+                        <div class="col-12 col-lg-6">
+                        {{-- Step 2: choose where it applies --}}
+                        <div>
+                            <label class="form-label fw-semibold mb-0">2. Select the area(s) of responsibility</label>
+                            <p class="text-muted small mb-2">Grant organisation-wide access and/or one or more areas.</p>
+
+                            @if ($selectedRole)
+                                @php($globalOption = $this->globalOptionFor($selectedRole))
+                                {{-- Global access: kept visually separate from the area list --}}
+                                <div class="border rounded bg-body-tertiary p-2 mb-3">
+                                    <div class="text-uppercase text-muted fw-semibold small mb-1">Organisation-wide</div>
+                                    <div class="form-check mb-0" wire:key="opt-global">
+                                        <input class="form-check-input" type="checkbox"
+                                               wire:model.live="selectedGlobal"
+                                               id="option-global"
+                                               @disabled(! $globalOption['enabled'])>
+                                        <label class="form-check-label" for="option-global">
+                                            Global
+                                            @if (! $globalOption['enabled'])
+                                                <small class="text-muted ms-1">({{ $globalOption['reason'] }})</small>
+                                            @endif
+                                        </label>
+                                    </div>
+                                </div>
+
+                                {{-- Areas of responsibility --}}
+                                <div class="text-uppercase text-muted fw-semibold small mb-1">Areas of responsibility</div>
+                                @foreach ($this->areaOptionsFor($selectedRole) as $opt)
+                                    <div class="form-check" wire:key="opt-{{ $opt['area']->id }}">
+                                        <input class="form-check-input" type="checkbox"
+                                               value="{{ $opt['area']->id }}" wire:model.live="selectedAreaIds"
+                                               id="area-{{ $opt['area']->id }}"
+                                               @disabled(! $opt['enabled'])>
+                                        <label class="form-check-label" for="area-{{ $opt['area']->id }}">
+                                            {{ $opt['area']->name }}
+                                            @if (! $opt['enabled'])
+                                                <small class="text-muted ms-1">({{ $opt['reason'] }})</small>
+                                            @endif
+                                        </label>
+                                    </div>
+                                @endforeach
+                            @else
+                                <p class="text-muted mb-0">Select a role first.</p>
+                            @endif
+                        </div>
+                        </div>{{-- /col step 2 --}}
+                      </div>{{-- /row --}}
+                    </div>
+                    @php($targetCount = ($selectedGlobal ? 1 : 0) + count($selectedAreaIds))
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" wire:click="closeAddModal">Cancel</button>
+                        <button type="button" class="btn btn-primary" wire:click="grant" @disabled(! $selectedRole || (! $selectedGlobal && count($selectedAreaIds) === 0))>
+                            Grant{{ $targetCount >= 2 ? ' ×' . $targetCount : '' }}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endif
+
+    @if ($pendingRemoval)
+        @php($isMentor = $pendingRemoval['role'] === 'mentor')
+        <div class="modal fade show d-block" tabindex="-1" style="background:rgba(0,0,0,.5)">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Remove {{ $roles[$pendingRemoval['role']]['name'] ?? $pendingRemoval['role'] }}{{ $pendingRemoval['area_id'] !== null ? ' in ' . $this->pendingRemovalAreaName() : '' }}?</h5>
+                        <button type="button" class="btn-close" wire:click="cancelRemoval"></button>
+                    </div>
+                    <div class="modal-body">
+                        @if ($isMentor)
+                            <div class="alert alert-danger mb-0">
+                                This will notify the Division API.
+                                @if ($this->removalWillDetach() && $this->removalTrainingCount() > 0)
+                                    This will also detach this user's {{ $this->removalTrainingCount() }} training(s) in this area.
+                                @endif
+                            </div>
+                        @else
+                            <p class="mb-0">This will revoke the role immediately.</p>
+                        @endif
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" wire:click="cancelRemoval">Cancel</button>
+                        <button type="button" class="btn {{ $isMentor ? 'btn-danger' : 'btn-primary' }}" wire:click="remove">Remove</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -92,6 +92,10 @@
             </div>
         </div>
 
+        @can('viewAccess', $user)
+            @livewire('user-roles', ['user' => $user])
+        @endcan
+
         <div class="card shadow mb-4">
             <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
                 <h6 class="m-0 fw-bold text-white">
@@ -469,76 +473,6 @@
                 </div>
             </div>
         </div>
-        @if (\Illuminate\Support\Facades\Gate::inspect('viewAccess', $user)->allowed())
-            <div class="col-xl-12 col-lg-12 col-md-12 mb-12 p-0">
-                <div class="card shadow mb-4">
-                    <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
-                        <h6 class="m-0 fw-bold text-white">
-                            Access
-                        </h6>
-                    </div>
-                    <div class="card-body">
-                        <form action="{{ route('user.update', $user->id) }}" method="POST">
-                            @method('PATCH')
-                            @csrf
-
-                            <p>Select none, one or multiple permissions for the user.</p>
-
-                            <table class="table table-bordered table-hover table-responsive w-100 d-block d-md-table">
-                                <thead>
-                                    <tr>
-                                        <th>Area</th>
-                                        @foreach($roles as $roleKey => $roleData)
-                                            <th class="text-center">{{ $roleData['name'] }} <i class="fas fa-question-circle text-gray-400" title="{{ $roleData['description'] }}"></i></th>
-                                        @endforeach
-                                    </tr>
-                                </thead>
-                                <tbody>
-
-                                    <tr>
-                                        <td><strong>Global</strong></td>
-                                        @foreach($roles as $roleKey => $roleData)
-
-                                            @if (\Illuminate\Support\Facades\Gate::inspect('updateRole', [$user, $roleKey, null])->allowed())
-                                                <td class="text-center"><input type="checkbox" name="global_{{ $roleKey }}" {{ $user->roleAssignments->where('role', $roleKey)->whereNull('area_id')->isNotEmpty() ? 'checked' : '' }}></td>
-                                            @else
-                                                <td class="text-center"><input type="checkbox" {{ $user->roleAssignments->where('role', $roleKey)->whereNull('area_id')->isNotEmpty() ? 'checked' : '' }} disabled></td>
-                                            @endif
-
-                                        @endforeach
-                                    </tr>
-
-                                    @foreach($areas as $area)
-                                        <tr>
-                                            <td>{{ $area->name }}</td>
-
-                                            @foreach($roles as $roleKey => $roleData)
-
-                                                @if (\Illuminate\Support\Facades\Gate::inspect('updateRole', [$user, $roleKey, $area])->allowed())
-                                                    <td class="text-center"><input type="checkbox" name="{{ $area->id }}_{{ $roleKey }}" {{ $user->roleAssignments->where('role', $roleKey)->where('area_id', $area->id)->isNotEmpty() ? "checked" : "" }}></td>
-                                                @else
-                                                    <td class="text-center"><input type="checkbox" {{ $user->roleAssignments->where('role', $roleKey)->where('area_id', $area->id)->isNotEmpty() ? "checked" : "" }} disabled></td>
-                                                @endif
-
-                                            @endforeach
-
-                                        </tr>
-                                    @endforeach
-
-                                </tbody>
-                            </table>
-
-                            @if (\Illuminate\Support\Facades\Gate::inspect('update', $user)->allowed())
-                                <div class="mb-3">
-                                    <button type="submit" class="btn btn-primary">Save access</button>
-                                </div>
-                            @endif
-
-                        </form>
-                    </div>
-                </div>
-            </div>
-        @endif
     </div>
 
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -78,7 +78,6 @@ Route::middleware(['auth', 'activity', 'suspended'])->group(function () {
     // Users
     Route::controller(UserController::class)->group(function () {
         Route::get('/user/{user}', 'show')->name('user.show');
-        Route::patch('/user/{user}', 'update')->name('user.update');
         Route::get('/user/{user}/reports', 'reports')->name('user.reports');
         Route::get('/settings', 'settings')->name('user.settings');
         Route::post('/settings', 'settings_update')->name('user.settings.store');

--- a/tests/Feature/Actions/GrantRoleTest.php
+++ b/tests/Feature/Actions/GrantRoleTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature\Actions;
+
+use App\Actions\GrantRole;
+use App\Facades\DivisionApi;
+use App\Models\Area;
+use App\Models\User;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Response as ClientResponse;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class GrantRoleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        $admin = User::factory()->create();
+        $admin->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        return $admin;
+    }
+
+    #[Test]
+    public function it_creates_an_area_assignment(): void
+    {
+        $actor = $this->admin();
+        $target = User::factory()->create();
+        $area = Area::factory()->create();
+
+        $error = (new GrantRole)($actor, $target, 'moderator', $area);
+
+        $this->assertNull($error);
+        $this->assertDatabaseHas('role_user', [
+            'user_id' => $target->id, 'role' => 'moderator', 'area_id' => $area->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_is_idempotent_when_the_assignment_already_exists(): void
+    {
+        $actor = $this->admin();
+        $target = User::factory()->create();
+        $target->roleAssignments()->create(['role' => 'staff', 'area_id' => null]);
+
+        $error = (new GrantRole)($actor, $target, 'staff', null);
+
+        $this->assertNull($error);
+        $this->assertSame(1, $target->roleAssignments()->where('role', 'staff')->count());
+    }
+
+    #[Test]
+    public function it_throws_when_actor_is_not_authorized(): void
+    {
+        $actor = User::factory()->create(); // no users.manage
+        $target = User::factory()->create();
+
+        $this->expectException(AuthorizationException::class);
+
+        (new GrantRole)($actor, $target, 'staff', null);
+    }
+
+    #[Test]
+    public function it_creates_a_mentor_assignment_when_the_division_api_reports_success(): void
+    {
+        $actor = $this->admin();
+        $target = User::factory()->create();
+        $area = Area::factory()->create();
+
+        DivisionApi::shouldReceive('assignMentor')->once()->andReturn(false);
+
+        $error = (new GrantRole)($actor, $target, 'mentor', $area);
+
+        $this->assertNull($error);
+        $this->assertDatabaseHas('role_user', [
+            'user_id' => $target->id, 'role' => 'mentor', 'area_id' => $area->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_calls_the_division_api_before_creating_a_mentor_and_blocks_on_failure(): void
+    {
+        $actor = $this->admin();
+        $target = User::factory()->create();
+        $area = Area::factory()->create();
+
+        $failed = new ClientResponse(new GuzzleResponse(422, [], json_encode(['message' => 'nope'])));
+        DivisionApi::shouldReceive('assignMentor')->once()->andReturn($failed);
+        DivisionApi::shouldReceive('getName')->andReturn('VATEUD');
+
+        $error = (new GrantRole)($actor, $target, 'mentor', $area);
+
+        $this->assertStringContainsString('nope', $error);
+        $this->assertDatabaseMissing('role_user', ['user_id' => $target->id, 'role' => 'mentor']);
+    }
+}

--- a/tests/Feature/Actions/RevokeRoleTest.php
+++ b/tests/Feature/Actions/RevokeRoleTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature\Actions;
+
+use App\Actions\RevokeRole;
+use App\Facades\DivisionApi;
+use App\Models\Area;
+use App\Models\Training;
+use App\Models\User;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Response as ClientResponse;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class RevokeRoleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        $admin = User::factory()->create();
+        $admin->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        return $admin;
+    }
+
+    #[Test]
+    public function it_deletes_the_assignment(): void
+    {
+        $actor = $this->admin();
+        $target = User::factory()->create();
+        $area = Area::factory()->create();
+        $target->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $error = (new RevokeRole)($actor, $target, 'moderator', $area);
+
+        $this->assertNull($error);
+        $this->assertDatabaseMissing('role_user', [
+            'user_id' => $target->id, 'role' => 'moderator', 'area_id' => $area->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_detaches_trainings_in_area_when_no_longer_mentor_anywhere(): void
+    {
+        $actor = $this->admin();
+        $target = User::factory()->create();
+        $area = Area::factory()->create();
+        $target->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+        $training = Training::factory()->create(['area_id' => $area->id]);
+        $target->teaches()->attach($training->id, ['expire_at' => now()->addMonths(12)]);
+
+        (new RevokeRole)($actor, $target, 'mentor', $area);
+
+        $this->assertDatabaseMissing('training_mentor', [
+            'user_id' => $target->id, 'training_id' => $training->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_keeps_trainings_when_still_mentor_in_another_area(): void
+    {
+        $actor = $this->admin();
+        $target = User::factory()->create();
+        $areaA = Area::factory()->create();
+        $areaB = Area::factory()->create();
+        $target->roleAssignments()->create(['role' => 'mentor', 'area_id' => $areaA->id]);
+        $target->roleAssignments()->create(['role' => 'mentor', 'area_id' => $areaB->id]);
+        $training = Training::factory()->create(['area_id' => $areaA->id]);
+        $target->teaches()->attach($training->id, ['expire_at' => now()->addMonths(12)]);
+
+        (new RevokeRole)($actor, $target, 'mentor', $areaA);
+
+        $this->assertDatabaseHas('training_mentor', [
+            'user_id' => $target->id, 'training_id' => $training->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_detaches_trainings_when_the_roleassignments_relation_was_cached_before_revocation(): void
+    {
+        $actor = $this->admin();
+        $target = User::factory()->create();
+        $area = Area::factory()->create();
+        $target->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+
+        // Force the roleAssignments relation to load and cache on the model
+        // instance we pass into the action, simulating a realistic caller
+        // that already accessed the relation (e.g. via hasRole()) beforehand.
+        // Without RevokeRole's unsetRelation('roleAssignments') refresh, this
+        // stale cached collection would still contain the deleted assignment
+        // and hasRole('mentor') would wrongly report true.
+        $target->load('roleAssignments');
+
+        $training = Training::factory()->create(['area_id' => $area->id]);
+        $target->teaches()->attach($training->id, ['expire_at' => now()->addMonths(12)]);
+
+        (new RevokeRole)($actor, $target, 'mentor', $area);
+
+        $this->assertDatabaseMissing('training_mentor', [
+            'user_id' => $target->id, 'training_id' => $training->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_blocks_removal_when_division_api_fails(): void
+    {
+        $actor = $this->admin();
+        $target = User::factory()->create();
+        $area = Area::factory()->create();
+        $target->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+
+        $failed = new ClientResponse(new GuzzleResponse(422, [], json_encode(['message' => 'boom'])));
+        DivisionApi::shouldReceive('removeMentor')->once()->andReturn($failed);
+        DivisionApi::shouldReceive('getName')->andReturn('VATEUD');
+
+        $error = (new RevokeRole)($actor, $target, 'mentor', $area);
+
+        $this->assertSame('Request failed due to error in VATEUD API: boom', $error);
+        $this->assertDatabaseHas('role_user', ['user_id' => $target->id, 'role' => 'mentor']);
+    }
+}

--- a/tests/Feature/UserRoleAssignmentTest.php
+++ b/tests/Feature/UserRoleAssignmentTest.php
@@ -2,12 +2,19 @@
 
 namespace Tests\Feature;
 
+use App\Livewire\UserRoles;
 use App\Models\ActivityLog;
 use App\Models\Area;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
 use Tests\TestCase;
 
+/**
+ * Behavioural coverage for role assignment now that the Bootstrap role matrix
+ * (form + user.update endpoint) has been replaced by the UserRoles Livewire
+ * component. Each test drives the component the same way the profile page does.
+ */
 class UserRoleAssignmentTest extends TestCase
 {
     use RefreshDatabase;
@@ -30,15 +37,23 @@ class UserRoleAssignmentTest extends TestCase
         $this->target = User::factory()->create();
     }
 
-    public function test_role_assignment_checkbox_keys_match_controller_expectations(): void
+    public function test_user_show_page_renders_the_user_roles_component(): void
     {
-        // Submit with lowercase role key (what the controller expects)
-        $key = $this->area->id . '_moderator';
+        $this->actingAs($this->admin)
+            ->get(route('user.show', $this->target))
+            ->assertOk()
+            ->assertSeeLivewire(UserRoles::class);
+    }
 
-        $response = $this->actingAs($this->admin)
-            ->patch(route('user.update', $this->target), [$key => 'on']);
-
-        $response->assertRedirect();
+    public function test_global_admin_can_assign_moderator_per_area(): void
+    {
+        Livewire::actingAs($this->admin)
+            ->test(UserRoles::class, ['user' => $this->target])
+            ->call('openAddModal')
+            ->set('selectedRole', 'moderator')
+            ->set('selectedAreaIds', [$this->area->id])
+            ->call('grant')
+            ->assertHasNoErrors();
 
         $this->assertDatabaseHas('role_user', [
             'user_id' => $this->target->id,
@@ -47,37 +62,17 @@ class UserRoleAssignmentTest extends TestCase
         ]);
     }
 
-    public function test_role_removal_works_when_key_matches(): void
-    {
-        // Pre-assign moderator role
-        $this->target->roleAssignments()->create([
-            'role' => 'moderator',
-            'area_id' => $this->area->id,
-        ]);
-
-        // Submit without that key (unchecked) — should remove the role
-        $response = $this->actingAs($this->admin)
-            ->patch(route('user.update', $this->target), []);
-
-        $response->assertRedirect();
-
-        $this->assertDatabaseMissing('role_user', [
-            'user_id' => $this->target->id,
-            'role' => 'moderator',
-            'area_id' => $this->area->id,
-        ]);
-    }
-
-    public function test_revoking_a_role_via_the_update_endpoint_is_logged(): void
+    public function test_revoking_a_role_via_the_component_is_logged(): void
     {
         $this->target->roleAssignments()->create([
             'role' => 'moderator',
             'area_id' => $this->area->id,
         ]);
 
-        $this->actingAs($this->admin)
-            ->patch(route('user.update', $this->target), [])
-            ->assertRedirect();
+        Livewire::actingAs($this->admin)
+            ->test(UserRoles::class, ['user' => $this->target])
+            ->call('confirmRemoval', 'moderator', $this->area->id)
+            ->call('remove');
 
         $log = ActivityLog::where('subject_type', User::class)
             ->where('subject_id', $this->target->id)
@@ -93,72 +88,30 @@ class UserRoleAssignmentTest extends TestCase
         $this->assertSame($this->admin->id, $log->causer_id);
     }
 
-    public function test_global_row_is_visible_on_user_show_page(): void
+    public function test_admin_role_cannot_be_assigned_via_the_component_even_by_global_admin(): void
     {
-        $response = $this->actingAs($this->admin)
-            ->get(route('user.show', $this->target));
+        Livewire::actingAs($this->admin)
+            ->test(UserRoles::class, ['user' => $this->target])
+            ->set('selectedRole', 'admin')
+            ->set('selectedGlobal', true)
+            ->call('grant');
 
-        $response->assertOk();
-        $response->assertSee('Global');
-    }
-
-    public function test_global_admin_can_assign_director_per_area(): void
-    {
-        $key = $this->area->id . '_director';
-
-        $response = $this->actingAs($this->admin)
-            ->patch(route('user.update', $this->target), [$key => 'on']);
-
-        $response->assertRedirect();
-
-        $this->assertDatabaseHas('role_user', [
-            'user_id' => $this->target->id,
-            'role' => 'director',
-            'area_id' => $this->area->id,
-        ]);
-    }
-
-    public function test_global_admin_can_revoke_director_per_area(): void
-    {
-        $this->target->roleAssignments()->create([
-            'role' => 'director',
-            'area_id' => $this->area->id,
-        ]);
-
-        $response = $this->actingAs($this->admin)
-            ->patch(route('user.update', $this->target), []);
-
-        $response->assertRedirect();
-
-        $this->assertDatabaseMissing('role_user', [
-            'user_id' => $this->target->id,
-            'role' => 'director',
-            'area_id' => $this->area->id,
-        ]);
-    }
-
-    public function test_admin_role_cannot_be_assigned_via_ui_even_by_global_admin(): void
-    {
-        $key = $this->area->id . '_admin';
-
-        $response = $this->actingAs($this->admin)
-            ->patch(route('user.update', $this->target), [$key => 'on']);
-
-        $response->assertRedirect();
         $this->assertDatabaseMissing('role_user', [
             'user_id' => $this->target->id,
             'role' => 'admin',
         ]);
     }
 
-    public function test_admin_role_cannot_be_revoked_via_ui(): void
+    public function test_admin_role_cannot_be_revoked_via_the_component(): void
     {
         $this->target->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
 
-        $response = $this->actingAs($this->admin)
-            ->patch(route('user.update', $this->target), []);
+        Livewire::actingAs($this->admin)
+            ->test(UserRoles::class, ['user' => $this->target])
+            ->call('confirmRemoval', 'admin', null)
+            ->call('remove')
+            ->assertForbidden();
 
-        $response->assertRedirect();
         $this->assertDatabaseHas('role_user', [
             'user_id' => $this->target->id,
             'role' => 'admin',
@@ -171,12 +124,14 @@ class UserRoleAssignmentTest extends TestCase
         $director = User::factory()->create();
         $director->roleAssignments()->create(['role' => 'director', 'area_id' => $this->area->id]);
 
-        $key = $this->area->id . '_moderator';
+        Livewire::actingAs($director)
+            ->test(UserRoles::class, ['user' => $this->target])
+            ->call('openAddModal')
+            ->set('selectedRole', 'moderator')
+            ->set('selectedAreaIds', [$this->area->id])
+            ->call('grant')
+            ->assertHasNoErrors();
 
-        $response = $this->actingAs($director)
-            ->patch(route('user.update', $this->target), [$key => 'on']);
-
-        $response->assertRedirect();
         $this->assertDatabaseHas('role_user', [
             'user_id' => $this->target->id,
             'role' => 'moderator',
@@ -189,12 +144,12 @@ class UserRoleAssignmentTest extends TestCase
         $director = User::factory()->create();
         $director->roleAssignments()->create(['role' => 'director', 'area_id' => $this->area->id]);
 
-        $key = $this->area->id . '_director';
+        Livewire::actingAs($director)
+            ->test(UserRoles::class, ['user' => $this->target])
+            ->set('selectedRole', 'director')
+            ->set('selectedAreaIds', [$this->area->id])
+            ->call('grant');
 
-        $response = $this->actingAs($director)
-            ->patch(route('user.update', $this->target), [$key => 'on']);
-
-        $response->assertRedirect();
         $this->assertDatabaseMissing('role_user', [
             'user_id' => $this->target->id,
             'role' => 'director',
@@ -206,12 +161,14 @@ class UserRoleAssignmentTest extends TestCase
         $globalDirector = User::factory()->create();
         $globalDirector->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
 
-        $key = $this->area->id . '_director';
+        Livewire::actingAs($globalDirector)
+            ->test(UserRoles::class, ['user' => $this->target])
+            ->call('openAddModal')
+            ->set('selectedRole', 'director')
+            ->set('selectedAreaIds', [$this->area->id])
+            ->call('grant')
+            ->assertHasNoErrors();
 
-        $response = $this->actingAs($globalDirector)
-            ->patch(route('user.update', $this->target), [$key => 'on']);
-
-        $response->assertRedirect();
         $this->assertDatabaseHas('role_user', [
             'user_id' => $this->target->id,
             'role' => 'director',
@@ -224,23 +181,32 @@ class UserRoleAssignmentTest extends TestCase
         $moderator = User::factory()->create();
         $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $this->area->id]);
 
-        $response = $this->actingAs($moderator)
-            ->patch(route('user.update', $this->target), [
-                $this->area->id . '_director' => 'on',
-                $this->area->id . '_admin' => 'on',
-            ]);
+        $component = Livewire::actingAs($moderator)
+            ->test(UserRoles::class, ['user' => $this->target]);
 
-        $response->assertRedirect();
+        $component->set('selectedRole', 'director')
+            ->set('selectedAreaIds', [$this->area->id])
+            ->call('grant');
+
+        $component->set('selectedRole', 'admin')
+            ->set('selectedAreaIds', [])
+            ->set('selectedGlobal', true)
+            ->call('grant');
+
         $this->assertDatabaseMissing('role_user', ['user_id' => $this->target->id, 'role' => 'director']);
         $this->assertDatabaseMissing('role_user', ['user_id' => $this->target->id, 'role' => 'admin']);
     }
 
     public function test_global_admin_can_assign_global_moderator(): void
     {
-        $response = $this->actingAs($this->admin)
-            ->patch(route('user.update', $this->target), ['global_moderator' => 'on']);
+        Livewire::actingAs($this->admin)
+            ->test(UserRoles::class, ['user' => $this->target])
+            ->call('openAddModal')
+            ->set('selectedRole', 'moderator')
+            ->set('selectedGlobal', true)
+            ->call('grant')
+            ->assertHasNoErrors();
 
-        $response->assertRedirect();
         $this->assertDatabaseHas('role_user', [
             'user_id' => $this->target->id,
             'role' => 'moderator',
@@ -252,37 +218,29 @@ class UserRoleAssignmentTest extends TestCase
     {
         $this->target->roleAssignments()->create(['role' => 'moderator', 'area_id' => null]);
 
-        $response = $this->actingAs($this->admin)
-            ->patch(route('user.update', $this->target), []);
+        Livewire::actingAs($this->admin)
+            ->test(UserRoles::class, ['user' => $this->target])
+            ->call('confirmRemoval', 'moderator', null)
+            ->call('remove');
 
-        $response->assertRedirect();
         $this->assertDatabaseMissing('role_user', [
             'user_id' => $this->target->id,
             'role' => 'moderator',
+            'area_id' => null,
         ]);
     }
 
-    public function test_global_mentor_key_is_ignored_due_to_area_scope(): void
+    public function test_mentor_cannot_be_assigned_globally_due_to_area_scope(): void
     {
-        $response = $this->actingAs($this->admin)
-            ->patch(route('user.update', $this->target), ['global_mentor' => 'on']);
+        Livewire::actingAs($this->admin)
+            ->test(UserRoles::class, ['user' => $this->target])
+            ->call('openAddModal')
+            ->set('selectedRole', 'mentor')
+            ->call('grant');
 
-        $response->assertRedirect();
         $this->assertDatabaseMissing('role_user', [
             'user_id' => $this->target->id,
             'role' => 'mentor',
-        ]);
-    }
-
-    public function test_global_admin_key_is_ignored(): void
-    {
-        $response = $this->actingAs($this->admin)
-            ->patch(route('user.update', $this->target), ['global_admin' => 'on']);
-
-        $response->assertRedirect();
-        $this->assertDatabaseMissing('role_user', [
-            'user_id' => $this->target->id,
-            'role' => 'admin',
         ]);
     }
 
@@ -291,10 +249,14 @@ class UserRoleAssignmentTest extends TestCase
         $globalDirector = User::factory()->create();
         $globalDirector->roleAssignments()->create(['role' => 'director', 'area_id' => null]);
 
-        $response = $this->actingAs($globalDirector)
-            ->patch(route('user.update', $this->target), ['global_director' => 'on']);
+        Livewire::actingAs($globalDirector)
+            ->test(UserRoles::class, ['user' => $this->target])
+            ->call('openAddModal')
+            ->set('selectedRole', 'director')
+            ->set('selectedGlobal', true)
+            ->call('grant')
+            ->assertHasNoErrors();
 
-        $response->assertRedirect();
         $this->assertDatabaseHas('role_user', [
             'user_id' => $this->target->id,
             'role' => 'director',
@@ -307,25 +269,17 @@ class UserRoleAssignmentTest extends TestCase
         $director = User::factory()->create();
         $director->roleAssignments()->create(['role' => 'director', 'area_id' => $this->area->id]);
 
-        $response = $this->actingAs($director)
-            ->patch(route('user.update', $this->target), ['global_moderator' => 'on']);
+        Livewire::actingAs($director)
+            ->test(UserRoles::class, ['user' => $this->target])
+            ->set('selectedRole', 'moderator')
+            ->set('selectedAreaIds', [])
+            ->set('selectedGlobal', true)
+            ->call('grant');
 
-        $response->assertRedirect();
         $this->assertDatabaseMissing('role_user', [
             'user_id' => $this->target->id,
             'role' => 'moderator',
+            'area_id' => null,
         ]);
-    }
-
-    public function test_global_row_renders_enabled_checkboxes_for_admin(): void
-    {
-        $response = $this->actingAs($this->admin)
-            ->get(route('user.show', $this->target));
-
-        $response->assertOk();
-        $response->assertSee('name="global_moderator"', false);
-        $response->assertSee('name="global_director"', false);
-        $response->assertDontSee('name="global_admin"', false);
-        $response->assertDontSee('name="global_mentor"', false);
     }
 }

--- a/tests/Feature/UserRolesTest.php
+++ b/tests/Feature/UserRolesTest.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Facades\DivisionApi;
+use App\Livewire\UserRoles;
+use App\Models\Area;
+use App\Models\Training;
+use App\Models\User;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class UserRolesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        $admin = User::factory()->create();
+        $admin->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        return $admin;
+    }
+
+    #[Test]
+    public function it_forbids_mounting_without_view_access(): void
+    {
+        $target = User::factory()->create();
+
+        Livewire::actingAs(User::factory()->create())
+            ->test(UserRoles::class, ['user' => $target])
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_lists_current_assignments_grouped_by_scope(): void
+    {
+        $area = Area::factory()->create(['name' => 'Enroute East']);
+        $target = User::factory()->create();
+        $target->roleAssignments()->create(['role' => 'staff', 'area_id' => null]);
+        $target->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->assertSee('Global')
+            ->assertSee('Staff')
+            ->assertSee('Enroute East')
+            ->assertSee('Moderator');
+    }
+
+    #[Test]
+    public function it_shows_the_global_section_with_an_empty_note_when_the_user_has_no_assignments(): void
+    {
+        $target = User::factory()->create();
+
+        Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->assertSee('Global')
+            ->assertSee('No global roles assigned')
+            ->assertSee('No area roles assigned');
+    }
+
+    #[Test]
+    public function admin_role_is_shown_without_a_remove_control(): void
+    {
+        $target = User::factory()->create();
+        $target->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->assertSee('Administrator')
+            ->assertDontSeeHtml('wire:click="confirmRemoval(\'admin\'');
+    }
+
+    #[Test]
+    public function it_grants_an_area_role_to_multiple_areas_at_once(): void
+    {
+        $areaA = Area::factory()->create();
+        $areaB = Area::factory()->create();
+        $target = User::factory()->create();
+
+        Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->call('openAddModal')
+            ->set('selectedRole', 'nav-editor')
+            ->set('selectedAreaIds', [$areaA->id, $areaB->id])
+            ->call('grant')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('role_user', ['user_id' => $target->id, 'role' => 'nav-editor', 'area_id' => $areaA->id]);
+        $this->assertDatabaseHas('role_user', ['user_id' => $target->id, 'role' => 'nav-editor', 'area_id' => $areaB->id]);
+    }
+
+    #[Test]
+    public function granting_an_area_scoped_role_with_no_areas_ticked_does_not_report_success(): void
+    {
+        $area = Area::factory()->create();
+        $target = User::factory()->create();
+
+        $component = Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->call('openAddModal')
+            ->set('selectedRole', 'nav-editor')
+            // An unknown/stale area ID is dropped rather than resolving to null
+            // and being mistaken for a global grant, so this is still "no options".
+            ->set('selectedAreaIds', [$area->id + 999])
+            ->call('grant');
+
+        $this->assertDatabaseMissing('role_user', ['user_id' => $target->id, 'role' => 'nav-editor']);
+        $component->assertSet('status', null)
+            ->assertSet('error', 'Select at least one option to grant.')
+            ->assertSet('showAddModal', true)
+            ->assertSee('Select at least one option to grant.');
+    }
+
+    #[Test]
+    public function grantable_roles_exclude_admin_and_roles_the_actor_cannot_grant(): void
+    {
+        $area = Area::factory()->create();
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+        $target = User::factory()->create();
+
+        // Moderators may only grant mentor/buddy.
+        $component = Livewire::actingAs($moderator)->test(UserRoles::class, ['user' => $target]);
+        $grantable = array_keys($component->instance()->grantableRoles());
+
+        $this->assertEqualsCanonicalizing(['mentor', 'buddy'], $grantable);
+    }
+
+    #[Test]
+    public function global_option_for_an_area_only_role_is_not_applicable(): void
+    {
+        $target = User::factory()->create();
+
+        $component = Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target]);
+
+        $option = $component->instance()->globalOptionFor('mentor');
+
+        $this->assertFalse($option['applicable']);
+        $this->assertFalse($option['enabled']);
+        $this->assertSame('Not available for this role', $option['reason']);
+    }
+
+    #[Test]
+    public function area_options_for_marks_an_already_held_area_disabled_and_a_free_area_enabled(): void
+    {
+        $heldArea = Area::factory()->create();
+        $openArea = Area::factory()->create();
+        $target = User::factory()->create();
+        $target->roleAssignments()->create(['role' => 'nav-editor', 'area_id' => $heldArea->id]);
+
+        $component = Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target]);
+
+        $options = collect($component->instance()->areaOptionsFor('nav-editor'))
+            ->keyBy(fn (array $opt) => $opt['area']->id);
+
+        $this->assertFalse($options[$heldArea->id]['enabled']);
+        $this->assertSame('Already assigned', $options[$heldArea->id]['reason']);
+
+        $this->assertTrue($options[$openArea->id]['enabled']);
+        $this->assertNull($options[$openArea->id]['reason']);
+    }
+
+    #[Test]
+    public function it_grants_a_global_role(): void
+    {
+        $target = User::factory()->create();
+
+        Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->call('openAddModal')
+            ->set('selectedRole', 'staff')
+            ->set('selectedGlobal', true)
+            ->call('grant')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('role_user', ['user_id' => $target->id, 'role' => 'staff', 'area_id' => null]);
+    }
+
+    #[Test]
+    public function add_modal_shows_the_reason_when_global_is_not_available_for_the_selected_role(): void
+    {
+        $target = User::factory()->create();
+
+        Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->call('openAddModal')
+            ->set('selectedRole', 'mentor')
+            ->assertSee('Not available for this role');
+    }
+
+    #[Test]
+    public function add_modal_presents_two_labelled_steps_with_global_kept_distinct_from_areas(): void
+    {
+        Area::factory()->create();
+        $target = User::factory()->create();
+
+        Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->call('openAddModal')
+            ->assertSee('1. Select a role')
+            ->assertSee('2. Select the area(s) of responsibility')
+            ->assertSee(config('roles.roles.director.description'))
+            ->set('selectedRole', 'director')
+            ->assertSee('Organisation-wide')
+            ->assertSee('Areas of responsibility');
+    }
+
+    #[Test]
+    public function multi_area_mentor_grant_reports_partial_failure(): void
+    {
+        $ok = Area::factory()->create();
+        $bad = Area::factory()->create();
+        $target = User::factory()->create();
+
+        DivisionApi::shouldReceive('assignMentor')->andReturnUsing(function () {
+            static $calls = 0;
+            $calls++;
+
+            return $calls === 1
+                ? false // success (no-op)
+                : new \Illuminate\Http\Client\Response(new Response(422, [], json_encode(['message' => 'x'])));
+        });
+        DivisionApi::shouldReceive('getName')->andReturn('VATEUD');
+
+        Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->call('openAddModal')
+            ->set('selectedRole', 'mentor')
+            ->set('selectedAreaIds', [$ok->id, $bad->id])
+            ->call('grant');
+
+        // Exactly one of the two mentor assignments persisted.
+        $this->assertSame(1, $target->roleAssignments()->where('role', 'mentor')->count());
+    }
+
+    #[Test]
+    public function removing_a_role_requires_confirmation_then_deletes(): void
+    {
+        $area = Area::factory()->create();
+        $target = User::factory()->create();
+        $target->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->call('confirmRemoval', 'moderator', $area->id)
+            ->assertSet('pendingRemoval', ['role' => 'moderator', 'area_id' => $area->id])
+            ->assertSee('Remove Moderator')
+            ->assertSee('Remove Moderator in ' . $area->name . '?')
+            ->call('remove');
+
+        $this->assertDatabaseMissing('role_user', ['user_id' => $target->id, 'role' => 'moderator']);
+    }
+
+    #[Test]
+    public function mentor_removal_shows_the_division_and_training_consequence(): void
+    {
+        $area = Area::factory()->create();
+        $target = User::factory()->create();
+        $target->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+
+        Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->call('confirmRemoval', 'mentor', $area->id)
+            ->assertSee('Division API')
+            ->assertSeeHtml('btn-danger');
+    }
+
+    #[Test]
+    public function mentor_removal_in_one_of_two_areas_does_not_show_the_detach_clause(): void
+    {
+        $areaA = Area::factory()->create();
+        $areaB = Area::factory()->create();
+        $target = User::factory()->create();
+        $target->roleAssignments()->create(['role' => 'mentor', 'area_id' => $areaA->id]);
+        $target->roleAssignments()->create(['role' => 'mentor', 'area_id' => $areaB->id]);
+
+        Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->call('confirmRemoval', 'mentor', $areaA->id)
+            ->assertSee('Division API')
+            ->assertSeeHtml('btn-danger')
+            ->assertDontSee('detach');
+    }
+
+    #[Test]
+    public function cancel_removal_clears_the_pending_removal(): void
+    {
+        $area = Area::factory()->create();
+        $target = User::factory()->create();
+        $target->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->call('confirmRemoval', 'moderator', $area->id)
+            ->assertSet('pendingRemoval', ['role' => 'moderator', 'area_id' => $area->id])
+            ->call('cancelRemoval')
+            ->assertSet('pendingRemoval', null);
+    }
+
+    #[Test]
+    public function removal_training_count_reflects_trainings_taught_in_the_area(): void
+    {
+        $area = Area::factory()->create();
+        $target = User::factory()->create();
+        $target->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+        $training = Training::factory()->create(['area_id' => $area->id]);
+        $target->teaches()->attach($training->id, ['expire_at' => now()->addMonths(12)]);
+
+        $component = Livewire::actingAs($this->admin())
+            ->test(UserRoles::class, ['user' => $target])
+            ->call('confirmRemoval', 'mentor', $area->id);
+
+        $this->assertSame(1, $component->instance()->removalTrainingCount());
+        $component->assertSee('1 training(s)');
+    }
+}


### PR DESCRIPTION
Retire the Bootstrap role access-matrix on the user profile, a checkbox
grid of every role against Global plus every area, saved through a
single UserController@update POST, in favour of an assignment-centric
UserRoles Livewire component. 

The old grid rendered every role regardless of scope and was easy to
misread and mis-save; the component instead shows the roles a user
actually holds, offers a scope-aware add picker, and removes them one at
a time with confirmation.

Grant and revoke run through dedicated GrantRole/RevokeRole actions, the
latter also driving the external mentor sync. Removes the now-dead
UserController@update method and its user.update route, porting its
endpoint tests to component and integration tests.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary by Sourcery

Replace the user profile role access matrix with a Livewire-based UserRoles component and dedicated actions for granting and revoking roles.

New Features:
- Introduce a UserRoles Livewire component to manage a user’s global and area-scoped role assignments with scoped add/remove flows and confirmation dialogs.
- Add GrantRole and RevokeRole action classes to encapsulate role assignment changes, including integration with the external mentor synchronisation API.

Bug Fixes:
- Ensure mentor revocations correctly detach trainings even when the user model’s roleAssignments relation was previously cached.
- Prevent assigning or revoking admin roles via the UI or component while keeping existing admin assignments visible without removal controls.

Enhancements:
- Gate access to the new UserRoles component via the existing viewAccess policy and display a clearer, scope-aware presentation of current roles.
- Refine role-granting logic to exclude admin from grantable options and only offer roles/scopes that the acting user is authorised to manage.
- Show user-friendly status and error messaging in the UserRoles UI, including partial failure reporting for multi-area mentor grants and Division API failures.
- Group role assignments by global vs per-area in the UI and provide empty-state messaging when no roles are assigned.

Tests:
- Replace controller-based role matrix tests with Livewire behavioural tests that exercise the UserRoles component on the profile page.
- Add comprehensive tests for the GrantRole and RevokeRole actions, covering authorisation, idempotency, Division API success/failure, and mentor training-detach behaviour.
- Add feature tests asserting component behaviours such as grantable role sets, global/area option availability, confirmation flows, and mentor-specific consequences.

Chores:
- Remove the obsolete UserController@update method, its user.update route, and the legacy Bootstrap access matrix form from the user profile view.