### PR TITLE
refactor(training): extract core training into TrainingService

### DIFF
--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -6,14 +6,11 @@ use anlutro\LaravelSettings\Facade as Setting;
 use App;
 use App\Exceptions\PolicyMethodMissingException;
 use App\Exceptions\PolicyMissingException;
-use App\Facades\DivisionApi;
 use App\Helpers\InterestStatus;
 use App\Helpers\LogName;
 use App\Helpers\TrainingStatus;
 use App\Helpers\VatsimRating;
 use App\Models\Area;
-use App\Models\AtcActivity;
-use App\Models\Endorsement;
 use App\Models\Rating;
 use App\Models\Training;
 use App\Models\TrainingExamination;
@@ -25,11 +22,11 @@ use App\Notifications\TrainingCreatedNotification;
 use App\Notifications\TrainingMentorNotification;
 use App\Notifications\TrainingPreStatusNotification;
 use App\Services\ActivityLogService;
+use App\Services\TrainingService;
 use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Contracts\View\Factory;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -540,74 +537,10 @@ class TrainingController extends Controller
         // Send e-mail and store endorsements rating (non-GRP ones), if it's a new status and it goes from active to closed
         if ($training->status !== $oldStatus) {
             if ($training->status->isClosed()) {
-                // Detach all mentors
-                $training->mentors()->detach();
-
-                // If the training was completed store the relevant endorsements
-                if ($training->status === TrainingStatus::COMPLETED) {
-                    foreach ($training->ratings as $rating) {
-                        if ($rating->vatsim_rating == null) {
-                            // Revoke the old endorsement if active
-                            $oldEndorsement = $training->user->endorsements->where('type', 'FACILITY')->where('revoked', false)->where('expired', false);
-                            foreach ($oldEndorsement as $oe) {
-                                foreach ($oe->ratings as $oer) {
-                                    if ($oer->id == $rating->id) {
-                                        $oe->revoked = true;
-                                        $oe->valid_to = now();
-                                        $oe->save();
-                                        break;
-                                    }
-                                }
-                            }
-
-                            // All clear, let's start by attemping the insertion to the API
-                            $response = DivisionApi::assignTierEndorsement($training->user, $rating, Auth::id());
-                            if ($response && $response->failed()) {
-                                return back()->withErrors('Request failed due to error in ' . DivisionApi::getName() . ' API: ' . $response->json()['message']);
-                            }
-
-                            // Grant new endorsement
-                            $endorsement = new Endorsement();
-                            $endorsement->user_id = $training->user->id;
-                            $endorsement->type = 'FACILITY';
-                            $endorsement->valid_from = now()->format('Y-m-d H:i:s');
-                            $endorsement->valid_to = null;
-                            $endorsement->issued_by = null;
-                            $endorsement->save();
-
-                            $endorsement->ratings()->save(Rating::find($rating->id));
-                        }
-                    }
+                $error = app(TrainingService::class)->closeTraining($training);
+                if ($error !== null) {
+                    return back()->withErrors($error);
                 }
-
-                // If training is completed, let's set the user to active
-                if ($training->status === TrainingStatus::COMPLETED) {
-                    // atcActivityBasedOnTotalHours is false OR true and type is not familiarisation
-                    if (! Setting::get('atcActivityBasedOnTotalHours') || Setting::get('atcActivityBasedOnTotalHours') && $training->type <= 4) {
-
-                        // Apply activity only if user belongs to accepted divisions.
-                        // Visitors should manually be granted visitor endorsement, hence not covered here.
-                        if ($this->isUserInDivision($training->user)) {
-
-                            try {
-                                $activity = AtcActivity::where('user_id', $training->user->id)->where('area_id', $training->area->id)->firstOrFail();
-                                $activity->atc_active = true;
-                                $activity->start_of_grace_period = now();
-                                $activity->save();
-                            } catch (ModelNotFoundException $e) {
-                                AtcActivity::create([
-                                    'user_id' => $training->user->id,
-                                    'area_id' => $training->area->id,
-                                    'hours' => 0,
-                                    'atc_active' => true,
-                                    'start_of_grace_period' => now(),
-                                ]);
-                            }
-                        }
-                    }
-                }
-
-                $training->user->notify(new TrainingClosedNotification($training, $training->status, $training->closed_reason));
 
                 return redirect($training->path())->withSuccess('Training successfully closed. E-mail confirmation sent to the student.');
             }
@@ -768,20 +701,6 @@ class TrainingController extends Controller
         }
 
         return ['success' => true];
-    }
-
-    /**
-     * Check if the user is from the same division as the training request
-     *
-     * @return bool
-     */
-    protected function isUserInDivision($user)
-    {
-        if (config('app.mode') === 'subdivision') {
-            return in_array($user->subdivision, array_map('trim', explode(',', Setting::get('trainingSubDivisions'))));
-        }
-
-        return $user->division === config('app.owner_code');
     }
 
     /**

--- a/app/Services/TrainingService.php
+++ b/app/Services/TrainingService.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Services;
+
+use anlutro\LaravelSettings\Facade as Setting;
+use App\Facades\DivisionApi;
+use App\Helpers\TrainingStatus;
+use App\Models\AtcActivity;
+use App\Models\Endorsement;
+use App\Models\Rating;
+use App\Models\Training;
+use App\Models\User;
+use App\Notifications\TrainingClosedNotification;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * The service layer for acting on trainings.
+ *
+ * This is where training actions live so that controllers, console commands,
+ * and member-sync code all drive the same behaviour instead of each
+ * re-implementing it inline. New training actions belong here, not scattered
+ * across callers. Keeping the logic in one place is what lets the rest of the
+ * app touch different parts of a training's lifecycle without duplicating it.
+ *
+ * Today it owns the closed/completed transition. The rest of the lifecycle
+ * still lives in the oversized TrainingController (~750 lines) and should be
+ * pulled in here incrementally:
+ *
+ * @todo Route the hand-rolled closures through closeTraining() so the close +
+ *       notification path is defined once. Duplicate sites: TrainingController::close(),
+ *       and the UpdateMemberDetails, SendTrainingInterestNotifications, and UserDelete
+ *       console commands. It is not a drop-in replacement for them yet, so do not
+ *       swap them over blindly: closeTraining() reads $training->status without
+ *       persisting it (those sites rely on updateStatus() for that), and it notifies
+ *       with $training->closed_reason, which updateStatus() never sets, so the
+ *       commands' hardcoded reason strings would silently vanish from the student's
+ *       email. Give it an explicit reason argument and make it persist the status.
+ * @todo Move mentor attach/detach syncing out of TrainingController::updateDetails.
+ * @todo Move the paused-time accounting out of TrainingController::updateDetails.
+ * @todo Move the store / apply / updateRequest domain logic behind this service.
+ */
+class TrainingService
+{
+    /**
+     * Close a training, running the completion work when it is being completed.
+     *
+     * Precondition: $training->status is already set to the target closed status.
+     * Returns the Division API error string on failure (no notification sent),
+     * or null on success.
+     */
+    public function closeTraining(Training $training): ?string
+    {
+        $training->mentors()->detach();
+
+        if ($training->status === TrainingStatus::COMPLETED) {
+            $error = $this->completeTraining($training);
+            if ($error !== null) {
+                return $error;
+            }
+        }
+
+        $training->user->notify(new TrainingClosedNotification($training, $training->status, $training->closed_reason));
+
+        return null;
+    }
+
+    /**
+     * Run the completion work for a training: per-rating endorsements, then ATC activation.
+     */
+    public function completeTraining(Training $training): ?string
+    {
+        foreach ($training->ratings as $rating) {
+            $error = $this->completeRating($training, $rating);
+            if ($error !== null) {
+                return $error;
+            }
+        }
+
+        $this->activateAtcForTraining($training);
+
+        return null;
+    }
+
+    /**
+     * Apply one rating's completion effect. Facility ratings (vatsim_rating null)
+     * revoke the prior endorsement, call the Division API, and grant a fresh
+     * endorsement; VATSIM ratings are a no-op.
+     */
+    public function completeRating(Training $training, Rating $rating): ?string
+    {
+        if ($rating->vatsim_rating != null) {
+            return null;
+        }
+
+        // Revoke the old endorsement if active
+        $oldEndorsement = $training->user->endorsements->where('type', 'FACILITY')->where('revoked', false)->where('expired', false);
+        foreach ($oldEndorsement as $oe) {
+            foreach ($oe->ratings as $oer) {
+                if ($oer->id == $rating->id) {
+                    $oe->revoked = true;
+                    $oe->valid_to = now();
+                    $oe->save();
+                    break;
+                }
+            }
+        }
+
+        // All clear, let's start by attemping the insertion to the API
+        $response = DivisionApi::assignTierEndorsement($training->user, $rating, Auth::id());
+        if ($response && $response->failed()) {
+            return 'Request failed due to error in ' . DivisionApi::getName() . ' API: ' . $response->json()['message'];
+        }
+
+        // Grant new endorsement
+        $endorsement = new Endorsement();
+        $endorsement->user_id = $training->user->id;
+        $endorsement->type = 'FACILITY';
+        $endorsement->valid_from = now()->format('Y-m-d H:i:s');
+        $endorsement->valid_to = null;
+        $endorsement->issued_by = null;
+        $endorsement->save();
+
+        $endorsement->ratings()->save(Rating::find($rating->id));
+
+        return null;
+    }
+
+    /**
+     * Set the user active for the training area, gated by the total-hours setting,
+     * training type, and division membership.
+     *
+     * Repeat calls restart the activity grace period on purpose: finishing another
+     * training earns a fresh window, even when the current one is still running.
+     * The activation itself is idempotent.
+     */
+    public function activateAtcForTraining(Training $training): void
+    {
+        // atcActivityBasedOnTotalHours is false OR true and type is not familiarisation
+        if (! Setting::get('atcActivityBasedOnTotalHours') || Setting::get('atcActivityBasedOnTotalHours') && $training->type <= 4) {
+
+            // Apply activity only if user belongs to accepted divisions.
+            // Visitors should manually be granted visitor endorsement, hence not covered here.
+            if ($this->isUserInDivision($training->user)) {
+
+                try {
+                    $activity = AtcActivity::where('user_id', $training->user->id)->where('area_id', $training->area->id)->firstOrFail();
+                    $activity->atc_active = true;
+                    $activity->start_of_grace_period = now();
+                    $activity->save();
+                } catch (ModelNotFoundException $e) {
+                    AtcActivity::create([
+                        'user_id' => $training->user->id,
+                        'area_id' => $training->area->id,
+                        'hours' => 0,
+                        'atc_active' => true,
+                        'start_of_grace_period' => now(),
+                    ]);
+                }
+            }
+        }
+    }
+
+    public function isUserInDivision(User $user): bool
+    {
+        if (config('app.mode') === 'subdivision') {
+            return in_array($user->subdivision, array_map('trim', explode(',', Setting::get('trainingSubDivisions'))));
+        }
+
+        return $user->division === config('app.owner_code');
+    }
+}

