### PR TITLE
Show booked training sessions to mentors

### DIFF
--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -346,11 +346,12 @@ class TrainingController extends Controller
         $activeTrainingInterest = TrainingInterest::where('training_id', $training->id)->where('expired', false)->get()->count();
 
         $relatedTasks = $training->tasks->sortByDesc('created_at');
+        $trainingSessions = $training->trainingSessions()->with('position')->get();
 
         $requestTypes = TaskController::getTypes();
         $requestPopularAssignees = TaskController::getPopularAssignees($training->area);
 
-        return view('training.show', compact('training', 'reportsAndExams', 'trainingMentors', 'types', 'experiences', 'activities', 'trainingInterests', 'activeTrainingInterest', 'relatedTasks', 'requestTypes', 'requestPopularAssignees'));
+        return view('training.show', compact('training', 'reportsAndExams', 'trainingMentors', 'types', 'experiences', 'activities', 'trainingInterests', 'activeTrainingInterest', 'relatedTasks', 'trainingSessions', 'requestTypes', 'requestPopularAssignees'));
     }
 
     /**

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -249,6 +249,17 @@ class Training extends Model
     }
 
     /**
+     * Get the student's bookings that are tagged as training sessions.
+     */
+    public function trainingSessions(): HasMany
+    {
+        return $this->hasMany(Booking::class, 'user_id', 'user_id')
+            ->where('training', true)
+            ->where('deleted', false)
+            ->orderBy('time_start');
+    }
+
+    /**
      * Get the one time links associated with the training.
      */
     public function onetimelink(): HasMany

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -344,7 +344,15 @@ class User extends Authenticatable
     {
         $trainings = Training::where('status', '>=', TrainingStatus::PRE_TRAINING)->whereHas('mentors', function ($query) {
             $query->where('user_id', $this->id);
-        })->with('area', 'ratings', 'reports', 'user')->orderBy('id')->get();
+        })->with([
+            'area',
+            'ratings',
+            'reports',
+            'user',
+            'trainingSessions' => fn ($query) => $query
+                ->where('time_start', '>=', now())
+                ->with('position'),
+        ])->orderBy('id')->get();
 
         return $trainings;
     }

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -156,6 +156,7 @@
                                 <th>Area</th>
                                 <th>State</th>
                                 <th>Last Training</th>
+                                <th>Next Training Session</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -196,6 +197,19 @@
                                         </span>
                                     @else
                                         No registered training yet
+                                    @endif
+                                </td>
+                                <td>
+                                    @if($training->trainingSessions->isNotEmpty())
+                                        @php($nextTrainingSession = $training->trainingSessions->first())
+                                        <span title="{{ \Carbon\Carbon::create($nextTrainingSession->time_start)->toEuropeanDateTime() }}">
+                                            {{ \Carbon\Carbon::create($nextTrainingSession->time_start)->toEuropeanDate(true) }}
+                                            {{ \Carbon\Carbon::create($nextTrainingSession->time_start)->toEuropeanTime() }}
+                                        </span>
+                                        <br>
+                                        <span class="text-muted">{{ $nextTrainingSession->position->callsign }}</span>
+                                    @else
+                                        Not booked
                                     @endif
                                 </td>
                             </tr>

--- a/resources/views/training/show.blade.php
+++ b/resources/views/training/show.blade.php
@@ -601,6 +601,42 @@
             </div>
         </div>
 
+        <div class="card shadow mb-4">
+            <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
+                <h6 class="m-0 fw-bold text-white">
+                    Training Sessions
+                </h6>
+            </div>
+            <div class="card-body {{ $trainingSessions->count() == 0 ? '' : 'p-0' }}">
+                @if($trainingSessions->count() == 0)
+                    <p class="mb-0">No training sessions booked</p>
+                @else
+                    <div class="table-responsive">
+                        <table class="table table-sm table-leftpadded mb-0" width="100%" cellspacing="0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Start</th>
+                                    <th>End</th>
+                                    <th>Position</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($trainingSessions as $trainingSession)
+                                    <tr>
+                                        <td>{{ \Carbon\Carbon::create($trainingSession->time_start)->toEuropeanDate(true) }}</td>
+                                        <td>{{ \Carbon\Carbon::create($trainingSession->time_start)->toEuropeanTime() }}</td>
+                                        <td>{{ \Carbon\Carbon::create($trainingSession->time_end)->toEuropeanTime() }}</td>
+                                        <td>{{ $trainingSession->position->callsign }} ({{ $trainingSession->position->name }})</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                @endif
+            </div>
+        </div>
+
     </div>
 </div>
 

