### PR TITLE
refactor(training): reuse getInlineRatings() for training title in show view

### DIFF
--- a/resources/views/training/show.blade.php
+++ b/resources/views/training/show.blade.php
@@ -45,14 +45,7 @@
         <div class="card shadow mb-2">
             <div class="card-header bg-primary py-3 d-flex flex-row column-gap-3 pe-0">
                 <h6 class="m-0 fw-bold text-white flex-grow-1">
-                    <i class="fas fa-flag"></i>&nbsp;{{ $training->user->first_name }}'s training for
-                    @foreach($training->ratings as $rating)
-                        @if ($loop->last)
-                            {{ $rating->name }}
-                        @else
-                            {{ $rating->name . " + " }}
-                        @endif
-                    @endforeach
+                    <i class="fas fa-flag"></i>&nbsp;{{ $training->user->first_name }}'s training for {{ $training->getInlineRatings() }}
                 </h6>
 
                 @can('create', [\App\Models\Task::class])
@@ -90,19 +83,7 @@
                     <dd><i class="{{ $types[$training->type]["icon"] }} text-primary"></i>&ensp;{{ $types[$training->type]["text"] }}</dd>
 
                     <dt>Level</dt>
-                    <dd class="separator pb-3">
-                        @if ( is_iterable($ratings = $training->ratings->toArray()) )
-                            @for( $i = 0; $i < sizeof($ratings); $i++ )
-                                @if ( $i == (sizeof($ratings) - 1) )
-                                    {{ $ratings[$i]["name"] }}
-                                @else
-                                    {{ $ratings[$i]["name"] . " + " }}
-                                @endif
-                            @endfor
-                        @else
-                            {{ $ratings["name"] }}
-                        @endif
-                    </dd>
+                    <dd class="separator pb-3">{{ $training->getInlineRatings() }}</dd>
 
                     <dt class="pt-2">Vatsim ID</dt>
                     <dd>

--- a/tests/Feature/TrainingsTest.php
+++ b/tests/Feature/TrainingsTest.php
@@ -205,7 +205,8 @@ class TrainingsTest extends TestCase
         $this->actingAs($moderator)->get($combinedTraining->path())
             ->assertSeeText('Rating Upgrade')
             ->assertSeeText('Theoretical Exam Access')
-            ->assertSee('for <b>TST-S2</b> rating', false);
+            ->assertSee('for <b>TST-S2</b> rating', false)
+            ->assertSeeText('TST-S2 + TST-MAE');
     }
 
     #[Test]


### PR DESCRIPTION
The training **show** page built the inline rating title (e.g. `S1 + S2`) by hand in two separate places using duplicated Blade loops: the card header ("X's training for …") and the "Level" field. This replaces both with the existing `Training::getInlineRatings()` helper, which produces the identical string and is already reused across notifications and other views.

## Summary by Sourcery

Centralize training show-page rating display through the existing inline-ratings helper.

Enhancements:
- Reuse the existing inline-ratings helper throughout the training show page to keep rating titles consistent and eliminate duplicated view logic.

Tests:
- Add regression coverage verifying combined ratings render correctly on the training show page.

## Summary by Sourcery

Reuse the inline-ratings helper to keep rating titles consistent across the training show page.

Enhancements:
- Centralize training show-page rating titles through the existing inline-ratings helper, removing duplicated view formatting logic.

Tests:
- Add regression coverage for displaying combined ratings on the training show page.