--- a/tests/Feature/TrainingsTest.php
+++ b/tests/Feature/TrainingsTest.php
@@ -3,17 +3,23 @@
 namespace Tests\Feature;
 
 use anlutro\LaravelSettings\Facade as Setting;
+use App\Facades\DivisionApi;
 use App\Helpers\TrainingStatus;
 use App\Helpers\VatsimRating;
 use App\Models\Area;
 use App\Models\AtcActivity;
+use App\Models\Endorsement;
 use App\Models\Rating;
 use App\Models\Training;
 use App\Models\User;
+use App\Notifications\TrainingClosedNotification;
 use App\Notifications\TrainingCreatedNotification;
 use App\Notifications\TrainingMentorNotification;
+use App\Services\TrainingService;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\Client\Response as ClientResponse;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Notification;
 use PHPUnit\Framework\Attributes\Test;
@@ -45,14 +51,67 @@ class TrainingsTest extends TestCase
     }
 
     /**
-     * Create a user with moderator rights in the training's area.
+     * Create a user with moderator rights in the default training's area.
      */
     private function makeModerator(): User
     {
+        return $this->moderatorFor($this->training);
+    }
+
+    /**
+     * Create a user with moderator rights in the given training's area.
+     */
+    private function moderatorFor(Training $training): User
+    {
         $moderator = User::factory()->create();
-        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $this->training->area->id]);
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $training->area->id]);
 
         return $moderator;
