### PR TITLE
feat(user): move recent connections & activity graph to second column

### DIFF
--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -99,17 +99,6 @@
         <div class="card shadow mb-4">
             <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
                 <h6 class="m-0 fw-bold text-white">
-                    Activity
-                </h6>
-            </div>
-            <div class="card-body">
-                <canvas id="activityChart"></canvas>
-            </div>
-        </div>
-
-        <div class="card shadow mb-4">
-            <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
-                <h6 class="m-0 fw-bold text-white">
                     Mentoring
                 </h6>
                 <a href="{{ route('user.reports', $user->id) }}" class="btn btn-icon btn-light"><i class="fas fa-file"></i> See reports</a>
@@ -134,47 +123,6 @@
                                     <td>{{ Carbon\Carbon::parse($user->teaches->find($training->id)->pivot->expire_at)->toEuropeanDate() }}</td>
                                 </tr>
                                 @endforeach
-                            </tbody>
-                        </table>
-                    </div>
-                @endif
-
-            </div>
-        </div>
-
-        <div class="card shadow mb-4">
-            <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
-                <h6 class="m-0 fw-bold text-white">
-                    Recent Connections
-                </h6>
-            </div>
-            <div class="card-body {{ $recentAtcSessions->count() == 0 ? '' : 'p-0' }}">
-
-                @if($recentAtcSessions->count() == 0)
-                    <p class="mb-0">No recent ATC sessions</p>
-                @else
-                    <div class="table-responsive">
-                        <table class="table table-sm table-leftpadded mb-0" width="100%" cellspacing="0">
-                            <thead class="table-light">
-                                <tr>
-                                    <th data-sortable="true">Callsign</th>
-                                    <th data-sortable="true">Date</th>
-                                    <th data-sortable="true">Time</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach($recentAtcSessions as $session)
-                                <tr>
-                                    <td>{{ $session['callsign'] }}</td>
-                                    <td>{{ isset($session['start']) ? Carbon\Carbon::parse($session['start'])->toEuropeanDateTime() : '—' }}</td>
-                                    <td>{{ $session['duration'] ?? '—' }}</td>
-                                </tr>
-                                @endforeach
-                                <tr>
-                                    <td colspan="3" class="text-center">
-                                        <a href="https://stats.vatsim.net/stats/{{ $user->id }}" target="_blank" rel="noopener noreferrer">View additional sessions</a>
-                                    </td>
-                                </tr>
                             </tbody>
                         </table>
                     </div>
@@ -308,6 +256,64 @@
                                                 </td>
                                             </tr>
                                         @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+                        @endif
+
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-xl-8 col-lg-12 col-md-12">
+                <div class="card shadow mb-4">
+                    <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
+                        <h6 class="m-0 fw-bold text-white">
+                            Activity
+                        </h6>
+                    </div>
+                    <div class="card-body">
+                        <canvas id="activityChart"></canvas>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-xl-4 col-lg-12 col-md-12">
+                <div class="card shadow mb-4">
+                    <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
+                        <h6 class="m-0 fw-bold text-white">
+                            Recent Connections
+                        </h6>
+                    </div>
+                    <div class="card-body {{ $recentAtcSessions->count() == 0 ? '' : 'p-0' }}">
+
+                        @if($recentAtcSessions->count() == 0)
+                            <p class="mb-0">No recent ATC sessions</p>
+                        @else
+                            <div class="table-responsive">
+                                <table class="table table-sm table-leftpadded mb-0" width="100%" cellspacing="0">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th data-sortable="true">Callsign</th>
+                                            <th data-sortable="true">Date</th>
+                                            <th data-sortable="true">Time</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach($recentAtcSessions as $session)
+                                        <tr>
+                                            <td>{{ $session['callsign'] }}</td>
+                                            <td>{{ isset($session['start']) ? Carbon\Carbon::parse($session['start'])->toEuropeanDateTime() : '—' }}</td>
+                                            <td>{{ $session['duration'] ?? '—' }}</td>
+                                        </tr>
+                                        @endforeach
+                                        <tr>
+                                            <td colspan="3" class="text-center">
+                                                <a href="https://stats.vatsim.net/stats/{{ $user->id }}" target="_blank" rel="noopener noreferrer">View additional sessions</a>
+                                            </td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </div>


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary by Sourcery

Enhancements:
- Group the activity chart and recent connections into a responsive two-column row in the main content area of the user detail page.