### PR TITLE
refactor(logs): string-backed enum for the category names

### DIFF
--- a/app/Console/Commands/UpdateMemberDetails.php
+++ b/app/Console/Commands/UpdateMemberDetails.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use anlutro\LaravelSettings\Facade as Setting;
+use App\Helpers\LogName;
 use App\Helpers\TrainingStatus;
 use App\Models\AtcActivity;
 use App\Models\Training;
@@ -104,7 +105,7 @@ class UpdateMemberDetails extends Command
             $training->user->notify(new TrainingClosedNotification($training, TrainingStatus::CLOSED_BY_SYSTEM, 'Student has left the division.'));
 
             // Log the closure
-            ActivityLogService::warning('TRAINING', 'Closed training request ' . $training->id . ' due to student leaving division');
+            ActivityLogService::warning(LogName::Training, 'Closed training request ' . $training->id . ' due to student leaving division');
 
             $count++;
         }

--- a/app/Helpers/LogName.php
+++ b/app/Helpers/LogName.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Helpers;
+
+/**
+ * Category of an activity log entry. Values are lowercase because they are
+ * stored verbatim as the activity log_name.
+ */
+enum LogName: string
+{
+    case Access = 'access';
+    case Booking = 'booking';
+    case Endorsement = 'endorsement';
+    case Feedback = 'feedback';
+    case Other = 'other';
+    case Role = 'role';
+    case Sector = 'sector';
+    case Training = 'training';
+}

--- a/app/Http/Controllers/API/BookingController.php
+++ b/app/Http/Controllers/API/BookingController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API;
 
 use App;
+use App\Helpers\LogName;
 use App\Helpers\TrainingStatus;
 use App\Helpers\VatsimRating;
 use App\Http\Controllers\Controller;
@@ -165,7 +166,7 @@ class BookingController extends Controller
 
         $booking->save();
 