+    }
+
+    /**
+     * An open training (ACTIVE_TRAINING) in area 1, type 1, whose student is inside the division.
+     */
+    private function openTrainingInDivision(): Training
+    {
+        Setting::set('trainingSubDivisions', 'SCA');
+
+        $student = User::factory()->create([
+            'division' => config('app.owner_code'),
+            'subdivision' => 'SCA',
+        ]);
+
+        return Training::factory()->create([
+            'user_id' => $student->id,
+            'area_id' => 1,
+            'type' => 1,
+            'status' => TrainingStatus::ACTIVE_TRAINING->value,
+        ]);
+    }
+
+    /**
+     * Attach a fresh facility rating (no VATSIM rating) to the training.
+     */
+    private function attachFacilityRating(Training $training): Rating
+    {
+        $rating = Rating::factory()->create(['vatsim_rating' => null]);
+        $training->ratings()->attach($rating->id);
+
+        return $rating;
+    }
+
+    /**
+     * An existing active FACILITY endorsement for $rating, which completion should revoke.
+     */
+    private function priorFacilityEndorsement(Training $training, Rating $rating): Endorsement
+    {
+        $endorsement = Endorsement::factory()->create([
+            'user_id' => $training->user->id,
+            'type' => 'FACILITY',
+        ]);
+        $endorsement->ratings()->attach($rating->id);
+
+        return $endorsement;
     }
 
     #[Test]
