### PR TITLE
feat(roles): matrix-driven role-grant authority

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -494,6 +494,17 @@ class User extends Authenticatable
         return $this->hasRole($allowedRoles, $area);
     }
 
+    public function hasGlobalPermission(string $permission): bool
+    {
+        $allowedRoles = app(PermissionMatrix::class)->rolesFor($permission);
+
+        if (empty($allowedRoles)) {
+            return false;
+        }
+
+        return $this->hasGlobalRole($allowedRoles);
+    }
+
     public function accessibleAreasForPermission(string $permission): AreaScope
     {
         $allowedRoles = app(PermissionMatrix::class)->rolesFor($permission);

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -75,35 +75,21 @@ class UserPolicy
             return false;
         }
 
-        // Global assignments require the role's scope to allow them
-        if ($requestedArea === null && ! in_array(config("roles.roles.{$requestedRole}.scope"), ['both', 'global'], true)) {
+        // Global (area-less) assignments require the role's scope to allow them
+        if ($requestedArea === null
+            && ! in_array(config("roles.roles.{$requestedRole}.scope"), ['both', 'global'], true)) {
             return false;
         }
 
-        if ($user->hasRole('admin')) {
-            return true;
-        }
+        $permission = "roles.{$requestedRole}.manage";
 
-        // Only global directors may grant or revoke the director role
-        if ($requestedRole === 'director') {
-            return $user->hasGlobalRole('director');
-        }
+        // Grant authority must be held at (or above) the grant's scope. A global grant always
+        // needs global authority; a role declaring grant_scope 'global' needs it even in an area.
+        $requiresGlobalAuthority = $requestedArea === null
+            || config("roles.roles.{$requestedRole}.grant_scope", 'area') === 'global';
 
-        // Global assignments of the remaining roles also require a global director
-        if ($requestedArea === null) {
-            return $user->hasGlobalRole('director');
-        }
-
-        // Directors manage the remaining roles within their scope
-        if ($user->hasRole('director', $requestedArea)) {
-            return true;
-        }
-
-        // Moderators can only set mentors and buddies
-        if ($user->hasRole('moderator', $requestedArea)) {
-            return in_array($requestedRole, ['mentor', 'buddy']);
-        }
-
-        return false;
+        return $requiresGlobalAuthority
+            ? $user->hasGlobalPermission($permission)
+            : $user->hasPermission($permission, $requestedArea);
     }
 }

