### PR TITLE
fix(user): make activity graph reflow on browser resize

### DIFF
--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -275,7 +275,9 @@
                         </h6>
                     </div>
                     <div class="card-body">
-                        <canvas id="activityChart"></canvas>
+                        <div class="ratio ratio-21x9">
+                            <canvas id="activityChart"></canvas>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -567,7 +569,7 @@
 
                     // Handle empty response - user has no ATC sessions
                     if (!Array.isArray(data) || data.length === 0) {
-                        chartElement.parentElement.innerHTML = '<p class="mb-0">No ATC activity data available</p>';
+                        chartElement.closest('.card-body').innerHTML = '<p class="mb-0">No ATC activity data available</p>';
                         return;
                     }
 
@@ -616,11 +618,15 @@
                                 borderWidth: 1
                             }]
                         },
+                        options: {
+                            responsive: true,
+                            maintainAspectRatio: false,
+                        },
                     });
                 })
                 .catch(error => {
                     console.error('Statistics API error:', error);
-                    chartElement.parentElement.innerHTML = '<p class="mb-0 text-danger">Failed to load activity data</p>';
+                    chartElement.closest('.card-body').innerHTML = '<p class="mb-0 text-danger">Failed to load activity data</p>';
                 });
         });
     </script>


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary by Sourcery

Ensure the user activity chart is responsive and correctly reflows within the profile page layout.

Bug Fixes:
- Fix activity chart not reflowing on browser resize by enabling Chart.js responsiveness and using a fixed-height container.
- Correct activity chart empty/error state rendering to target the card body instead of the canvas container.