@@ -519,5 +578,273 @@ class TrainingsTest extends TestCase
             ->assertRedirect();
 
         $this->assertEquals('Discussed holding patterns and missed approaches', $activity->fresh()->comment);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Completion / closure side-effects (TrainingController::updateDetails,
+    | delegated to App\Services\TrainingService)
+    |--------------------------------------------------------------------------
+    */
+
+    #[Test]
+    public function completing_a_training_grants_a_facility_endorsement_and_activates_atc(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $rating = $this->attachFacilityRating($training);
+        $oldEndorsement = $this->priorFacilityEndorsement($training, $rating);
+
+        DivisionApi::shouldReceive('assignTierEndorsement')->once()->andReturn(false);
+
+        $this->actingAs($this->moderatorFor($training))
+            ->patch(route('training.update.details', $training), ['status' => TrainingStatus::COMPLETED->value])
+            ->assertRedirect($training->path());
+
+        $this->assertTrue((bool) $oldEndorsement->fresh()->revoked);
+
+        $new = Endorsement::where('user_id', $training->user->id)
+            ->where('revoked', false)
+            ->where('id', '!=', $oldEndorsement->id)
+            ->get();
+        $this->assertCount(1, $new);
+        $this->assertTrue($new->first()->ratings->contains($rating->id));
+
+        $this->assertTrue(
+            AtcActivity::where('user_id', $training->user->id)
+                ->where('area_id', $training->area->id)
+                ->where('atc_active', true)
+                ->exists()
+        );
+
+        Notification::assertSentToTimes($training->user, TrainingClosedNotification::class, 1);
+    }
+
+    #[Test]
+    public function completing_a_vatsim_only_training_activates_atc_without_an_endorsement(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $training->ratings()->attach(Rating::factory()->create(['vatsim_rating' => VatsimRating::S2->value])->id);
+
+        // VATSIM ratings are Core-side upgrades, not facility endorsements: no API call.
+        DivisionApi::shouldReceive('assignTierEndorsement')->never();
+
+        $this->actingAs($this->moderatorFor($training))
+            ->patch(route('training.update.details', $training), ['status' => TrainingStatus::COMPLETED->value])
+            ->assertRedirect($training->path());
+
+        $this->assertSame(0, Endorsement::where('user_id', $training->user->id)->count());
+        $this->assertTrue(
+            AtcActivity::where('user_id', $training->user->id)
+                ->where('area_id', $training->area->id)
+                ->where('atc_active', true)
+                ->exists()
+        );
+        Notification::assertSentToTimes($training->user, TrainingClosedNotification::class, 1);
+    }
+
+    #[Test]
+    public function atc_activation_respects_the_total_hours_gate_for_familiarisation(): void
+    {
+        Notification::fake();
+        DivisionApi::shouldReceive('assignTierEndorsement')->never();
+
+        // When activity is hours-based, familiarisations (type > 4) are excluded from
+        // automatic ATC activation; with the setting off, every type activates.
+        Setting::set('atcActivityBasedOnTotalHours', true);
+        $gated = $this->openTrainingInDivision();
+        $gated->update(['type' => 5]);
+        $gated->ratings()->attach(Rating::factory()->create(['vatsim_rating' => VatsimRating::S2->value])->id);
+
+        $this->actingAs($this->moderatorFor($gated))
+            ->patch(route('training.update.details', $gated), ['status' => TrainingStatus::COMPLETED->value])
+            ->assertRedirect($gated->path());
+
+        $this->assertFalse(
+            AtcActivity::where('user_id', $gated->user->id)
+                ->where('area_id', $gated->area->id)
+                ->where('atc_active', true)
+                ->exists()
+        );
+
+        Setting::set('atcActivityBasedOnTotalHours', false);
+        $ungated = $this->openTrainingInDivision();
+        $ungated->update(['type' => 5]);
+        $ungated->ratings()->attach(Rating::factory()->create(['vatsim_rating' => VatsimRating::S2->value])->id);
+
+        $this->actingAs($this->moderatorFor($ungated))
+            ->patch(route('training.update.details', $ungated), ['status' => TrainingStatus::COMPLETED->value])
+            ->assertRedirect($ungated->path());
+
+        $this->assertTrue(
+            AtcActivity::where('user_id', $ungated->user->id)
+                ->where('area_id', $ungated->area->id)
+                ->where('atc_active', true)
+                ->exists()
+        );
+    }
+
+    #[Test]
+    public function completing_a_training_for_a_user_outside_the_division_skips_atc_activation(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+        Setting::set('trainingSubDivisions', 'SCA');
+
+        // Both fields mismatched so the user is out-of-division regardless of app.mode
+        // (subdivision mode checks subdivision; division mode checks division vs owner_code).
+        $student = User::factory()->create(['division' => 'XXX', 'subdivision' => 'XXX']);
+        $training = Training::factory()->create([
+            'user_id' => $student->id,
+            'area_id' => 1,
+            'type' => 1,
+            'status' => TrainingStatus::ACTIVE_TRAINING->value,
+        ]);
+        $training->ratings()->attach(Rating::factory()->create(['vatsim_rating' => VatsimRating::S2->value])->id);
+
+        DivisionApi::shouldReceive('assignTierEndorsement')->never();
+
+        $this->actingAs($this->moderatorFor($training))
+            ->patch(route('training.update.details', $training), ['status' => TrainingStatus::COMPLETED->value])
+            ->assertRedirect($training->path());
+
+        $this->assertSame(0, AtcActivity::where('user_id', $student->id)->count());
+    }
+
+    #[Test]
+    public function a_division_api_failure_when_completing_redirects_back_without_notifying(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $rating = $this->attachFacilityRating($training);
+        $oldEndorsement = $this->priorFacilityEndorsement($training, $rating);
+
+        $failed = new ClientResponse(new GuzzleResponse(422, [], json_encode(['message' => 'nope'])));
+        DivisionApi::shouldReceive('assignTierEndorsement')->once()->andReturn($failed);
+        DivisionApi::shouldReceive('getName')->andReturn('VATEUD');
+
+        $this->actingAs($this->moderatorFor($training))
+            ->patch(route('training.update.details', $training), ['status' => TrainingStatus::COMPLETED->value])
+            ->assertRedirect() // back(), not the training path
+            ->assertSessionHasErrors();
+
+        // The grant runs after the API call, so a failure leaves no new endorsement...
+        $this->assertSame(1, Endorsement::where('user_id', $training->user->id)->count());
+        // ...but the old one was already revoked before the call. That partial state is
+        // one the controller has always produced, pinned here so a refactor can't silently change it.
+        $this->assertTrue((bool) $oldEndorsement->fresh()->revoked);
+        Notification::assertNotSentTo($training->user, TrainingClosedNotification::class);
+    }
+
+    #[Test]
+    public function closing_a_training_without_completion_detaches_mentors_and_notifies(): void
+    {
+        Notification::fake();
+
+        $training = $this->openTrainingInDivision();
+        $this->attachFacilityRating($training);
+
+        $mentor = User::factory()->create();
+        $mentor->roleAssignments()->create(['role' => 'mentor', 'area_id' => $training->area->id]);
+        $training->mentors()->attach($mentor, ['expire_at' => now()->addYear()]);
+
+        DivisionApi::shouldReceive('assignTierEndorsement')->never();
+
+        // Send the mentor back so mentor-sync keeps them: the close path itself must be
+        // what detaches them, not the "no mentors key = detach all" fallback.
+        $this->actingAs($this->moderatorFor($training))
+            ->patch(route('training.update.details', $training), [
+                'status' => TrainingStatus::CLOSED_BY_STAFF->value,
+                'closed_reason' => 'Test reason',
+                'mentors' => [$mentor->id],
+            ])
+            ->assertRedirect($training->path());
+
+        $this->assertTrue($training->fresh()->mentors->isEmpty());
+        $this->assertSame(0, Endorsement::where('user_id', $training->user->id)->count());
+        $this->assertFalse(AtcActivity::where('user_id', $training->user->id)->where('atc_active', true)->exists());
+        Notification::assertSentToTimes($training->user, TrainingClosedNotification::class, 1);
+    }
+
+    #[Test]
+    public function re_saving_an_already_completed_training_unchanged_fires_no_side_effects(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $training->update(['status' => TrainingStatus::COMPLETED->value]);
+        $rating = $this->attachFacilityRating($training);
+        $oldEndorsement = $this->priorFacilityEndorsement($training, $rating);
+
+        // Re-saving with the status unchanged must hit the "status changed" guard and
+        // short-circuit. Otherwise a closed training would re-grant endorsements and
+        // re-notify every time its detail form is submitted.
+        DivisionApi::shouldReceive('assignTierEndorsement')->never();
+
+        $this->actingAs($this->moderatorFor($training))
+            ->patch(route('training.update.details', $training), ['status' => TrainingStatus::COMPLETED->value])
+            ->assertRedirect($training->path());
+
+        $this->assertSame(1, Endorsement::where('user_id', $training->user->id)->count());
+        $this->assertFalse((bool) $oldEndorsement->fresh()->revoked);
+        Notification::assertNotSentTo($training->user, TrainingClosedNotification::class);
+    }
+
+    #[Test]
+    public function close_training_on_an_open_status_notifies_and_detaches_without_completion_work(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision(); // status = ACTIVE_TRAINING
+        $this->attachFacilityRating($training);
+
+        DivisionApi::shouldReceive('assignTierEndorsement')->never();
+
+        // Called directly (no HTTP path leaves a training open at this point): completion
+        // work is gated on COMPLETED, but the detach + notification run for any status.
+        $error = app(TrainingService::class)->closeTraining($training);
+
+        $this->assertNull($error);
+        $this->assertSame(0, Endorsement::where('user_id', $training->user->id)->count());
+        $this->assertFalse(AtcActivity::where('user_id', $training->user->id)->where('atc_active', true)->exists());
+        Notification::assertSentToTimes($training->user, TrainingClosedNotification::class, 1);
+    }
+
+    #[Test]
+    public function completing_another_training_restarts_the_activity_grace_period(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $training->ratings()->attach(Rating::factory()->create(['vatsim_rating' => VatsimRating::S2->value])->id);
+
+        // The student is already half way through a grace period.
+        $activity = AtcActivity::create([
+            'user_id' => $training->user->id,
+            'area_id' => $training->area->id,
+            'hours' => 0,
+            'atc_active' => true,
+            'start_of_grace_period' => now()->subMonths(6),
+        ]);
+
+        DivisionApi::shouldReceive('assignTierEndorsement')->never();
+
+        $this->actingAs($this->moderatorFor($training))
+            ->patch(route('training.update.details', $training), ['status' => TrainingStatus::COMPLETED->value])
+            ->assertRedirect($training->path());
+
+        // Deliberate: finishing another training earns a fresh window rather than
+        // running out the one already in progress.
+        $this->assertTrue($activity->fresh()->start_of_grace_period->greaterThan(now()->subMinute()));
     }
 }


### PR DESCRIPTION
updateDetails()'s fat closed-status tail now lives in a dedicated
TrainingService (endorsement granting, ATC activation, closed
notification); the controller just delegates inside the status-change
guard. Behaviour is unchanged, and TrainingsTest now covers the
completion and closure paths that had no tests before.

Relates to #1431 as preparation work.

## Summary by Sourcery

Centralize training completion and closure behavior in TrainingService and protect the existing lifecycle behavior with comprehensive tests.

Enhancements:
- Extract training completion and closure side effects into a reusable TrainingService while keeping the controller focused on status-change handling.

Tests:
- Add coverage for endorsement granting, ATC activation rules, division eligibility, API failures, mentor detachment, closure notifications, idempotent status updates, and grace-period resets.