--- a/tests/Feature/TrainingSessionsDisplayTest.php
+++ b/tests/Feature/TrainingSessionsDisplayTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Helpers\TrainingStatus;
+use App\Models\Area;
+use App\Models\Booking;
+use App\Models\Position;
+use App\Models\Training;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TrainingSessionsDisplayTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function dashboard_shows_the_next_tagged_training_booking_for_each_student(): void
+    {
+        Carbon::setTestNow('2026-08-14 12:00:00');
+
+        $area = Area::factory()->create();
+        $mentor = User::factory()->create();
+        $student = User::factory()->create();
+        $position = Position::factory()->for($area)->create([
+            'callsign' => 'EKCH_TWR',
+            'name' => 'Copenhagen Tower',
+        ]);
+        $laterPosition = Position::factory()->for($area)->create([
+            'callsign' => 'EKDK_CTR',
+            'name' => 'Copenhagen Control',
+        ]);
+        $training = Training::factory()->for($student)->for($area)->create([
+            'status' => TrainingStatus::ACTIVE_TRAINING,
+        ]);
+
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $area->id]);
+        $training->mentors()->attach($mentor, ['expire_at' => now()->addYear()]);
+
+        $this->createBooking($student, $position, now()->subDay(), true);
+        $this->createBooking($student, $laterPosition, now()->addDays(3), true);
+        $nextBooking = $this->createBooking($student, $position, now()->addDay(), true);
+
+        $response = $this->actingAs($mentor)->get(route('dashboard'));
+
+        $response->assertOk()
+            ->assertSee('Next Training Session')
+            ->assertSee(Carbon::parse($nextBooking->time_start)->toEuropeanDate(true))
+            ->assertSee(Carbon::parse($nextBooking->time_start)->toEuropeanTime())
+            ->assertSee('EKCH_TWR')
+            ->assertDontSee('EKDK_CTR');
+    }
+
+    #[Test]
+    public function training_page_lists_only_non_deleted_bookings_with_the_training_tag(): void
+    {
+        $area = Area::factory()->create();
+        $student = User::factory()->create();
+        $otherStudent = User::factory()->create();
+        $training = Training::factory()->for($student)->for($area)->create([
+            'status' => TrainingStatus::ACTIVE_TRAINING,
+        ]);
+        $firstPosition = Position::factory()->for($area)->create([
+            'callsign' => 'FIRST_TWR',
+            'name' => 'First Tower',
+        ]);
+        $secondPosition = Position::factory()->for($area)->create([
+            'callsign' => 'SECOND_APP',
+            'name' => 'Second Approach',
+        ]);
+        $untaggedPosition = Position::factory()->for($area)->create(['callsign' => 'UNTAGGED']);
+        $deletedPosition = Position::factory()->for($area)->create(['callsign' => 'DELETED']);
+        $otherPosition = Position::factory()->for($area)->create(['callsign' => 'OTHER_TWR']);
+
+        $this->createBooking($student, $secondPosition, now()->addDays(2), true);
+        $this->createBooking($student, $firstPosition, now()->subDay(), true);
+        $this->createBooking($student, $untaggedPosition, now()->addDay(), false);
+        $this->createBooking($student, $deletedPosition, now()->addDay(), true, true);
+        $this->createBooking($otherStudent, $otherPosition, now()->addDay(), true);
+
+        $response = $this->actingAs($student)->get(route('training.show', $training));
+
+        $response->assertOk()
+            ->assertSee('Training Sessions')
+            ->assertSeeInOrder(['FIRST_TWR', 'SECOND_APP'])
+            ->assertDontSee('UNTAGGED')
+            ->assertDontSee('DELETED')
+            ->assertDontSee('OTHER_TWR');
+    }
+
+    private function createBooking(
+        User $user,
+        Position $position,
+        Carbon $start,
+        bool $training,
+        bool $deleted = false,
+    ): Booking {
+        return Booking::factory()->create([
+            'callsign' => $position->callsign,
+            'position_id' => $position->id,
+            'name' => $user->name,
+            'user_id' => $user->id,
+            'time_start' => $start,
+            'time_end' => $start->copy()->addHours(2),
+            'training' => $training,
+            'deleted' => $deleted,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- add a **Next Training Session** column to **My Students** on the dashboard
- show the earliest upcoming booking tagged as training, including date, time, and position
- show **Not booked** when a student has no upcoming tagged session
- add a chronological **Training Sessions** table below **Related Tasks** on each training page
- correlate sessions through the student and include only bookings where `training = true` and `deleted = false`

Inspired by [issue #516](https://github.com/Vatsim-Scandinavia/controlcenter/issues/516).

## Why this helps

Mentors currently need to cross-reference the booking calendar with their student list to understand whether practical training has been arranged. Showing the next session directly on the dashboard makes it quicker to:

- prepare for the correct position and time
- identify students who still need a session booked
- prioritize follow-up without opening each booking separately

For the training department, the chronological list on the training page keeps the student's booked training activity alongside reports, tasks, mentors, and other case information. This reduces context switching and makes coordination and review easier.

## Implementation

The booking correlation uses the training student's `user_id`. Deleted bookings and bookings without the training tag are excluded. The dashboard loads only future sessions and displays the earliest one; the training page displays all matching sessions in chronological order.

## Testing

- `TrainingSessionsDisplayTest` covers upcoming/past, tagged/untagged, deleted, and other-student bookings
- focused regression suite: **10 tests, 28 assertions**
- Laravel Pint
- Blade template compilation

## Summary by Sourcery

Display upcoming, tagged training bookings for students to mentors on the dashboard and training detail pages.

New Features:
- Add a Next Training Session column to the mentor dashboard student list showing the earliest upcoming tagged training booking with date, time, and position.
- Add a Training Sessions table to the training detail page listing all non-deleted, tagged training bookings for the student in chronological order.

Enhancements:
- Introduce a trainingSessions relationship on Training to filter, order, and reuse tagged, non-deleted student bookings.
- Extend mentoringTrainings loading to eager-load upcoming trainingSessions with their positions for dashboard display.

Tests:
- Add feature tests verifying dashboard next-session display logic and training page session filtering for tagged, non-deleted, student-specific bookings.