--- a/config/roles.php
+++ b/config/roles.php
@@ -9,6 +9,10 @@ return [
     | Define all available roles here instead of in the database.
     | The string key is the identifier used in the system.
     |
+    | Each role has a `scope` (where it may be HELD: global|area|both) and an
+    | optional `grant_scope` (where grant-authority must be HELD to grant/revoke
+    | it: 'area' [default] accepts area-or-global authority, 'global' requires an
+    | area-less assignment even for an area-scoped grant).
     */
     'roles' => [
         'admin' => [
@@ -20,6 +24,7 @@ return [
             'name' => 'Director',
             'description' => 'Director of an area or the whole organisation',
             'scope' => 'both',
+            'grant_scope' => 'global', // only global directors may grant the director role
         ],
         'moderator' => [
             'name' => 'Moderator',
@@ -132,6 +137,16 @@ return [
         'system.settings.manage',
         'system.votes.manage',
         'system.activity-log.view',
+
+        // Role management — one grant-authority permission per grantable role.
+        // Governs both granting and revoking that role (both go through UserPolicy::updateRole).
+        'roles.director.manage',
+        'roles.moderator.manage',
+        'roles.training-staff.manage',
+        'roles.staff.manage',
+        'roles.nav-editor.manage',
+        'roles.mentor.manage',
+        'roles.buddy.manage',
     ],
 
     /*
@@ -156,6 +171,7 @@ return [
             '!examinations.create',
             '!training.reports.one-time-link',
             '!training.attachments.view-hidden',
+            'roles.*.manage',
         ],
         'moderator' => [
             'training.**',
@@ -173,6 +189,8 @@ return [
             'notifications.**',
             'tasks.**',
             'users.**',
+            'roles.mentor.manage',
+            'roles.buddy.manage',
         ],
         'training-staff' => [
             'training.**',
@@ -189,6 +207,8 @@ return [
             'notifications.**',
             'tasks.**',
             'users.**',
+            'roles.mentor.manage',
+            'roles.buddy.manage',
         ],
         'staff' => [
             'fir.positions.view',

--- a/tests/Feature/Actions/RevokeRoleTest.php
+++ b/tests/Feature/Actions/RevokeRoleTest.php
@@ -120,4 +120,24 @@ class RevokeRoleTest extends TestCase
         $this->assertSame('Request failed due to error in VATEUD API: boom', $error);
         $this->assertDatabaseHas('role_user', ['user_id' => $target->id, 'role' => 'mentor']);
     }
+
+    #[Test]
+    public function area_training_staff_can_revoke_a_mentor_in_their_area(): void
+    {
+        $area = Area::factory()->create();
+        $trainingStaff = User::factory()->create();
+        $trainingStaff->roleAssignments()->create(['role' => 'training-staff', 'area_id' => $area->id]);
+
+        $target = User::factory()->create();
+        $target->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+
+        DivisionApi::shouldReceive('removeMentor')->once()->andReturn(false);
+
+        $error = (new RevokeRole)($trainingStaff, $target, 'mentor', $area);
+
+        $this->assertNull($error);
+        $this->assertDatabaseMissing('role_user', [
+            'user_id' => $target->id, 'role' => 'mentor', 'area_id' => $area->id,
+        ]);
+    }
 }

--- a/tests/Feature/UserRoleAssignmentTest.php
+++ b/tests/Feature/UserRoleAssignmentTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Facades\DivisionApi;
 use App\Livewire\UserRoles;
 use App\Models\ActivityLog;
 use App\Models\Area;
@@ -281,5 +282,41 @@ class UserRoleAssignmentTest extends TestCase
             'role' => 'moderator',
             'area_id' => null,
         ]);
+    }
+
+    public function test_area_training_staff_can_assign_mentor_in_their_area(): void
+    {
+        DivisionApi::shouldReceive('assignMentor')->once()->andReturn(false);
+
+        $trainingStaff = User::factory()->create();
+        $trainingStaff->roleAssignments()->create(['role' => 'training-staff', 'area_id' => $this->area->id]);
+
+        Livewire::actingAs($trainingStaff)
+            ->test(UserRoles::class, ['user' => $this->target])
+            ->call('openAddModal')
+            ->set('selectedRole', 'mentor')
+            ->set('selectedAreaIds', [$this->area->id])
+            ->call('grant')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('role_user', [
+            'user_id' => $this->target->id,
+            'role' => 'mentor',
+            'area_id' => $this->area->id,
+        ]);
+    }
+
+    public function test_area_training_staff_cannot_assign_moderator_or_director(): void
+    {
+        $trainingStaff = User::factory()->create();
+        $trainingStaff->roleAssignments()->create(['role' => 'training-staff', 'area_id' => $this->area->id]);
+
+        $component = Livewire::actingAs($trainingStaff)->test(UserRoles::class, ['user' => $this->target]);
+
+        $component->set('selectedRole', 'moderator')->set('selectedAreaIds', [$this->area->id])->call('grant');
+        $component->set('selectedRole', 'director')->set('selectedAreaIds', [$this->area->id])->call('grant');
+
+        $this->assertDatabaseMissing('role_user', ['user_id' => $this->target->id, 'role' => 'moderator']);
+        $this->assertDatabaseMissing('role_user', ['user_id' => $this->target->id, 'role' => 'director']);
     }
 }

--- a/tests/Feature/UserRolesTest.php
+++ b/tests/Feature/UserRolesTest.php
@@ -132,6 +132,20 @@ class UserRolesTest extends TestCase
     }
 
     #[Test]
+    public function grantable_roles_for_training_staff_are_mentor_and_buddy(): void
+    {
+        $area = Area::factory()->create();
+        $trainingStaff = User::factory()->create();
+        $trainingStaff->roleAssignments()->create(['role' => 'training-staff', 'area_id' => $area->id]);
+        $target = User::factory()->create();
+
+        $component = Livewire::actingAs($trainingStaff)->test(UserRoles::class, ['user' => $target]);
+        $grantable = array_keys($component->instance()->grantableRoles());
+
+        $this->assertEqualsCanonicalizing(['mentor', 'buddy'], $grantable);
+    }
+
+    #[Test]
     public function global_option_for_an_area_only_role_is_not_applicable(): void
     {
         $target = User::factory()->create();

--- a/tests/Unit/RolePermissionTest.php
+++ b/tests/Unit/RolePermissionTest.php
@@ -211,4 +211,27 @@ class RolePermissionTest extends TestCase
 
         $this->assertCount(1, User::allWithPermission('test-permission', $area));
     }
+
+    public function test_has_global_permission_true_only_for_a_global_holder(): void
+    {
+        config(['roles.matrix.moderator' => ['training.view', 'test-permission']]);
+
+        $globalHolder = User::factory()->create();
+        $globalHolder->roleAssignments()->create(['role' => 'moderator', 'area_id' => null]);
+
+        $areaHolder = User::factory()->create();
+        $areaHolder->roleAssignments()->create(['role' => 'moderator', 'area_id' => Area::factory()->create()->id]);
+
+        $this->assertTrue($globalHolder->hasGlobalPermission('test-permission'));
+        $this->assertFalse($areaHolder->hasGlobalPermission('test-permission'));
+    }
+
+    public function test_has_global_permission_false_for_unregistered_permission(): void
+    {
+        $admin = User::factory()->create();
+        $admin->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        // Even though admin grants '**', an unregistered permission resolves to no roles.
+        $this->assertFalse($admin->hasGlobalPermission('does-not-exist'));
+    }
 }

--- a/tests/Unit/RolesConfigTest.php
+++ b/tests/Unit/RolesConfigTest.php
@@ -46,4 +46,16 @@ class RolesConfigTest extends TestCase
             $this->assertNotEmpty($matrix->rolesFor($permission), "Permission '{$permission}' is granted to no role.");
         }
     }
+
+    public function test_role_management_permissions_are_registered_and_granted(): void
+    {
+        $matrix = new PermissionMatrix;
+        $grantableRoles = array_keys(array_diff_key(config('roles.roles'), ['admin' => true]));
+
+        foreach ($grantableRoles as $role) {
+            $permission = "roles.{$role}.manage";
+            $this->assertContains($permission, $matrix->all(), "{$permission} is not registered in the catalogue.");
+            $this->assertNotEmpty($matrix->rolesFor($permission), "{$permission} is granted by no role.");
+        }
+    }
 }


### PR DESCRIPTION
Replace hard-coded role-name checks in UserPolicy::updateRole with
config-driven roles.<role>.manage permissions and a per-role
grant_scope, making grant authority declarative. Adds
User::hasGlobalPermission. 

Training staff can now assign mentors. Again.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary by Sourcery

Make role granting and revocation authority configuration-driven via permissions and grant scopes rather than hard-coded role checks.

New Features:
- Introduce per-role roles.<role>.manage permissions and grant_scope configuration to control who can grant or revoke each role.
- Add User::hasGlobalPermission to check permissions held via global role assignments only.

Enhancements:
- Refactor UserPolicy::updateRole to use permission-based, matrix-driven checks for grant authority instead of hard-coded role-name logic.
- Extend the roles permission matrix to include role-management permissions and ensure they are registered and granted to at least one role.

Tests:
- Add feature and unit tests covering training-staff authority to grant and revoke mentor roles, grantable roles for training staff, and global permission behavior.
- Add configuration tests ensuring all role-management permissions are present in the permission catalogue and assigned to some role.