-        ActivityLogService::info('BOOKING', 'Created booking booking' . $booking->id . ' via API' .
+        ActivityLogService::info(LogName::Booking, 'Created booking booking' . $booking->id . ' via API' .
             ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
             ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
             ' ― Position: ' . Position::find($booking->position_id)->callsign);
@@ -335,7 +336,7 @@ class BookingController extends Controller
 
         $booking->save();
 
-        ActivityLogService::info('BOOKING', 'Updated booking booking ' . $booking->id . ' via API' .
+        ActivityLogService::info(LogName::Booking, 'Updated booking booking ' . $booking->id . ' via API' .
             ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
             ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
             ' ― Position: ' . Position::find($booking->position_id)->callsign);
@@ -368,7 +369,7 @@ class BookingController extends Controller
 
         $booking->save();
 
-        ActivityLogService::warning('BOOKING', 'Deleted booking booking ' . $booking->id . ' via API' .
+        ActivityLogService::warning(LogName::Booking, 'Deleted booking booking ' . $booking->id . ' via API' .
             ' ― from ' . Carbon::parse($booking->time_start)->toEuropeanDateTime() .
             ' → ' . Carbon::parse($booking->time_end)->toEuropeanDateTime() .
             ' ― Position: ' . Position::find($booking->position_id)->callsign);

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Helpers\LogName;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\OAuthController;
 use App\Models\User;
@@ -92,9 +93,9 @@ class LoginController extends Controller
 
         $roles = \Auth::user()->roleAssignments->pluck('role')->unique();
         if ($roles->isNotEmpty()) {
-            ActivityLogService::warning('ACCESS', 'Logged in with ' . $roles->join(', ') . ' access');
+            ActivityLogService::warning(LogName::Access, 'Logged in with ' . $roles->join(', ') . ' access');
         } else {
-            ActivityLogService::info('ACCESS', 'Logged in with User access');
+            ActivityLogService::info(LogName::Access, 'Logged in with User access');
         }
 
         return redirect()->intended(route('dashboard'))->withSuccess('Login Successful');
@@ -141,7 +142,7 @@ class LoginController extends Controller
      */
     public function logout()
     {
-        ActivityLogService::info('ACCESS', 'Logged out.');
+        ActivityLogService::info(LogName::Access, 'Logged out.');
         auth()->logout();
 
         return redirect(route('front'))->withSuccess('You have been successfully logged out');

--- a/app/Http/Controllers/EndorsementController.php
+++ b/app/Http/Controllers/EndorsementController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Facades\DivisionApi;
+use App\Helpers\LogName;
 use App\Helpers\TrainingStatus;
 use App\Models\Area;
 use App\Models\Endorsement;
@@ -144,7 +145,7 @@ class EndorsementController extends Controller
             // Add ratings
             $endorsement->ratings()->save(Rating::find($data['ratingFACILITY']));
 
-            ActivityLogService::warning('ENDORSEMENT', 'Created facility endorsement ' .
+            ActivityLogService::warning(LogName::Endorsement, 'Created facility endorsement ' .
             ' ― User: ' . $endorsement->user_id .
             ' ― Rating: ' . Rating::find($data['ratingFACILITY'])->name);
 
@@ -211,7 +212,7 @@ class EndorsementController extends Controller
             // Add positions
             $endorsement->positions()->save(Position::where('callsign', $data['position'])->get()->first());
 
-            ActivityLogService::warning('ENDORSEMENT', 'Created SOLO endorsement ' .
+            ActivityLogService::warning(LogName::Endorsement, 'Created SOLO endorsement ' .
             ' ― User: ' . $endorsement->user_id .
             ' ― Positions: ' . $data['position']);
 
@@ -250,7 +251,7 @@ class EndorsementController extends Controller
             $endorsement->ratings()->save(Rating::find($data['ratingGRP']));
             $endorsement->areas()->saveMany(Area::find($data['areas']));
 
-            ActivityLogService::warning('ENDORSEMENT', 'Created ' . $endorsementType . ' endorsement ' .
+            ActivityLogService::warning(LogName::Endorsement, 'Created ' . $endorsementType . ' endorsement ' .
             ' ― User: ' . $endorsement->user_id .
             ' ― Rating: ' . $data['ratingGRP'] .
             ' ― Areas: ' . implode(',', $data['areas']));
@@ -278,7 +279,7 @@ class EndorsementController extends Controller
             $endorsement->areas()->saveMany(Area::find($data['areas']));
             $endorsement->ratings()->save(Rating::find($data['ratingGRP']));
 
-            ActivityLogService::warning('ENDORSEMENT', 'Created ' . $endorsementType . ' endorsement ' .
+            ActivityLogService::warning(LogName::Endorsement, 'Created ' . $endorsementType . ' endorsement ' .
             ' ― User: ' . $endorsement->user_id .
             ' ― Areas: ' . implode(',', $data['areas']));
 
@@ -329,7 +330,7 @@ class EndorsementController extends Controller
         $endorsement->valid_to = now();
         $endorsement->save();
 
-        ActivityLogService::warning('ENDORSEMENT', 'Deleted ' . $user->name . '\'s ' . $endorsement->type . ' endorsement');
+        ActivityLogService::warning(LogName::Endorsement, 'Deleted ' . $user->name . '\'s ' . $endorsement->type . ' endorsement');
         if ($endorsement->type == 'SOLO') {
             $endorsement->user->notify(new EndorsementRevokedNotification($endorsement));
 
@@ -368,7 +369,7 @@ class EndorsementController extends Controller
         $endorsement->valid_to = $date;
         $endorsement->save();
 
-        ActivityLogService::warning('ENDORSEMENT', 'Shortened ' . User::find($endorsement->user_id)->name . '\'s ' . $endorsement->type . ' endorsement to date ' . $date);
+        ActivityLogService::warning(LogName::Endorsement, 'Shortened ' . User::find($endorsement->user_id)->name . '\'s ' . $endorsement->type . ' endorsement to date ' . $date);
         $endorsement->user->notify(new EndorsementModifiedNotification($endorsement));
 
         return redirect()->back()->withSuccess(User::find($endorsement->user_id)->name . "'s " . $endorsement->type . ' endorsement shortened to ' . Carbon::parse($date)->toEuropeanDateTime() . '. E-mail sent to student.');

--- a/app/Http/Controllers/GlobalSettingController.php
+++ b/app/Http/Controllers/GlobalSettingController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use anlutro\LaravelSettings\Facade as Setting;
+use App\Helpers\LogName;
 use App\Rules\InactivityReminderHours;
 use App\Services\ActivityLogService;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -114,7 +115,7 @@ class GlobalSettingController extends Controller
         Setting::set('telemetryEnabled', $telemetryEnabled);
         Setting::save();
 
-        ActivityLogService::danger('OTHER', 'Global Settings Updated');
+        ActivityLogService::danger(LogName::Other, 'Global Settings Updated');
 
         return redirect()->intended(route('admin.settings'))->withSuccess('Server settings successfully changed');
     }

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\LogName;
 use App\Models\Area;
 use App\Services\ActivityLogService;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -63,7 +64,7 @@ class NotificationController extends Controller
 
         $area->save();
 
-        ActivityLogService::warning('OTHER', 'Training Notification Text Updated ― Area: ' . $area->name);
+        ActivityLogService::warning(LogName::Other, 'Training Notification Text Updated ― Area: ' . $area->name);
 
         return redirect()->intended(route('admin.templates.area', $area->id))->withSuccess($area->name . "'s notifications updated.");
     }

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -8,6 +8,7 @@ use App\Exceptions\PolicyMethodMissingException;
 use App\Exceptions\PolicyMissingException;
 use App\Facades\DivisionApi;
 use App\Helpers\InterestStatus;
+use App\Helpers\LogName;
 use App\Helpers\TrainingStatus;
 use App\Helpers\VatsimRating;
 use App\Models\Area;
@@ -296,7 +297,7 @@ class TrainingController extends Controller
 
         $training->ratings()->saveMany($ratings);
 
-        ActivityLogService::info('TRAINING', 'Created training request ' . $training->id . ' for CID ' . $training->user_id . ' ― Ratings: ' . $ratings->pluck('name') . ' in ' . Area::find($training->area_id)->name);
+        ActivityLogService::info(LogName::Training, 'Created training request ' . $training->id . ' for CID ' . $training->user_id . ' ― Ratings: ' . $ratings->pluck('name') . ' in ' . Area::find($training->area_id)->name);
 
         // Send confimration mail
         $training->user->notify(new TrainingCreatedNotification($training));
@@ -415,7 +416,7 @@ class TrainingController extends Controller
         $training->save();
 
         // Log the action
-        ActivityLogService::warning('TRAINING', 'Updated training request ' . $training->id .
+        ActivityLogService::warning(LogName::Training, 'Updated training request ' . $training->id .
         ' ― Old Ratings: ' . $preChangeRatings->pluck('name') .
         ' ― New Ratings: ' . $ratings->pluck('name') .
         ' ― Old Training type: ' . TrainingController::$types[$preChangeType]['text'] .
@@ -531,7 +532,7 @@ class TrainingController extends Controller
         // Update the training
         $training->update($attributes);
 
-        ActivityLogService::warning('TRAINING', 'Updated training details ' . $training->id .
+        ActivityLogService::warning(LogName::Training, 'Updated training details ' . $training->id .
         ' ― Old Status: ' . $oldStatus->label() .
         ' ― New Status: ' . $training->status->label() .
         ' ― Mentor: ' . $training->mentors->pluck('name'));
@@ -636,7 +637,7 @@ class TrainingController extends Controller
     public function close(Training $training)
     {
         $this->authorize('close', $training);
-        ActivityLogService::warning('TRAINING', 'Student closed training request ' . $training->id .
+        ActivityLogService::warning(LogName::Training, 'Student closed training request ' . $training->id .
         ' ― Status: ' . $training->status->label() .
         ' ― Training type: ' . TrainingController::$types[$training->type]['text']);
         TrainingActivityController::create($training->id, 'STATUS', TrainingStatus::CLOSED_BY_STUDENT->value, $training->status->value, $training->user->id);
@@ -667,7 +668,7 @@ class TrainingController extends Controller
         $training->pre_training_completed = $newState;
         $training->save();
 
-        ActivityLogService::warning('TRAINING', 'Student marked pre-training as completed ' . $training->id);
+        ActivityLogService::warning(LogName::Training, 'Student marked pre-training as completed ' . $training->id);
         TrainingActivityController::create($training->id, 'PRETRAINING', $newState, $oldState, Auth::id());
 
         return redirect($training->path())->withSuccess('Pre-training marked as ' . ($newState ? 'completed' : 'not completed'));
@@ -702,7 +703,7 @@ class TrainingController extends Controller
             $interest->expired = InterestStatus::CLOSED;
             $interest->save();
 
-            ActivityLogService::info('TRAINING', 'Training interest confirmed.');
+            ActivityLogService::info(LogName::Training, 'Training interest confirmed.');
 
             return redirect()->to($training->path())->withSuccess('Interest successfully confirmed');
         }

--- a/app/Http/Controllers/TrainingExaminationController.php
+++ b/app/Http/Controllers/TrainingExaminationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Facades\DivisionApi;
+use App\Helpers\LogName;
 use App\Helpers\TrainingStatus;
 use App\Helpers\VatsimRating;
 use App\Models\OneTimeLink;
@@ -173,7 +174,7 @@ class TrainingExaminationController extends Controller
         $this->authorize('delete', $examination);
 
         $examination->delete();
-        ActivityLogService::danger('TRAINING', 'Deleted training examination ' . $examination->id . ' ― From Training ' . $examination->training->id);
+        ActivityLogService::danger(LogName::Training, 'Deleted training examination ' . $examination->id . ' ― From Training ' . $examination->training->id);
 
         if ($request->wantsJson()) {
             return response()->json(['message' => 'Examination successfully deleted']);

--- a/app/Http/Controllers/VoteController.php
+++ b/app/Http/Controllers/VoteController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\LogName;
 use App\Models\Vote;
 use App\Models\VoteOption;
 use App\Services\ActivityLogService;
@@ -102,7 +103,7 @@ class VoteController extends Controller
             $vote_option->save();
         }
 
-        ActivityLogService::danger('OTHER', 'Created vote ' . $vote->id . ' ― Question: ' . $vote->question);
+        ActivityLogService::danger(LogName::Other, 'Created vote ' . $vote->id . ' ― Question: ' . $vote->question);
 
         return redirect()->intended(route('vote.overview'))->withSuccess('Vote succesfully created.');
     }
@@ -153,7 +154,7 @@ class VoteController extends Controller
         $user = \Auth::user();
         $vote->user()->attach($user);
 
-        ActivityLogService::info('OTHER', 'Voted in vote poll ' . $vote->id);
+        ActivityLogService::info(LogName::Other, 'Voted in vote poll ' . $vote->id);
 
         return redirect()->intended(route('vote.show', $vote->id))->withSuccess('Your vote is succesfully registered.');
     }

--- a/app/Models/Endorsement.php
+++ b/app/Models/Endorsement.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Helpers\LogName;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
@@ -21,7 +22,7 @@ class Endorsement extends Model
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
-            ->useLogName('endorsement')
+            ->useLogName(LogName::Endorsement)
             ->logOnly(['type', 'valid_from', 'valid_to', 'expired', 'revoked', 'user_id'])
             ->logOnlyDirty()
             ->dontLogEmptyChanges();

--- a/app/Models/Feedback.php
+++ b/app/Models/Feedback.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Contracts\DescribesActivityChanges;
+use App\Helpers\LogName;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -41,7 +42,7 @@ class Feedback extends Model implements DescribesActivityChanges
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
-            ->useLogName('feedback')
+            ->useLogName(LogName::Feedback)
             ->logOnly(['reference_user_id', 'reference_position_id'])
             ->logOnlyDirty()
             ->dontLogEmptyChanges()

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Helpers\LogName;
 use App\Helpers\VatsimRating;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -25,7 +26,7 @@ class Position extends Model
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
-            ->useLogName('sector')
+            ->useLogName(LogName::Sector)
             ->logOnly(['callsign', 'name', 'frequency', 'fir', 'rating', 'area_id'])
             ->logOnlyDirty()
             ->dontLogEmptyChanges()

--- a/app/Models/RoleAssignment.php
+++ b/app/Models/RoleAssignment.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Helpers\LogName;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -90,7 +91,7 @@ class RoleAssignment extends Model
             return;
         }
 
-        activity('role')
+        activity(LogName::Role)
             ->performedOn($user)
             ->event($event)
             ->withProperties([

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Helpers\InterestStatus;
+use App\Helpers\LogName;
 use App\Helpers\TrainingStatus;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -22,7 +23,7 @@ class Training extends Model
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
-            ->useLogName('training')
+            ->useLogName(LogName::Training)
             ->logOnly(['status', 'type', 'user_id', 'paused_at', 'closed_reason'])
             ->logOnlyDirty()
             ->dontLogEmptyChanges();

--- a/app/Services/ActivityLogService.php
+++ b/app/Services/ActivityLogService.php
@@ -3,8 +3,8 @@
 namespace App\Services;
 
 use App\Helpers\ActivityLevel;
+use App\Helpers\LogName;
 use App\Models\ActivityLog;
-use Illuminate\Support\Str;
 
 /**
  * Backwards-compatible logging shims over the activity() helper.
@@ -16,32 +16,32 @@ use Illuminate\Support\Str;
 class ActivityLogService
 {
     /**
-     * Write a legacy-style log entry, mapping the free-text category onto the
-     * activity log_name and the severity onto the level.
+     * Write a legacy-style log entry, mapping the category onto the activity
+     * log_name and the severity onto the level.
      */
-    private static function record(ActivityLevel $level, string $category, string $message): void
+    private static function record(ActivityLevel $level, LogName $category, string $message): void
     {
-        activity(Str::lower($category))
+        activity($category)
             ->tap(fn (ActivityLog $log) => $log->level = $level)
             ->log($message);
     }
 
-    public static function debug(string $category, string $message): void
+    public static function debug(LogName $category, string $message): void
     {
         self::record(ActivityLevel::Debug, $category, $message);
     }
 
-    public static function info(string $category, string $message): void
+    public static function info(LogName $category, string $message): void
     {
         self::record(ActivityLevel::Info, $category, $message);
     }
 
-    public static function warning(string $category, string $message): void
+    public static function warning(LogName $category, string $message): void
     {
         self::record(ActivityLevel::Warning, $category, $message);
     }
 
-    public static function danger(string $category, string $message): void
+    public static function danger(LogName $category, string $message): void
     {
         self::record(ActivityLevel::Danger, $category, $message);
     }

--- a/app/Services/BookingService.php
+++ b/app/Services/BookingService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use anlutro\LaravelSettings\Facade as Setting;
+use App\Helpers\LogName;
 use App\Helpers\TrainingStatus;
 use App\Helpers\VatsimRating;
 use App\Models\Booking;
@@ -192,17 +193,17 @@ class BookingService
     public function logBookingCreated(Booking|Sweatbook $booking, bool $bulk = false): void
     {
         $kind = $bulk ? 'booking BULK' : $this->bookingKind($booking);
-        ActivityLogService::info('BOOKING', 'Created ' . $kind . ' ' . $this->describeBooking($booking));
+        ActivityLogService::info(LogName::Booking, 'Created ' . $kind . ' ' . $this->describeBooking($booking));
     }
 
     public function logBookingUpdated(Booking|Sweatbook $booking): void
     {
-        ActivityLogService::info('BOOKING', 'Updated ' . $this->bookingKind($booking) . ' ' . $this->describeBooking($booking));
+        ActivityLogService::info(LogName::Booking, 'Updated ' . $this->bookingKind($booking) . ' ' . $this->describeBooking($booking));
     }
 
     public function logBookingDeleted(Booking|Sweatbook $booking): void
     {
-        ActivityLogService::warning('BOOKING', 'Deleted ' . $this->bookingKind($booking) . ' ' . $this->describeBooking($booking));
+        ActivityLogService::warning(LogName::Booking, 'Deleted ' . $this->bookingKind($booking) . ' ' . $this->describeBooking($booking));
     }
 
     private function bookingKind(Booking|Sweatbook $booking): string

--- a/tests/Feature/ActivityLogShimTest.php
+++ b/tests/Feature/ActivityLogShimTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Helpers\LogName;
 use App\Services\ActivityLogService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -14,9 +15,9 @@ class ActivityLogShimTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_info_shim_lowercases_category_into_log_name(): void
+    public function test_info_shim_stores_the_category_enum_value_as_log_name(): void
     {
-        ActivityLogService::info('TRAINING', 'Created training request 5');
+        ActivityLogService::info(LogName::Training, 'Created training request 5');
 
         $this->assertDatabaseHas('activity_logs', [
             'log_name' => 'training',
@@ -27,7 +28,7 @@ class ActivityLogShimTest extends TestCase
 
     public function test_warning_shim_sets_warning_level(): void
     {
-        ActivityLogService::warning('ACCESS', 'Logged in with Admin access');
+        ActivityLogService::warning(LogName::Access, 'Logged in with Admin access');
 
         $this->assertDatabaseHas('activity_logs', [
             'log_name' => 'access',
@@ -38,7 +39,7 @@ class ActivityLogShimTest extends TestCase
 
     public function test_danger_shim_sets_danger_level(): void
     {
-        ActivityLogService::danger('OTHER', 'Global Settings Updated');
+        ActivityLogService::danger(LogName::Other, 'Global Settings Updated');
 
         $this->assertDatabaseHas('activity_logs', [
             'log_name' => 'other',
@@ -49,7 +50,7 @@ class ActivityLogShimTest extends TestCase
 
     public function test_debug_shim_sets_debug_level(): void
     {
-        ActivityLogService::debug('OTHER', 'Some debug detail');
+        ActivityLogService::debug(LogName::Other, 'Some debug detail');
 
         $this->assertDatabaseHas('activity_logs', [
             'log_name' => 'other',

--- a/tests/Feature/LogNameTest.php
+++ b/tests/Feature/LogNameTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Helpers\LogName;
+use App\Models\ActivityLog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * LogName is the set of categories an activity entry can be filed under. The
+ * enum is passed straight to activity(), which stores the backing value.
+ */
+class LogNameTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_every_case_is_stored_as_its_backing_value(): void
+    {
+        foreach (LogName::cases() as $logName) {
+            activity($logName)->log('Entry for ' . $logName->name);
+
+            $this->assertDatabaseHas('activity_logs', [
+                'log_name' => $logName->value,
+                'description' => 'Entry for ' . $logName->name,
+            ]);
+        }
+    }
+
+    public function test_cases_can_be_queried_with_the_in_log_scope(): void
+    {
+        activity(LogName::Access)->log('Logged in');
+        activity(LogName::Booking)->log('Created booking');
+        activity(LogName::Training)->log('Created training request');
+
+        $logs = ActivityLog::inLog(LogName::Access, LogName::Booking)->get();
+
+        $this->assertEqualsCanonicalizing(
+            ['Logged in', 'Created booking'],
+            $logs->pluck('description')->all(),
+        );
+    }
+
+    public function test_backing_values_are_lowercase_and_unique(): void
+    {
+        $values = array_column(LogName::cases(), 'value');
+
+        $this->assertSame(array_map(strtolower(...), $values), $values);
+        $this->assertSame(array_unique($values), $values);
+    }
+}


### PR DESCRIPTION
Contributes to reducing the likelihood of accidentally using a category that does not exist.

## Summary by Sourcery

Introduce a string-backed LogName enum for activity log categories and adopt it across the codebase.

Enhancements:
- Replace free-text activity log category strings with a typed LogName enum to prevent invalid categories.
- Update ActivityLogService and related controllers, services, and models to accept and use LogName instead of raw strings for log_name.
- Ensure model activity logging uses LogName enum values for log names instead of hardcoded strings.
- Add feature tests to verify LogName backing values, storage, and querying via activity log scopes.

Tests:
- Add LogNameTest to validate enum cases are stored as their backing values, can be queried via scopes, and have unique lowercase values.
- Adjust ActivityLogShimTest to use LogName enum values when asserting shim behavior.