### PR TITLE
fix(feedback): avoid table jumping in

### DIFF
--- a/resources/sass/_global.scss
+++ b/resources/sass/_global.scss
@@ -1,5 +1,11 @@
 // Global component styles
 
+// Keep Alpine x-show/x-transition elements hidden until Alpine boots,
+// preventing a flash of the initial state (e.g. combobox dropdowns) on load.
+[x-cloak] {
+    display: none !important;
+}
+
 html {
     position: relative;
     min-height: 100%;

--- a/resources/views/livewire/combobox.blade.php
+++ b/resources/views/livewire/combobox.blade.php
@@ -41,6 +41,7 @@
 
     <div
         x-ref="list"
+        x-cloak
         x-show="open"
         x-transition.opacity
         class="list-group position-absolute w-100 shadow mt-1"

--- a/resources/views/reports/feedback.blade.php
+++ b/resources/views/reports/feedback.blade.php
@@ -5,7 +5,7 @@
 @section('content')
     <div class="row">
         <div class="col-xl-12 col-md-12 mb-12">
-            <livewire:feedback-table lazy />
+            <livewire:feedback-table />
         </div>
     </div>
 @endsection


### PR DESCRIPTION
## Summary by Sourcery

Prevent UI elements from visually jumping or flashing when loading feedback reports and using comboboxes.

Bug Fixes:
- Ensure feedback Livewire table loads immediately instead of lazily to avoid layout jumping.
- Hide Alpine-driven dropdown elements with x-cloak until they are shown, preventing initial flash on page load.