### PR TITLE
fix(training): show user action icons on smaller screens

### DIFF
--- a/resources/sass/_global.scss
+++ b/resources/sass/_global.scss
@@ -89,6 +89,13 @@ dl.copyable{
             color: var(--color-success);
         }
     }
+
+    @include media-breakpoint-down(lg) {
+        dd button, dd a.link-btn, dt a {
+            visibility: visible;
+            color: var(--color-gray-400);
+        }
+    }
 }
 
 


### PR DESCRIPTION
## Summary

- show copy and profile action icons by default below the `lg` breakpoint
- preserve the existing hover-only behavior on larger screens
- keep the icons' existing muted color

Closes #1624

## Testing

- `git diff --check`
- isolated Sass compilation of `resources/sass/_global.scss` with Bootstrap dependencies

The full Vite build reaches stylesheet processing but cannot complete in this checkout because `vendor/livewire/flux/dist/flux.css` is not installed.

## Summary by Sourcery

Make training action icons accessible on smaller screens without changing their desktop hover behavior.

Bug Fixes:
- Ensure training copy and profile action icons are visible by default on screens below the large breakpoint.

Enhancements:
- Preserve hover-only icon behavior on larger screens while retaining the existing muted icon color.