### PR TITLE
fix(api)!: report globally scoped roles on the users endpoint

### DIFF
--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -49,6 +49,17 @@ class UserController extends Controller
         //
         // Validate data and set paramters to defaults
         //
+
+        // The `boolean` rule accepts 1/0 only, so normalise the spellings a query string
+        // carries. Unparseable values are left for validation to reject.
+        if ($request->has('onlyAtcActive')) {
+            $normalisedOnlyAtcActive = filter_var($request->input('onlyAtcActive'), FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+
+            if ($normalisedOnlyAtcActive !== null) {
+                $request->merge(['onlyAtcActive' => $normalisedOnlyAtcActive]);
+            }
+        }
+
         $parameters = $request->validate([
             /**
              * Restrict results to users who are currently ATC active.
@@ -155,6 +166,10 @@ class UserController extends Controller
         if ($paramIncludeRoles) {
             foreach ($returnUsers as $user) {
                 $user->roles = collect();
+
+                // A global assignment has no area_id, so it fits no area bucket.
+                $globalRoles = $user->roleAssignments->whereNull('area_id')->pluck('role');
+                $user->roles['global'] = $globalRoles->count() ? $globalRoles : null;
 
                 foreach (Area::all() as $area) {
                     $areaRoles = $user->roleAssignments->where('area_id', $area->id)->pluck('role');

--- a/tests/Feature/Api/V1/UsersEndpointTest.php
+++ b/tests/Feature/Api/V1/UsersEndpointTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\ApiKey;
+use App\Models\Area;
+use App\Models\AtcActivity;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Regressions from 7.0.0: globally scoped role assignments matched no area
+ * bucket and were dropped, and `onlyAtcActive` rejected the boolean spelling
+ * the published OpenAPI spec advertises.
+ */
+class UsersEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function token(): string
+    {
+        ApiKey::create(['id' => 'users-endpoint-key', 'name' => 't', 'read_only' => true, 'created_at' => now()]);
+
+        return 'users-endpoint-key';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function roles(): array
+    {
+        return $this->withToken($this->token())
+            ->getJson('/api/v1/users?include[]=roles')
+            ->assertOk()
+            ->json('data.0.roles');
+    }
+
+    /**
+     * The roles map without the areas the user holds nothing in.
+     *
+     * @return array<string, mixed>
+     */
+    private function assignedRoles(): array
+    {
+        return array_filter($this->roles(), fn ($roles) => $roles !== null);
+    }
+
+    public function test_global_and_area_roles_are_reported_separately(): void
+    {
+        $area = Area::factory()->create(['name' => 'Alpha']);
+        $user = User::factory()->create();
+        $user->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+        $user->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $this->assertSame(['global' => ['admin'], 'Alpha' => ['moderator']], $this->assignedRoles());
+    }
+
+    /**
+     * The regression: such a user is selected because they hold a role, so an
+     * all-null roles map means the assignment was lost.
+     */
+    public function test_a_user_holding_only_a_global_role_still_reports_it(): void
+    {
+        Area::factory()->create(['name' => 'Alpha']);
+        $user = User::factory()->create();
+        $user->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        $this->assertSame(['global' => ['admin']], $this->assignedRoles());
+    }
+
+    public function test_global_is_null_without_a_global_role(): void
+    {
+        $area = Area::factory()->create(['name' => 'Alpha']);
+        $user = User::factory()->create();
+        $user->roleAssignments()->create(['role' => 'training-staff', 'area_id' => $area->id]);
+
+        $roles = $this->roles();
+
+        $this->assertNull($roles['global']);
+        $this->assertSame(['training-staff'], $roles['Alpha']);
+    }
+
+    /**
+     * @return array<string, array{string, bool}>
+     */
+    public static function booleanSpellings(): array
+    {
+        return [
+            'true' => ['true', true],
+            '1' => ['1', true],
+            'yes' => ['yes', true],
+            'on' => ['on', true],
+            'false' => ['false', false],
+            '0' => ['0', false],
+            'no' => ['no', false],
+            'off' => ['off', false],
+        ];
+    }
+
+    #[DataProvider('booleanSpellings')]
+    public function test_only_atc_active_accepts_boolean_spellings(string $value, bool $filters): void
+    {
+        $area = Area::factory()->create();
+        $active = User::factory()->create();
+        $inactive = User::factory()->create();
+
+        foreach ([[$active, true], [$inactive, false]] as [$user, $isActive]) {
+            AtcActivity::create(['user_id' => $user->id, 'area_id' => $area->id, 'atc_active' => $isActive, 'hours' => 20]);
+            $user->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+        }
+
+        $ids = $this->withToken($this->token())
+            ->getJson("/api/v1/users?include[]=roles&onlyAtcActive={$value}")
+            ->assertOk()
+            ->json('data.*.id');
+
+        $this->assertEqualsCanonicalizing($filters ? [$active->id] : [$active->id, $inactive->id], $ids);
+    }
+
+    public function test_only_atc_active_rejects_values_that_are_not_boolean(): void
+    {
+        User::factory()->create();
+
+        $this->withToken($this->token())
+            ->getJson('/api/v1/users?include[]=roles&onlyAtcActive=banana')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('onlyAtcActive');
+    }
+
+    public function test_legacy_and_v1_users_endpoints_stay_identical(): void
+    {
+        $area = Area::factory()->create(['name' => 'Alpha']);
+        $user = User::factory()->create();
+        $user->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+        $user->roleAssignments()->create(['role' => 'moderator', 'area_id' => $area->id]);
+
+        $token = $this->token();
+        $query = 'include[]=roles&onlyAtcActive=false';
+
+        $this->assertSame(
+            $this->withToken($token)->getJson("/api/users?{$query}")->json(),
+            $this->withToken($token)->getJson("/api/v1/users?{$query}")->json(),
+        );
+    }
+}


### PR DESCRIPTION
The 7.0.0 roles refactor moved assignments into role_user, where a globally scoped role is stored with a null area_id. The UserController still bucketed roles by iterating Area::all() and matching area_id, so global assignments matched no bucket and vanished. Users selected purely because they hold a global role came back with every area null, which is how the regression surfaced in practice.

Global assignments are now reported under a dedicated 'global' key. Role values stay the config/roles.php identifiers introduced in 7.0.0; the endpoint published group display names before then, but identifiers are the more stable contract and are kept deliberately.

Also normalises onlyAtcActive before validation. 'sometimes|boolean' only accepts 1/0, so onlyAtcActive=true returned 422 even though the OpenAPI spec published in 7.0.0 documents it as a boolean with example 'true'. The rule is left as boolean so docs/api-v1.json does not drift; unparseable values still fail validation.

BREAKING CHANGE: v7 introduced new roles, using identifiers instead of display names, which means any API consumer needs to update how users are fetched.

BREAKING CHANGE: global roles are reported as a dedicated area in /api{/v1}/users.

Release-As: 7.0.1

## Summary by Sourcery

Fix users endpoint role reporting and boolean filtering for the 7.0.0 roles model.

Bug Fixes:
- Report globally scoped user roles under a dedicated `global` area in both users API endpoints.
- Accept documented boolean query-string values for `onlyAtcActive` while continuing to reject invalid values.

Enhancements:
- Preserve stable role identifiers in the users endpoint and maintain consistent responses between legacy and v1 routes.

Tests:
- Add feature coverage for global and area-scoped roles, boolean filter spellings, invalid filter values, and endpoint parity.