### PR TITLE
docs(upgrade): take two for improving the upgrade docs

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -18,21 +18,79 @@ php artisan optimize:clear
 
 ## Upgrading to 7.0.0
 
-This release changes how access is managed and rebuilds the theme system, so it
-needs a few manual steps beyond the usual migrate and cache clear. Work through the
-sections below in order.
+This release changes how access is managed, rebuilds the theme system, and switches
+the ATC activity chart to a new API. Follow the upgrade steps once, then work
+through the post-upgrade tasks. A single `php artisan migrate` applies every
+database change in this release, so you only run it once.
 
-### ATC activity chart (StatSim)
+### Upgrade steps
 
-The ATC activity numbers on user profiles started erroring out. The old StatSim API
-was deprecated and shut down before we could update the integration, which is what
-you were seeing.
+1. If you added any custom groups beyond the four defaults (Administrator,
+   Moderator, Mentor, Buddy), note down their members now. The migration drops them,
+   and you recreate them as roles afterwards.
+2. Update your environment file:
+    - Add the new [StatSim API key variable](configuration/index.md#vatsim). The
+      activity chart stays broken until this is set.
+    - Remove any `VITE_THEME_*` color variables. They are no longer used.
+3. Run the database migration. This one command applies everything in the release,
+   including the new `setting_theme` column on `users` and the new `role_user` table.
+   It also copies the four standard groups across and drops the old `groups` and
+   `permissions` tables:
+   ```sh
+   php artisan migrate
+   ```
+4. Rebuild the frontend assets, but only if you run without a container and maintain
+   a custom theme. The published container image already ships with assets built,
+   and you should never build inside a running container. See
+   [Themes](setup/theme.md) for why:
+   ```sh
+   npm run build
+   ```
+5. Clear the caches:
+   ```sh
+   php artisan optimize:clear
+   ```
+6. Clear your browser cache, then load the app and confirm theme switching works and
+   the ATC activity chart renders on a profile.
 
-The replacement API needs its own API key. Add the new
-[StatSim environment variable](configuration/index.md#vatsim) and the chart will
-work again.
+### Post-upgrade tasks
 
-### Admin is now CLI-only, with a new Director role
+These need your judgement, so do them after the steps above.
+
+#### Review who is a global admin
+
+Everyone in the old administrator group becomes a global admin during the migration,
+so they keep full access until you review it. Admins can no longer be changed from
+the UI, so this is a manual database step.
+
+!!! warning "Back up first, and keep at least one admin"
+    This edits the `role_user` table directly, with no undo. Back the table up before
+    you delete anything, remove only the rows you mean to, and make sure at least one
+    admin remains. Do not delete your own only admin row.
+
+1. Grant `director` (per area or global) from a user's access page to anyone who only
+   needs area or organisation level management.
+2. List the current admin assignments and confirm which rows you mean to remove.
+   `user_id` is the person's VATSIM CID:
+   ```sql
+   SELECT * FROM role_user WHERE role = 'admin';
+   ```
+3. Remove the assignments you no longer want:
+   ```sql
+   DELETE FROM role_user WHERE user_id = <cid> AND role = 'admin';
+   ```
+   There is no command for revoking admin yet.
+   <!-- TODO: replace with `user:removeadmin` once available. -->
+
+#### Review `config/roles.php`
+
+Adjust the matrix if your division wants different permissions per role, or extra
+roles beyond the defaults. Recreate any custom groups you noted down in step 1 as
+roles here. Run `php artisan optimize:clear` again after editing the file.
+
+### What changed
+
+#### Admin is now CLI-only, with a new Director role
 
 The `admin` role is now strictly system-wide. You can no longer grant it, scope it
 to an area, or revoke it from the web UI. Assign it from the command line instead:
@@ -42,101 +100,46 @@ php artisan user:makeadmin
 ```
 
 The new `director` role covers the "full access to an area" case that admin used to
-fill. You grant it per area or globally from a user's access page, and it holds
-every admin permission except the system-level ones (`manage-area`,
-`view-system-health`). Only global admins and global directors can grant or revoke
-it. See [Roles and Permissions](reference/permissions.md) for the full picture.
+fill. It holds every admin permission except the system-level ones (`manage-area`,
+`view-system-health`), and only global admins and global directors can grant or
+revoke it. See [Roles and Permissions](reference/permissions.md) for the full picture.
 
-#### After upgrading, review who is an admin
-
-Everyone in the old administrator group becomes a global admin during the
-migration, so they keep full access. Once you have upgraded, check who really needs
-system-wide rights:
-
-1. Grant `director` (per area or global) to anyone who only needs area or
-   organisation level management.
-2. Remove their admin assignment from the `role_user` table by hand. There is no
-   command for revoking admin yet.
-   ```sql
-   DELETE FROM role_user WHERE user_id = <cid> AND role = 'admin';
-   ```
-   <!-- TODO: replace with `user:removeadmin` once available. -->
-
-Until you do this, the migrated admins keep unrestricted access.
-
-### Theme system
+#### Theme system
 
 Themes were redesigned to support light and dark modes and a per-user preference.
-The colors you used to set in `.env` have moved into SCSS files.
+The colors you used to set with `VITE_THEME_*` in `.env` have moved into SCSS files
+under `resources/sass/themes/`, and each user now picks their own theme, stored in
+the database.
 
-What changed:
+If you had custom colors in `.env`, move them into a custom theme file: copy
+`_custom.scss.example` to `_custom.scss`, port your colors across using `_light.scss`
+and `_dark.scss` as a reference, and rebuild. See [Themes](setup/theme.md) for the
+full walkthrough, including how to bake a custom theme into a container image.
 
-- The `VITE_THEME_*` color variables in `.env` are gone.
-- Themes now live in SCSS files under `resources/sass/themes/`.
-- Each user picks their own theme, and the choice is stored in the database.
-
-To upgrade:
-
-1. Remove any `VITE_THEME_*` variables from your `.env` file.
-2. Run the migration, which adds the `setting_theme` column to the `users` table:
-   ```sh
-   php artisan migrate
-   ```
-3. Rebuild the frontend assets:
-   ```sh
-   npm run build
-   ```
-4. Clear the caches:
-   ```sh
-   php artisan optimize:clear
-   ```
-5. Clear your browser cache and check that theme switching works.
-
-If you had custom colors in `.env`, move them into a custom theme file. In short:
-copy `_custom.scss.example` to `_custom.scss`, port your colors across using
-`_light.scss` and `_dark.scss` as a reference, and rebuild. See
-[Themes](setup/theme.md) for the full walkthrough.
-
-### Permissions and roles
+#### Permissions and roles
 
 The old groups and permissions system has been rebuilt around a role matrix you
-configure in `config/roles.php`. See [Roles and Permissions](concepts/permissions.md)
-for how the new model works.
+configure in `config/roles.php`. Assignments now live in one `role_user` table that
+stores the role name and an optional `area_id` (null means global), and permissions
+are defined in `config/roles.php` rather than the database. A few things to know:
 
-What changed:
-
-- The `groups` and `permissions` tables are dropped. Assignments now live in one
-  `role_user` table that stores the role name and an optional `area_id` (null means
-  global).
-- Permissions are no longer in the database. They are defined in `config/roles.php`
-  as a matrix that maps each permission to the roles that hold it. Changing access
-  now means editing that file and clearing the config cache, not updating the
-  database.
-- Admins are now strictly global. Any `area_id` on an old admin assignment is
-  dropped during the migration.
-- Custom groups are not migrated. Only the four standard groups (Administrator,
-  Moderator, Mentor, Buddy) become roles. Any custom group or permission rows you
-  added by hand are dropped with the old tables, so note them down first and
-  recreate them as roles afterwards.
+- Admins are now strictly global. Any `area_id` on an old admin assignment is dropped
+  during the migration.
+- Only the four standard groups (Administrator, Moderator, Mentor, Buddy) are
+  migrated. Any custom group or permission rows you added by hand are dropped with
+  the old tables, which is why you note them down before upgrading and recreate them
+  as roles afterwards.
 - The `nav-editor` role is new and is not derived from any old group, so nobody is
   assigned to it automatically. Grant it to whoever needs to edit navigational data
   in an area.
 
-To upgrade:
+See [Roles and Permissions](concepts/permissions.md) for how the new model works.
 
-1. Note down any custom groups you added beyond the four defaults, along with their
-   members, so you can re-grant access afterwards.
-2. Run the migration, which creates `role_user`, copies the four standard groups
-   across, and drops the old tables:
-   ```sh
-   php artisan migrate
-   ```
-3. Review `config/roles.php` and adjust the matrix if your division wants different
-   permissions per role or extra roles.
-4. Clear the caches:
-   ```sh
-   php artisan optimize:clear
-   ```
+#### ATC activity chart (StatSim)
+
+The old StatSim API was deprecated and shut down, which is why the ATC activity
+numbers on profiles started erroring. The replacement API needs its own API key,
+added in step 2 above.
 
 ## Upgrading to 6.0.0
 


### PR DESCRIPTION
Restructures the upgrade doc to provide an actual, item by item list of instructions.

## Summary by Sourcery

Rewrite the 7.0.0 upgrade guide as an actionable sequence of upgrade and post-upgrade steps.

Enhancements:
- Restructure the 7.0.0 upgrade documentation into a clear, ordered checklist with separate post-upgrade review tasks and explanatory change summaries.
- Clarify migration prerequisites, environment updates, asset and cache handling, role reassignment, custom group recovery, and verification steps.
- Add safer guidance for reviewing and removing migrated administrator assignments, including database inspection and backup warnings.

Documentation:
- Update the 7.0.0 upgrade guide to document the StatSim API key, theme migration, role-system changes, and post-upgrade configuration tasks.