### PR TITLE
feat(training): sign off a training one VATSIM rating part at a time

### DIFF
--- a/app/Console/Commands/SyncRoster.php
+++ b/app/Console/Commands/SyncRoster.php
@@ -4,8 +4,11 @@ namespace App\Console\Commands;
 
 use anlutro\LaravelSettings\Facade as Setting;
 use App\Facades\DivisionApi;
+use App\Helpers\TaskStatus;
+use App\Models\Task;
 use App\Models\User;
 use App\Services\DivisionApi\DivisionApiError;
+use App\Tasks\Types\RatingUpgrade;
 use Illuminate\Console\Command;
 
 class SyncRoster extends Command
@@ -23,6 +26,17 @@ class SyncRoster extends Command
      * @var string
      */
     protected $description = 'Sync the roster with Division API';
+
+    /**
+     * How long a requested rating upgrade shields a member from roster removal.
+     *
+     * User.rating is only refreshed by update:member:data (daily 04:00) from the OAuth
+     * provider, so a member whose upgrade Core has already granted can read as OBS here
+     * for up to a day. This window comfortably exceeds that propagation while keeping the
+     * accepted edge case short: a member upgraded and then suspended inside the window
+     * stays on Core until it lapses.
+     */
+    private const UPGRADE_GRACE_DAYS = 30;
 
     /**
      * Execute the console command.
@@ -63,7 +77,18 @@ class SyncRoster extends Command
 
                 // Remove member who are not active anymore
                 $this->info('Removing members from roster...');
-                $removedMembers = $rosteredMembers->diff($activeMembers);
+                // Members whose rating upgrade was recently requested are still waiting for
+                // VATSIM to grant it, so their local rating lags behind the roster. A completed
+                // RatingUpgrade task is that request: requestRatingUpgrade() runs only inside
+                // RatingUpgrade::complete(). Removing them would undo the upgrade we just asked for.
+                $upgradeInProgress = Task::query()
+                    ->where('type', RatingUpgrade::class)
+                    ->where('status', TaskStatus::COMPLETED)
+                    ->where('closed_at', '>=', now()->subDays(self::UPGRADE_GRACE_DAYS))
+                    ->pluck('subject_user_id')
+                    ->unique();
+
+                $removedMembers = $rosteredMembers->diff($activeMembers)->diff($upgradeInProgress);
                 $removedMembers->each(function ($memberId) {
                     $response = DivisionApi::removeRosterUser($memberId);
                     if ($response->successful()) {

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -163,7 +163,7 @@ class ReportController extends Controller
 
         $this->authorize('accessActivityReports', [ManagementReport::class, $filterArea]);
 
-        $activities = TrainingActivity::with('training', 'training.ratings', 'training.user', 'user', 'endorsement')
+        $activities = TrainingActivity::with('training', 'training.ratings', 'training.user', 'user', 'endorsement', 'rating')
             ->when($filterArea, function (Builder $query, $filterArea) {
                 $query->whereHas('training', fn (Builder $q) => $q->where('area_id', $filterArea));
             })

--- a/app/Http/Controllers/TrainingActivityController.php
+++ b/app/Http/Controllers/TrainingActivityController.php
@@ -15,7 +15,7 @@ class TrainingActivityController extends Controller
     /*
     * A table over allowed activity types
     */
-    public static $activityTypes = ['STATUS' => true, 'TYPE' => true, 'MENTOR' => true, 'PAUSE' => true, 'ENDORSEMENT' => true, 'COMMENT' => true, 'PRETRAINING' => true];
+    public static $activityTypes = ['STATUS' => true, 'TYPE' => true, 'MENTOR' => true, 'PAUSE' => true, 'ENDORSEMENT' => true, 'COMMENT' => true, 'PRETRAINING' => true, 'RATING' => true];
 
     /**
      * Store a newly created resource in storage.

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -8,10 +8,12 @@ use App\Exceptions\PolicyMethodMissingException;
 use App\Exceptions\PolicyMissingException;
 use App\Helpers\InterestStatus;
 use App\Helpers\LogName;
+use App\Helpers\TaskStatus;
 use App\Helpers\TrainingStatus;
 use App\Helpers\VatsimRating;
 use App\Models\Area;
 use App\Models\Rating;
+use App\Models\Task;
 use App\Models\Training;
 use App\Models\TrainingExamination;
 use App\Models\TrainingInterest;
@@ -23,6 +25,7 @@ use App\Notifications\TrainingMentorNotification;
 use App\Notifications\TrainingPreStatusNotification;
 use App\Services\ActivityLogService;
 use App\Services\TrainingService;
+use App\Tasks\Types\RatingUpgrade;
 use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Routing\ResponseFactory;
@@ -338,7 +341,11 @@ class TrainingController extends Controller
         $trainingMentors = $training->area->mentors->sortBy('name');
         $types = TrainingController::$types;
         $experiences = TrainingController::$experiences;
-        $activities = $training->activities->sortByDesc('created_at');
+        // Entries written in the same request share a created_at, since training_activity
+        // only keeps second precision. Tie-breaking on id keeps the newest entry on top,
+        // so a status change lands above the part-completion comment that triggered it
+        // instead of in whatever order the query happened to return.
+        $activities = $training->activities->sortBy([['created_at', 'desc'], ['id', 'desc']]);
 
         $trainingInterests = TrainingInterest::where('training_id', $training->id)->orderBy('created_at', 'DESC')->get();
         $activeTrainingInterest = TrainingInterest::where('training_id', $training->id)->where('expired', false)->get()->count();
@@ -348,7 +355,50 @@ class TrainingController extends Controller
         $requestTypes = TaskController::getTypes();
         $requestPopularAssignees = TaskController::getPopularAssignees($training->area);
 
-        return view('training.show', compact('training', 'reportsAndExams', 'trainingMentors', 'types', 'experiences', 'activities', 'trainingInterests', 'activeTrainingInterest', 'relatedTasks', 'requestTypes', 'requestPopularAssignees'));
+        // Shares its rule with TrainingService::completeRatingPart(), so the control and
+        // the sign-off always agree on what is left.
+        $outstandingRatings = $training->outstandingRatings();
+
+        // Signing off a part is offered on multi-rating trainings in progress only: a
+        // single-rating training keeps the status -> Completed flow.
+        $multiRatingInProgress = $training->status->isInProgress() && $training->ratings->count() > 1;
+
+        // The next part staff can sign off: the lowest outstanding VATSIM rating, because a
+        // student earns S1 before S2. Facility and tier ratings are never signed off on
+        // their own, they are granted when the training is completed as a whole.
+        $completablePart = $multiRatingInProgress
+            ? $outstandingRatings
+                ->whereNotNull('vatsim_rating')
+                ->sortBy(fn (Rating $rating) => $rating->vatsim_rating->value)
+                ->first()
+            : null;
+
+        // Only a part that can actually be signed off gets a control. A training whose
+        // outstanding ratings are all facility or tier ones is finished through its status.
+        $showCompletionControl = $completablePart !== null;
+
+        // What stays outstanding once that part is signed off, so the modal can name it.
+        $otherOutstandingRatings = $outstandingRatings->filter(fn (Rating $rating) => $rating->id !== $completablePart?->id);
+
+        // With nothing else outstanding, signing off the part would finish the whole
+        // training, which is not a partial completion. The control is shown but disabled.
+        $canCompletePartially = $otherOutstandingRatings->isNotEmpty();
+
+        // Whether the rating upgrade for that part was already requested, so the modal can
+        // warn when it was not. Mirrors how RatingUpgrade picks its target rating.
+        $upgradeRequestedForPart = $completablePart !== null && $training->tasks->contains(function (Task $task) use ($training, $completablePart) {
+            if ($task->type !== RatingUpgrade::class || $task->status !== TaskStatus::COMPLETED) {
+                return false;
+            }
+
+            if ($task->subject_training_rating_id !== null) {
+                return (int) $task->subject_training_rating_id === $completablePart->id;
+            }
+
+            return $training->getHighestVatsimRating()?->id === $completablePart->id;
+        });
+
+        return view('training.show', compact('training', 'reportsAndExams', 'trainingMentors', 'types', 'experiences', 'activities', 'trainingInterests', 'activeTrainingInterest', 'relatedTasks', 'requestTypes', 'requestPopularAssignees', 'showCompletionControl', 'completablePart', 'otherOutstandingRatings', 'canCompletePartially', 'upgradeRequestedForPart'));
     }
 
     /**
@@ -405,6 +455,18 @@ class TrainingController extends Controller
 
         // Save the ratings
         $training->ratings()->saveMany($ratings);
+
+        // The detach above dropped the per-rating completion stamps. Put them back for the
+        // ratings that survived the edit: a part that was signed off stays signed off.
+        $completedAt = $preChangeRatings
+            ->mapWithKeys(fn (Rating $rating) => [$rating->id => $rating->pivot->completed_at])
+            ->filter();
+
+        foreach ($ratings as $rating) {
+            if ($completedAt->has($rating->id)) {
+                $training->ratings()->updateExistingPivot($rating->id, ['completed_at' => $completedAt->get($rating->id)]);
+            }
+        }
 
         // Save the rest
         $training->type = $attributes['type'];
@@ -605,6 +667,25 @@ class TrainingController extends Controller
         TrainingActivityController::create($training->id, 'PRETRAINING', $newState, $oldState, Auth::id());
 
         return redirect($training->path())->withSuccess('Pre-training marked as ' . ($newState ? 'completed' : 'not completed'));
+    }
+
+    /**
+     * Complete a single VATSIM rating part of a multi-rating training.
+     *
+     * @throws AuthorizationException
+     */
+    public function completePart(Training $training, Rating $rating): RedirectResponse
+    {
+        $this->authorize('update', $training);
+
+        $error = app(TrainingService::class)->completeRatingPart($training, $rating);
+        if ($error !== null) {
+            return back()->withErrors($error);
+        }
+
+        ActivityLogService::warning(LogName::Training, 'Completed the ' . $rating->name . ' part of training ' . $training->id . ' for CID ' . $training->user_id);
+
+        return back()->withSuccess('Completed the ' . $rating->name . ' part.');
     }
 
     /**

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
 use Spatie\Activitylog\Support\LogOptions;
 
 class Training extends Model
@@ -211,10 +212,29 @@ class Training extends Model
 
     /**
      * Get the ratings of the training.
+     *
+     * The completed_at pivot column marks an individually completed part of a
+     * multi-rating training. Read it with Carbon::parse, it is not cast.
      */
     public function ratings(): BelongsToMany
     {
-        return $this->belongsToMany(Rating::class);
+        return $this->belongsToMany(Rating::class)->withPivot('completed_at');
+    }
+
+    /**
+     * The ratings of this training that are still to be earned.
+     *
+     * A facility or tier rating counts as outstanding whatever its pivot says: it is only
+     * granted by completing the training as a whole, and a completion that was since
+     * reopened leaves its stamp behind.
+     *
+     * @return Collection<int, Rating>
+     */
+    public function outstandingRatings(): Collection
+    {
+        return $this->ratings->filter(
+            fn (Rating $rating) => $rating->pivot->completed_at === null || $rating->vatsim_rating === null
+        );
     }
 
     /**

--- a/app/Models/TrainingActivity.php
+++ b/app/Models/TrainingActivity.php
@@ -31,6 +31,15 @@ class TrainingActivity extends Model
     }
 
     /**
+     * The rating a RATING entry signed off. Shares new_data with endorsement(),
+     * so it is only meaningful on entries of that type.
+     */
+    public function rating()
+    {
+        return $this->belongsTo(Rating::class, 'new_data');
+    }
+
+    /**
      * The date this entry should be sorted and displayed by in activity feeds.
      */
     public function getActivityDateAttribute()

--- a/app/Services/TrainingService.php
+++ b/app/Services/TrainingService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use anlutro\LaravelSettings\Facade as Setting;
 use App\Facades\DivisionApi;
 use App\Helpers\TrainingStatus;
+use App\Http\Controllers\TrainingActivityController;
 use App\Models\AtcActivity;
 use App\Models\Endorsement;
 use App\Models\Rating;
@@ -67,10 +68,102 @@ class TrainingService
     }
 
     /**
+     * Complete a single VATSIM rating part of a multi-rating training.
+     *
+     * Stamps the part, activates ATC for the training area, and logs it on the training
+     * timeline. When it stamps the last outstanding part, the training is completed and
+     * closed through closeTraining(), so this and the full-completion flow send exactly
+     * one TrainingClosedNotification each.
+     *
+     * Facility ratings are never completable individually: they are granted by full
+     * completion, which calls the Division API for the tier endorsement.
+     *
+     * Returns an error string for the caller to flash, or null on success.
+     */
+    public function completeRatingPart(Training $training, Rating $rating): ?string
+    {
+        if (! $training->status->isInProgress()) {
+            return 'Only a training in progress can have a part completed.';
+        }
+
+        if ($training->ratings->count() < 2) {
+            return 'A single-rating training is completed by setting its status to Completed.';
+        }
+
+        if (! $training->ratings->contains($rating->id)) {
+            return $rating->name . ' is not part of this training.';
+        }
+
+        if ($rating->vatsim_rating === null) {
+            return $rating->name . ' is granted when the whole training is completed, not part by part.';
+        }
+
+        if ($this->ratingPartIsCompleted($training, $rating)) {
+            return 'The ' . $rating->name . ' part is already completed.';
+        }
+
+        $this->stampRatingCompleted($training, $rating);
+        $this->activateAtcForTraining($training);
+
+        // A RATING entry rather than a COMMENT: TrainingActivityPolicy hides COMMENT from
+        // the student, and the timeline renders COMMENT with an author edit button. A part
+        // sign-off is neither private nor editable, and holding the rating id keeps the
+        // entry readable after a rating is renamed.
+        TrainingActivityController::create($training->id, 'RATING', $rating->id, null, Auth::id());
+
+        // Load-bearing: the outstanding check below reads the pivots we just wrote.
+        $training->load('ratings');
+
+        if ($training->outstandingRatings()->isNotEmpty()) {
+            return null;
+        }
+
+        // Every part is done and all are VATSIM ratings, so finish the training.
+        return $this->completeWholeTraining($training);
+    }
+
+    /**
+     * Complete a whole training and close it.
+     *
+     * Reached from completeRatingPart() once the last outstanding part is stamped.
+     * closeTraining() grants every rating its endorsement, so a training can end with one
+     * endorsement or several.
+     *
+     * Returns an error string for the caller to flash, or null on success.
+     */
+    private function completeWholeTraining(Training $training): ?string
+    {
+        if (! $training->status->isInProgress()) {
+            return 'Only a training in progress can be completed.';
+        }
+
+        $oldStatus = $training->status;
+        $training->updateStatus(TrainingStatus::COMPLETED);
+        TrainingActivityController::create($training->id, 'STATUS', TrainingStatus::COMPLETED->value, $oldStatus->value, Auth::id());
+
+        return $this->closeTraining($training);
+    }
+
+    /**
+     * Whether this rating part of the training has already been completed.
+     */
+    private function ratingPartIsCompleted(Training $training, Rating $rating): bool
+    {
+        return $training->ratings()
+            ->wherePivotNotNull('completed_at')
+            ->wherePivot('rating_id', $rating->id)
+            ->exists();
+    }
+
+    /**
      * Run the completion work for a training: per-rating endorsements, then ATC activation.
      */
     public function completeTraining(Training $training): ?string
     {
+        // Deliberately unfiltered: a VATSIM part stamped earlier by completeRatingPart()
+        // re-runs completeRating() as a no-op (stampRatingCompleted() keeps the first
+        // stamp), but a facility part must re-run so a reopened and re-completed
+        // training still revokes the old endorsement and grants a fresh one.
         foreach ($training->ratings as $rating) {
             $error = $this->completeRating($training, $rating);
             if ($error !== null) {
@@ -86,11 +179,13 @@ class TrainingService
     /**
      * Apply one rating's completion effect. Facility ratings (vatsim_rating null)
      * revoke the prior endorsement, call the Division API, and grant a fresh
-     * endorsement; VATSIM ratings are a no-op.
+     * endorsement; VATSIM ratings only get stamped.
      */
     public function completeRating(Training $training, Rating $rating): ?string
     {
         if ($rating->vatsim_rating != null) {
+            $this->stampRatingCompleted($training, $rating);
+
             return null;
         }
 
@@ -124,7 +219,30 @@ class TrainingService
 
         $endorsement->ratings()->save(Rating::find($rating->id));
 
+        // Stamped last, and only on success, so a failed call leaves the part outstanding
+        // for a retry. The stamp records the grant; completeTraining() re-runs stamped
+        // parts deliberately.
+        $this->stampRatingCompleted($training, $rating);
+
         return null;
+    }
+
+    /**
+     * Mark one rating part of the training as completed.
+     *
+     * Keeps the first stamp: a part is completed once, and re-running completion must
+     * not move its date.
+     */
+    private function stampRatingCompleted(Training $training, Rating $rating): void
+    {
+        $outstanding = $training->ratings()
+            ->wherePivotNull('completed_at')
+            ->wherePivot('rating_id', $rating->id)
+            ->exists();
+
+        if ($outstanding) {
+            $training->ratings()->updateExistingPivot($rating->id, ['completed_at' => now()]);
+        }
     }
 
     /**

--- a/database/migrations/2026_08_26_120000_add_completed_at_to_rating_training_table.php
+++ b/database/migrations/2026_08_26_120000_add_completed_at_to_rating_training_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('rating_training', function (Blueprint $table) {
+            $table->timestamp('completed_at')->nullable();
+        });
+
+        // No backfill: closed_at is per-training, not per-rating, so stamping historic
+        // trainings would invent per-part dates. Their parts stay NULL.
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('rating_training', function (Blueprint $table) {
+            $table->dropColumn('completed_at');
+        });
+    }
+};

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -12,3 +12,5 @@ A selection of important scheduled tasks include:
 - All trainings with status In Queue or Pre-Training are given a continued interest request each month, and a reminder after a week.
 - ATC Active is flag given based on ATC activity. Refreshes daily with data from VATSIM Data API. It counts the hours from today's date and backwards according to the length of qualification period.
 - Daily member cleanup, if a member leaves the division, their training will be automatically closed. Same for mentors. Does not apply to visitors.
+- Member data, including the VATSIM rating held, is refreshed daily at 04:00 from your OAuth provider. A rating upgrade granted by VATSIM can therefore take up to a day to show in Control Center.
+- Roster sync keeps the Division roster in step with your active members. Members with a recently completed [rating upgrade task](./concepts/tasks.md) are never removed, since their local rating is only waiting to catch up. See [Roster Sync](./integrations/vateud.md#roster-sync) for the exact window.

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -14,7 +14,7 @@ You may only send a task to one person.
 
 ### Type of tasks
 
-- **Rating upgrade**: Request rating upgrade for a student
+- **Rating upgrade**: Request rating upgrade for a student. With a Division API enabled, completing it adds the student to the roster and protects them from roster removal for 30 days, while their rating catches up. It is also what Control Center looks for when [signing off a rating][completing] on a training.
 - **Solo Endorsement**: Request granting of solo endorsement
 - **Theory Exam Access**: Request access to theory exam
 - **Custom Request:** Free text
@@ -25,3 +25,5 @@ When running tasks without an API, the completion of a task will simply mark it 
 
 !!! tip "Quick add"
     When creating a task, there's up to three quick add buttons identified by a lightning bolt and the recipient's name. The quick feature automatically creates the suggestions based on who has a mentor or moderator role in the current area of training, and also historically who has received most of the tasks.
+
+  [completing]: ./training.md#rating-upgrades-and-the-roster

--- a/docs/concepts/training.md
+++ b/docs/concepts/training.md
@@ -11,20 +11,21 @@ This guide details the functionalities available to all ATC members, mentors, an
 
 ## For All ATC Members
 
-### Training Requests
+### Training requests
 
 As a member of the VATSIM division using Control Center, you can apply for ATC training [from the dashboard][dashboard].
 
-### Training Details
+### Training details
 
-- **Overview**: Access detailed information about your own training sessions.
-- **Status**: Check the current status of your training (e.g., scheduled, in progress, completed).
-- **Training Type**: Identify the type of training you are undergoing (Standard, Refresh, Transfer).
-- **Division Rating**: View the division rating applicable for the training.
-- **Training Period**: See the scheduled period of the training session.
-- **Training Reports**: Access a list of training reports (if available) related to your training sessions.
+Open one of your trainings to see everything recorded about it:
 
-### Minimum Activity Levels
+- The current status, such as *In Queue*, *In Progress*, or *Completed*.
+- The training type: Standard, Refresh, or Transfer.
+- The ratings the training covers under **Level**, each with the date it was signed off once your mentor gets there.
+- The scheduled training period.
+- Your training reports, once a mentor has written them.
+
+### Minimum activity levels
 
 Members with an active training request *In Queue* or in *Pre-Training* receive an email to confirm their continued interest in receiving ATC training every month, with a follow-up reminder after a week.
 
@@ -35,28 +36,81 @@ Members with an active training request *In Queue* or in *Pre-Training* receive 
 
 ## For Mentors
 
-In addition to the functionalities available to all ATC members, mentors have the following capabilities:
+Mentors can do everything an ATC member can, and can also keep the record of a training they mentor up to date.
 
-### Enhanced Training Overview
+### Comment on a training
 
-- **Commenting on Training Status**: Add comments regarding the training status, such as temporary postponements or student's health-related absences.
+Add a comment to the training timeline to explain where the training stands, such as a temporary postponement or a student's absence.
 
-### Reporting Tools
+### Write reports
 
-- **Create Training Reports**: Generate reports based on the training sessions.
-- **Create Exam Reports**: Develop reports for exams associated with the training sessions.
+Write a training report for a session, and an exam report for an examination attached to the training.
 
-## For Training Directors
+## For Training Staff
 
-Training Directors have access to all the functionalities available to Normal ATC Members and Mentors, with the added authority of:
+Training Directors complete and close trainings.
+Training staff and area moderators can do the same within their own area.
+Mentors cannot, even for a training they mentor.
+See [Roles and Permissions][permissions].
 
-### Training Management
+### Sign off part of a training
 
-- **Close Trainings**: Finalize and close training sessions upon completion or as required by the circumstances.
+A training can cover more than one rating, such as S1 + S2.
+Because a student is examined and awarded one rating at a time, you can sign off each rating as the student earns it and leave the training open for the rest.
 
-## Conclusion
+The **Complete partial training** button appears on the training page when the training is *In Progress* and covers more than one rating.
 
-The training functionality in Control Center is a versatile tool designed to support the varied needs of the VATSIM community.
-Whether you are a normal division member, a mentor, or a Training Director, this functionality provides the necessary functionalities to effectively manage and track training progress within a VATSIM division.
+1. Open the training and select **Complete partial training**.
+2. Check the rating shown. Control Center offers the lowest rating still outstanding, because a student earns S1 before S2.
+3. Select **Complete S1**, or whichever rating is named.
+
+Control Center then:
+
+- Marks that rating complete under **Level**, with the date you signed it off.
+- Marks the student active for the training's area and starts a fresh [activity grace period][activity]. This follows the same rules as closing a training, so visitors and members outside your division are not affected.
+- Adds an entry to the training timeline naming the rating and you as the author. Unlike a comment, the student sees this one on their own training, and it cannot be edited afterwards.
+
+The training stays *In Progress* for the remaining ratings, and the button offers the next one the next time you open the page.
+
+!!! note "Older trainings show no per-rating dates"
+    Trainings closed before per-rating sign-off existed show nothing under **Level** but the ratings themselves.
+    Only the training's own closing date was recorded then.
+
+### Finish a training
+
+The control only ever signs off a part while something else stays outstanding.
+When one rating is left, signing it off would finish the whole training, so the control is shown with the part it would sign off but is disabled.
+Close the training by setting its status to *Completed*, which grants any endorsements its ratings carry and emails the student a confirmation.
+
+Facility and tier ratings are never signed off part by part, because their endorsement is granted through the [Division API][vateud] when the training is completed.
+A training with nothing left that can be signed off on its own therefore offers no button.
+Close it by setting the training status to *Completed*.
+
+A training that covers a single rating has no completion button either.
+Close it the same way, and its rating still gets a completion date under **Level**.
+
+However you get there, a training is closed and the student emailed exactly once.
+
+### Close a training that was not finished
+
+Set the training status to *Closed by staff*, *Closed by student*, or *Completed* as the case requires.
+Every closing status emails the student, but only *Completed* grants the endorsements the ratings carry.
+
+### Rating upgrades and the roster
+
+When you sign off a rating, Control Center warns you if it finds no completed [rating upgrade task][tasks] for it.
+The warning is advisory and does not block you:
+
+- Completing the upgrade task first is the normal order, since that is what adds the student to the Division roster.
+- The warning can also appear for a rating that was upgraded, when the task predates Control Center recording which rating a request targeted. Sign off anyway if you know the upgrade was granted, inside or outside Control Center.
+
+The student does not appear on Control Center roster views until VATSIM actually grants the rating.
+This is deliberate, since they cannot control the position until they hold it.
+Their place on the Division roster is protected while they wait, as described under [Roster Sync][roster-sync].
 
   [dashboard]: ./index.md
+  [permissions]: ./permissions.md
+  [tasks]: ./tasks.md
+  [activity]: ../activity.md
+  [vateud]: ../integrations/vateud.md
+  [roster-sync]: ../integrations/vateud.md#roster-sync

--- a/docs/integrations/vateud.md
+++ b/docs/integrations/vateud.md
@@ -30,6 +30,13 @@ This job ensures the list of controllers on the VATEUD roster matches your **Act
     - **Inactive Members**: Home members who have failed to meet activity requirements (`atc_active = false`).
     - **Expired Visitors**: Visiting members whose endorsement has expired or been revoked.
     - **Transfers**: Members who have left the subdivision.
+- **Keeps regardless**:
+    - **Pending rating upgrades**: Members whose [rating upgrade task](../concepts/tasks.md) was completed within the last 30 days.
+
+!!! note "Why pending upgrades are kept"
+    Completing a rating upgrade task adds the member to the VATEUD roster immediately, but their rating in Control Center is only refreshed once a day, at 04:00, from your OAuth provider.
+    In between, the member reads as OBS locally, and a roster sync would otherwise undo the upgrade that was just granted.
+    The 30 day window covers that delay. A member who is upgraded and then suspended stays on the roster until the window lapses.
 
 ### Endorsement Sync
 

--- a/resources/views/reports/activities.blade.php
+++ b/resources/views/reports/activities.blade.php
@@ -85,6 +85,8 @@
                                                 <i class="fas fa-circle-pause"></i>
                                             @elseif($activity->type == "ENDORSEMENT")
                                                 <i class="fas fa-check-square"></i>
+                                            @elseif($activity->type == "RATING")
+                                                <i class="fas fa-list-check"></i>
                                             @elseif($activity->type == "COMMENT")
                                                 <i class="fas fa-comment"></i>
                                             @elseif($activity->type == 'PRETRAINING')
@@ -145,6 +147,10 @@
                                                         @endforeach
                                                     @endempty
                                                 @endif
+                                            @elseif($activity->type == "RATING")
+                                                @isset($activity->rating)
+                                                    <span class="badge text-bg-light">{{ $activity->rating->name }}</span> part completed
+                                                @endisset
                                             @elseif($activity->type == "COMMENT")
                                                 {!! nl2br($activity->comment) !!}
 

--- a/resources/views/training/parts/completepartmodal.blade.php
+++ b/resources/views/training/parts/completepartmodal.blade.php
@@ -1,0 +1,39 @@
+<div class="modal fade" id="completeTraining" tabindex="-1" aria-labelledby="completeTrainingLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title fs-5" id="completeTrainingLabel">Complete partial training</h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+
+                <form action="{{ route('training.action.completepart', ['training' => $training->id, 'rating' => $completablePart->id]) }}" method="POST">
+
+                    @csrf
+
+                    <div class="alert alert-primary">
+                        <i class="fas fa-check"></i> Sign off the <b>{{ $completablePart->name }}</b> part of this training
+                    </div>
+
+                    @if($otherOutstandingRatings->isNotEmpty())
+                        <p>The training stays open for {{ $otherOutstandingRatings->pluck('name')->implode(', ') }}.</p>
+                    @else
+                        <p>This is the last outstanding part, so the training is completed and closed.</p>
+                    @endif
+                    <p>The student is marked active for {{ $training->area->name }}.</p>
+
+                    @if(! $upgradeRequestedForPart)
+                        <div class="alert alert-warning mb-0">
+                            No rating upgrade request found for {{ $completablePart->name }}. Request the upgrade first, or complete it anyway if it was requested outside Control Center.
+                        </div>
+                    @endif
+
+                    <div class="modal-footer border-top-0">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-success">Complete {{ $completablePart->name }}</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/training/show.blade.php
+++ b/resources/views/training/show.blade.php
@@ -83,7 +83,18 @@
                     <dd><i class="{{ $types[$training->type]["icon"] }} text-primary"></i>&ensp;{{ $types[$training->type]["text"] }}</dd>
 
                     <dt>Level</dt>
-                    <dd class="separator pb-3">{{ $training->getInlineRatings() }}</dd>
+                    <dd class="separator pb-3">
+                        @foreach($training->ratings as $rating)
+                            <div>
+                                @if($rating->pivot->completed_at)
+                                    <i class="fas fa-check text-success"></i>&nbsp;{{ $rating->name }}
+                                    <span class="text-muted">({{ \Carbon\Carbon::parse($rating->pivot->completed_at)->toEuropeanDate() }})</span>
+                                @else
+                                    {{ $rating->name }}
+                                @endif
+                            </div>
+                        @endforeach
+                    </dd>
 
                     <dt class="pt-2">Vatsim ID</dt>
                     <dd>
@@ -132,9 +143,23 @@
                     </dd>
                 </dl>
 
-                @can('edit', [\App\Models\Training::class, $training])
-                    <a href="{{ route('training.edit', $training->id) }}" class="btn btn-outline-primary btn-icon"><i class="fas fa-pencil"></i>&nbsp;Edit training</a>
-                @endcan
+                <div class="btn-group" role="group" aria-label="Training actions">
+                    @can('edit', [\App\Models\Training::class, $training])
+                        <a href="{{ route('training.edit', $training->id) }}" class="btn btn-outline-primary btn-icon"><i class="fas fa-pencil"></i>&nbsp;Edit training</a>
+                    @endcan
+
+                    @if($showCompletionControl)
+                        @can('update', $training)
+                            <button type="button" class="btn btn-outline-success btn-icon" data-bs-toggle="modal" data-bs-target="#completeTraining"
+                                @unless($canCompletePartially)
+                                    disabled title="{{ $completablePart->name }} is the only rating left, so signing it off would finish the whole training. Set the training status to Completed instead."
+                                @endunless
+                            >
+                                <i class="fas fa-check"></i>&nbsp;Complete partial training
+                            </button>
+                        @endcan
+                    @endif
+                </div>
             </div>
         </div>
 
@@ -240,6 +265,8 @@
                                         <i class="fas fa-circle-pause"></i>
                                     @elseif($activity->type == "ENDORSEMENT")
                                         <i class="fas fa-check-square"></i>
+                                    @elseif($activity->type == "RATING")
+                                        <i class="fas fa-list-check"></i>
                                     @elseif($activity->type == "COMMENT")
                                         <i class="fas fa-comment"></i>
                                     @elseif($activity->type == 'PRETRAINING')
@@ -313,6 +340,10 @@
                                                 @endforeach
                                             @endempty
                                         @endif
+                                    @elseif($activity->type == "RATING")
+                                        @isset($activity->rating)
+                                            <span class="badge text-bg-light">{{ $activity->rating->name }}</span> part completed
+                                        @endisset
                                     @elseif($activity->type == "COMMENT")
                                         {!! nl2br($activity->comment) !!}
 
@@ -591,6 +622,11 @@
     @endif
 @endforeach
 
+@if($showCompletionControl)
+    @can('update', $training)
+        @include('training.parts.completepartmodal', ['training' => $training, 'completablePart' => $completablePart, 'otherOutstandingRatings' => $otherOutstandingRatings, 'upgradeRequestedForPart' => $upgradeRequestedForPart])
+    @endcan
+@endif
 
 @endsection
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -121,6 +121,7 @@ Route::middleware(['auth', 'activity', 'suspended'])->group(function () {
         Route::post('/training/store', 'store')->name('training.store');
         Route::get('/training/{training}/action/close', 'close')->name('training.action.close');
         Route::get('/training/{training}/action/pretraining', 'togglePreTrainingCompleted')->name('training.action.pretraining');
+        Route::post('/training/{training}/rating/{rating}/complete', 'completePart')->name('training.action.completepart');
         Route::patch('/training/{training}', 'updateDetails')->name('training.update.details');
         Route::get('/training/{training}', 'show')->name('training.show');
 

--- a/tests/Feature/ReportControllerTest.php
+++ b/tests/Feature/ReportControllerTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Helpers\VatsimRating;
 use App\Models\Area;
+use App\Models\Rating;
 use App\Models\Training;
 use App\Models\TrainingActivity;
 use App\Models\TrainingReport;
@@ -219,6 +221,30 @@ class ReportControllerTest extends TestCase
         $response->assertOk();
         $entries = $response->viewData('entries');
         $this->assertTrue($entries->first()->is($report));
+    }
+
+    #[Test]
+    public function activities_report_renders_a_rating_part_sign_off(): void
+    {
+        $training = Training::factory()->create([
+            'user_id' => User::factory()->create()->id,
+        ]);
+        $rating = Rating::factory()->create(['vatsim_rating' => VatsimRating::S1->value, 'name' => 'S1 TWR']);
+        $training->ratings()->attach($rating->id);
+
+        // This report switches on the activity type with no fallback branch, so a type it
+        // does not know renders as an empty cell rather than failing.
+        $activity = new TrainingActivity;
+        $activity->training_id = $training->id;
+        $activity->triggered_by_id = $this->adminUser->id;
+        $activity->type = 'RATING';
+        $activity->new_data = $rating->id;
+        $activity->save();
+
+        $this->actingAs($this->adminUser)
+            ->get(route('reports.activities'))
+            ->assertOk()
+            ->assertSee($rating->name . '</span> part completed', false);
     }
 
     #[Test]

--- a/tests/Feature/SyncRosterTest.php
+++ b/tests/Feature/SyncRosterTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Feature;
+
+use anlutro\LaravelSettings\Facade as Setting;
+use App\Facades\DivisionApi;
+use App\Helpers\TaskStatus;
+use App\Helpers\VatsimRating;
+use App\Models\AtcActivity;
+use App\Models\Task;
+use App\Models\Training;
+use App\Models\User;
+use App\Tasks\Types\RatingUpgrade;
+use Carbon\Carbon;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Response as ClientResponse;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SyncRosterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Setting::set('divisionApiEnabled', true);
+    }
+
+    /**
+     * Fake the Core roster so it contains exactly these VATSIM CIDs.
+     */
+    private function fakeRosterContaining(array $userIds): void
+    {
+        $members = array_map(fn (int $id) => ['user_cid' => $id], $userIds);
+
+        DivisionApi::shouldReceive('getRoster')->once()->andReturn(
+            new ClientResponse(new GuzzleResponse(200, [], json_encode(['data' => ['roster_members' => $members]])))
+        );
+    }
+
+    /**
+     * A student Core has already been asked to upgrade, whose local VATSIM rating has not
+     * caught up yet: active for ATC locally, but still OBS, so the rating >= S1 gate in
+     * getActiveAtcMembers() leaves them out of the active set.
+     */
+    private function upgradedButLaggingUser(): User
+    {
+        $user = User::factory()->create(['rating' => VatsimRating::OBS]);
+
+        AtcActivity::create([
+            'user_id' => $user->id,
+            'area_id' => 1,
+            'hours' => 0,
+            'atc_active' => true,
+        ]);
+
+        return $user;
+    }
+
+    /**
+     * The record left behind by a rating upgrade request.
+     */
+    private function ratingUpgradeTask(User $user, Carbon $closedAt, TaskStatus $status = TaskStatus::COMPLETED): Task
+    {
+        return Task::create([
+            'type' => RatingUpgrade::class,
+            'status' => $status,
+            'subject_user_id' => $user->id,
+            'subject_training_id' => Training::factory()->create(['user_id' => $user->id])->id,
+            'assignee_user_id' => User::factory()->create()->id,
+            'closed_at' => $closedAt,
+        ]);
+    }
+
+    private function successfulResponse(): ClientResponse
+    {
+        return new ClientResponse(new GuzzleResponse(200, [], json_encode(['status' => 'ok'])));
+    }
+
+    #[Test]
+    public function a_recent_rating_upgrade_keeps_a_lagging_student_on_the_roster(): void
+    {
+        $user = $this->upgradedButLaggingUser();
+        $this->ratingUpgradeTask($user, now()->subDay());
+        $this->fakeRosterContaining([$user->id]);
+
+        // Removing them here would undo the upgrade we just asked Core for.
+        DivisionApi::shouldReceive('removeRosterUser')->never();
+        DivisionApi::shouldReceive('assignRosterUser')->never();
+
+        $this->artisan('sync:roster');
+    }
+
+    #[Test]
+    public function a_student_without_a_recent_upgrade_is_still_removed(): void
+    {
+        // Indistinguishable from a suspended or demoted member: atc_active locally, rating
+        // below S1, and no pending upgrade to protect them.
+        $user = $this->upgradedButLaggingUser();
+        $this->fakeRosterContaining([$user->id]);
+
+        DivisionApi::shouldReceive('removeRosterUser')->once()->with($user->id)->andReturn($this->successfulResponse());
+
+        $this->artisan('sync:roster');
+    }
+
+    #[Test]
+    public function an_upgrade_that_is_stale_or_not_completed_does_not_protect(): void
+    {
+        $stale = $this->upgradedButLaggingUser();
+        $this->ratingUpgradeTask($stale, now()->subDays(31));
+
+        // closed_at is recent on purpose, so this pins the status filter rather than the window.
+        $pending = $this->upgradedButLaggingUser();
+        $this->ratingUpgradeTask($pending, now()->subDay(), TaskStatus::PENDING);
+
+        $this->fakeRosterContaining([$stale->id, $pending->id]);
+
+        DivisionApi::shouldReceive('removeRosterUser')->twice()->andReturn($this->successfulResponse());
+
+        $this->artisan('sync:roster');
+    }
+}

--- a/tests/Feature/TrainingsTest.php
+++ b/tests/Feature/TrainingsTest.php
@@ -4,22 +4,28 @@ namespace Tests\Feature;
 
 use anlutro\LaravelSettings\Facade as Setting;
 use App\Facades\DivisionApi;
+use App\Helpers\TaskStatus;
 use App\Helpers\TrainingStatus;
 use App\Helpers\VatsimRating;
 use App\Models\Area;
 use App\Models\AtcActivity;
 use App\Models\Endorsement;
 use App\Models\Rating;
+use App\Models\Task;
 use App\Models\Training;
+use App\Models\TrainingActivity;
 use App\Models\User;
 use App\Notifications\TrainingClosedNotification;
 use App\Notifications\TrainingCreatedNotification;
 use App\Notifications\TrainingMentorNotification;
 use App\Services\TrainingService;
+use App\Tasks\Types\RatingUpgrade;
+use Carbon\Carbon;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Notification;
 use PHPUnit\Framework\Attributes\Test;
@@ -98,6 +104,50 @@ class TrainingsTest extends TestCase
         $training->ratings()->attach($rating->id);
 
         return $rating;
+    }
+
+    /**
+     * Attach a fresh VATSIM rating to the training.
+     */
+    private function attachVatsimRating(Training $training, VatsimRating $vatsimRating, ?string $name = null): Rating
+    {
+        $attributes = ['vatsim_rating' => $vatsimRating->value];
+        if ($name !== null) {
+            $attributes['name'] = $name;
+        }
+
+        $rating = Rating::factory()->create($attributes);
+        $training->ratings()->attach($rating->id);
+
+        return $rating;
+    }
+
+    /**
+     * The record a completed rating upgrade request leaves on a training.
+     */
+    private function completedUpgradeTask(Training $training, ?Rating $rating): Task
+    {
+        return Task::create([
+            'type' => RatingUpgrade::class,
+            'status' => TaskStatus::COMPLETED,
+            'subject_user_id' => $training->user->id,
+            'subject_training_id' => $training->id,
+            'subject_training_rating_id' => $rating?->id,
+            'creator_user_id' => User::factory()->create()->id,
+            'assignee_user_id' => User::factory()->create()->id,
+            'closed_at' => now(),
+        ]);
+    }
+
+    /**
+     * The raw completed_at pivot value for one rating part, or null when outstanding.
+     */
+    private function partCompletedAt(Training $training, Rating $rating): ?string
+    {
+        return DB::table('rating_training')
+            ->where('training_id', $training->id)
+            ->where('rating_id', $rating->id)
+            ->value('completed_at');
     }
 
     /**
@@ -846,5 +896,620 @@ class TrainingsTest extends TestCase
         // Deliberate: finishing another training earns a fresh window rather than
         // running out the one already in progress.
         $this->assertTrue($activity->fresh()->start_of_grace_period->greaterThan(now()->subMinute()));
+    }
+
+    #[Test]
+    public function completing_a_training_stamps_every_rating_part(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $facility = $this->attachFacilityRating($training);
+        $vatsim = $this->attachVatsimRating($training, VatsimRating::S2);
+
+        DivisionApi::shouldReceive('assignTierEndorsement')->once()->andReturn(false);
+
+        $this->actingAs($this->moderatorFor($training))
+            ->patch(route('training.update.details', $training), ['status' => TrainingStatus::COMPLETED->value])
+            ->assertRedirect($training->path());
+
+        $this->assertNotNull($this->partCompletedAt($training, $facility));
+        $this->assertNotNull($this->partCompletedAt($training, $vatsim));
+    }
+
+    #[Test]
+    public function a_failed_endorsement_api_call_leaves_the_rating_part_unstamped_for_a_retry(): void
+    {
+        $training = $this->openTrainingInDivision();
+        $rating = $this->attachFacilityRating($training);
+
+        $failed = new ClientResponse(new GuzzleResponse(422, [], json_encode(['message' => 'nope'])));
+        DivisionApi::shouldReceive('getName')->andReturn('VATEUD');
+        DivisionApi::shouldReceive('assignTierEndorsement')->twice()->andReturn($failed, false);
+
+        $this->actingAs($this->moderatorFor($training));
+        $service = app(TrainingService::class);
+
+        // The API rejected it, so nothing is granted and the part stays outstanding.
+        $this->assertNotNull($service->completeRating($training, $rating));
+        $this->assertNull($this->partCompletedAt($training, $rating));
+        $this->assertSame(0, Endorsement::where('user_id', $training->user->id)->count());
+
+        // Because it is still outstanding, a retry runs it again and now it lands.
+        $this->assertNull($service->completeRating($training, $rating));
+        $this->assertNotNull($this->partCompletedAt($training, $rating));
+        $this->assertSame(1, Endorsement::where('user_id', $training->user->id)->count());
+    }
+
+    #[Test]
+    public function editing_a_trainings_ratings_keeps_the_completion_stamps_of_the_parts_it_keeps(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $facility = $this->attachFacilityRating($training);
+        $vatsim = $this->attachVatsimRating($training, VatsimRating::S2);
+
+        DivisionApi::shouldReceive('assignTierEndorsement')->once()->andReturn(false);
+
+        $this->actingAs($this->moderatorFor($training))
+            ->patch(route('training.update.details', $training), ['status' => TrainingStatus::COMPLETED->value])
+            ->assertRedirect($training->path());
+
+        $this->assertNotNull($stampedAt = $this->partCompletedAt($training, $vatsim));
+
+        // Editing the request detaches and re-saves every rating, which must not silently
+        // reset the parts that survive the edit.
+        $this->patch(route('training.update.request', $training), [
+            'type' => 1,
+            'ratings' => [$facility->id, $vatsim->id],
+        ])->assertRedirect($training->path());
+
+        $this->assertSame($stampedAt, $this->partCompletedAt($training, $vatsim));
+        $this->assertNotNull($this->partCompletedAt($training, $facility));
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Completing one VATSIM rating part of a multi-rating training
+    |--------------------------------------------------------------------------
+    */
+
+    #[Test]
+    public function completing_a_vatsim_part_stamps_it_and_activates_atc_without_closing_the_training(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        // The factory seeds closed_at from its own random status, which the status
+        // override inside openTrainingInDivision() does not clear. An in-progress
+        // training has no closed_at.
+        $training->update(['closed_at' => null]);
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1);
+        $s2 = $this->attachVatsimRating($training, VatsimRating::S2);
+
+        $this->actingAs($this->moderatorFor($training));
+
+        $this->assertNull(app(TrainingService::class)->completeRatingPart($training, $s1));
+
+        $this->assertNotNull($this->partCompletedAt($training, $s1));
+        $this->assertNull($this->partCompletedAt($training, $s2));
+
+        // Still in progress: one part is outstanding.
+        $this->assertSame(TrainingStatus::ACTIVE_TRAINING, $training->fresh()->status);
+        $this->assertNull($training->fresh()->closed_at);
+
+        $this->assertTrue(
+            AtcActivity::where('user_id', $training->user->id)
+                ->where('area_id', $training->area->id)
+                ->where('atc_active', true)
+                ->exists()
+        );
+
+        // Structured rather than free text: the rating is the entry's data, not a string
+        // baked into a comment.
+        $activity = TrainingActivity::where('training_id', $training->id)->where('type', 'RATING')->sole();
+        $this->assertSame($s1->id, (int) $activity->new_data);
+        $this->assertNull($activity->comment);
+
+        Notification::assertNothingSentTo($training->user);
+    }
+
+    #[Test]
+    public function a_signed_off_part_is_logged_where_the_student_can_see_it_and_nobody_can_edit_it(): void
+    {
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $this->attachVatsimRating($training, VatsimRating::S2, 'S2 TWR');
+
+        $moderator = $this->moderatorFor($training);
+        $this->actingAs($moderator);
+        $this->assertNull(app(TrainingService::class)->completeRatingPart($training, $s1));
+
+        $activity = TrainingActivity::where('training_id', $training->id)->where('type', 'RATING')->sole();
+
+        // TrainingActivityPolicy only gates COMMENT, so the student sees a milestone of
+        // their own training. The completion date is already on show under Level.
+        $this->actingAs($training->user)
+            ->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee($s1->name . '</span> part completed', false);
+
+        // The edit button is COMMENT-only, so the sign-off is not rewritable by its author.
+        $this->actingAs($moderator)
+            ->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee($s1->name . '</span> part completed', false)
+            ->assertDontSee('updateComment(' . $activity->id . ',', false);
+    }
+
+    #[Test]
+    public function completing_the_last_outstanding_part_closes_the_training(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        // The factory seeds closed_at from its own random status, which the status
+        // override inside openTrainingInDivision() does not clear. An in-progress
+        // training has no closed_at.
+        $training->update(['closed_at' => null]);
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1);
+        $s2 = $this->attachVatsimRating($training, VatsimRating::S2);
+        $training->mentors()->attach($this->moderatorFor($training)->id, ['expire_at' => now()->addMonths(12)]);
+
+        $this->actingAs($this->moderatorFor($training));
+        $service = app(TrainingService::class);
+
+        $this->assertNull($service->completeRatingPart($training, $s1));
+        $this->assertNull($service->completeRatingPart($training->fresh(), $s2));
+
+        $closed = $training->fresh();
+        $this->assertSame(TrainingStatus::COMPLETED, $closed->status);
+        $this->assertNotNull($closed->closed_at);
+        $this->assertCount(0, $closed->mentors);
+
+        // VATSIM parts never grant a facility endorsement.
+        $this->assertSame(0, Endorsement::where('user_id', $training->user->id)->count());
+
+        Notification::assertSentToTimes($training->user, TrainingClosedNotification::class, 1);
+
+        $this->assertSame(1, TrainingActivity::where('training_id', $training->id)
+            ->where('type', 'STATUS')
+            ->where('new_data', TrainingStatus::COMPLETED->value)
+            ->count());
+    }
+
+    #[Test]
+    public function completing_a_part_is_rejected_for_anything_but_an_outstanding_vatsim_part(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1);
+        $facility = $this->attachFacilityRating($training);
+        $unattached = Rating::factory()->create(['vatsim_rating' => VatsimRating::S3->value]);
+
+        $this->actingAs($this->moderatorFor($training));
+        $service = app(TrainingService::class);
+
+        // Facility ratings are granted by full completion only.
+        $this->assertNotNull($service->completeRatingPart($training, $facility));
+        $this->assertNull($this->partCompletedAt($training, $facility));
+
+        // A rating that is not part of this training.
+        $this->assertNotNull($service->completeRatingPart($training, $unattached));
+
+        // Double completion of the same part.
+        $this->assertNull($service->completeRatingPart($training, $s1));
+        $this->assertNotNull($service->completeRatingPart($training->fresh(), $s1));
+
+        // A single-rating training keeps the status -> Completed flow.
+        $single = $this->openTrainingInDivision();
+        $only = $this->attachVatsimRating($single, VatsimRating::S1);
+        $this->assertNotNull($service->completeRatingPart($single, $only));
+        $this->assertNull($this->partCompletedAt($single, $only));
+
+        // A closed training cannot have parts completed, which would re-close it.
+        $closed = $this->openTrainingInDivision();
+        $closedS1 = $this->attachVatsimRating($closed, VatsimRating::S1);
+        $this->attachVatsimRating($closed, VatsimRating::S2);
+        $closed->update(['status' => TrainingStatus::CLOSED_BY_STAFF]);
+        $this->assertNotNull($service->completeRatingPart($closed->fresh(), $closedS1));
+        $this->assertNull($this->partCompletedAt($closed, $closedS1));
+
+        $this->assertSame(0, Endorsement::count());
+    }
+
+    #[Test]
+    public function completing_the_vatsim_part_leaves_the_facility_rating_for_full_completion(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        // The S3 + T1 ENGM APP case from the spec.
+        $training = $this->openTrainingInDivision();
+        $s3 = $this->attachVatsimRating($training, VatsimRating::S3);
+        $facility = $this->attachFacilityRating($training);
+
+        $this->actingAs($this->moderatorFor($training));
+
+        $this->assertNull(app(TrainingService::class)->completeRatingPart($training, $s3));
+        $this->assertNotNull($stampedAt = $this->partCompletedAt($training, $s3));
+        $this->assertTrue($training->fresh()->status->isInProgress());
+
+        DivisionApi::shouldReceive('assignTierEndorsement')->once()->andReturn(false);
+
+        $this->patch(route('training.update.details', $training), ['status' => TrainingStatus::COMPLETED->value])
+            ->assertRedirect($training->path());
+
+        // The facility rating is granted and stamped, and S3 is left exactly as it was.
+        $this->assertNotNull($this->partCompletedAt($training, $facility));
+        $this->assertSame($stampedAt, $this->partCompletedAt($training, $s3));
+        $this->assertSame(1, Endorsement::where('user_id', $training->user->id)->count());
+        Notification::assertSentToTimes($training->user, TrainingClosedNotification::class, 1);
+    }
+
+    #[Test]
+    public function signing_off_the_last_vatsim_part_of_a_reopened_training_leaves_the_facility_rating_alone(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $s2 = $this->attachVatsimRating($training, VatsimRating::S2);
+        $facility = $this->attachFacilityRating($training);
+
+        $this->actingAs($this->moderatorFor($training));
+
+        // Complete it once, which stamps the facility part and grants it.
+        DivisionApi::shouldReceive('assignTierEndorsement')->once()->andReturn(false);
+        $this->patch(route('training.update.details', $training), ['status' => TrainingStatus::COMPLETED->value])
+            ->assertRedirect($training->path());
+        $this->assertNotNull($facilityStampedAt = $this->partCompletedAt($training, $facility));
+        $this->assertNotNull($this->partCompletedAt($training, $s2));
+
+        // Reopen it and add a rating the student still has to earn.
+        $this->patch(route('training.update.details', $training), ['status' => TrainingStatus::ACTIVE_TRAINING->value])
+            ->assertRedirect($training->path());
+        $s3 = $this->attachVatsimRating($training, VatsimRating::S3);
+
+        // No unstamped pivot is left, but the facility rating is still only granted by
+        // completing the whole training, so this must not close it or call the API again.
+        $this->assertNull(app(TrainingService::class)->completeRatingPart($training->fresh(), $s3));
+
+        $this->assertTrue($training->fresh()->status->isInProgress());
+        $this->assertNotNull($this->partCompletedAt($training, $s3));
+        $this->assertSame($facilityStampedAt, $this->partCompletedAt($training, $facility));
+        $this->assertSame(1, Endorsement::where('user_id', $training->user->id)->count());
+        Notification::assertSentToTimes($training->user, TrainingClosedNotification::class, 1);
+    }
+
+    #[Test]
+    public function a_moderator_can_complete_a_part_from_the_training_page(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1);
+        $this->attachVatsimRating($training, VatsimRating::S2);
+
+        $this->actingAs($this->moderatorFor($training))
+            ->from($training->path())
+            ->post(route('training.action.completepart', ['training' => $training->id, 'rating' => $s1->id]))
+            ->assertRedirect($training->path())
+            ->assertSessionHas('success');
+
+        $this->assertNotNull($this->partCompletedAt($training, $s1));
+
+        $this->assertDatabaseHas('activity_logs', [
+            'log_name' => 'training',
+            'level' => 'warning',
+            'description' => 'Completed the ' . $s1->name . ' part of training ' . $training->id . ' for CID ' . $training->user_id,
+        ]);
+    }
+
+    #[Test]
+    public function a_user_without_training_update_cannot_complete_a_part(): void
+    {
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1);
+        $this->attachVatsimRating($training, VatsimRating::S2);
+
+        $this->actingAs(User::factory()->create())
+            ->post(route('training.action.completepart', ['training' => $training->id, 'rating' => $s1->id]))
+            ->assertStatus(403);
+
+        $this->assertNull($this->partCompletedAt($training, $s1));
+    }
+
+    #[Test]
+    public function completing_a_facility_part_over_http_flashes_an_error_instead_of_stamping_it(): void
+    {
+        $training = $this->openTrainingInDivision();
+        $facility = $this->attachFacilityRating($training);
+        $this->attachVatsimRating($training, VatsimRating::S2);
+
+        $this->actingAs($this->moderatorFor($training))
+            ->from($training->path())
+            ->post(route('training.action.completepart', ['training' => $training->id, 'rating' => $facility->id]))
+            ->assertRedirect($training->path())
+            ->assertSessionHasErrors();
+
+        $this->assertNull($this->partCompletedAt($training, $facility));
+    }
+
+    #[Test]
+    public function the_training_page_offers_one_control_for_the_lowest_outstanding_vatsim_part(): void
+    {
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $s2 = $this->attachVatsimRating($training, VatsimRating::S2, 'S2 TWR');
+        $facility = Rating::factory()->create(['vatsim_rating' => null, 'name' => 'T1 ENGM APP']);
+        $training->ratings()->attach($facility->id);
+
+        $this->actingAs($this->moderatorFor($training))
+            ->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee('Complete partial training')
+            // The modal completes S1, the lowest outstanding VATSIM part, and nothing else.
+            ->assertSee('Complete ' . $s1->name)
+            ->assertDontSee('Complete ' . $s2->name)
+            ->assertDontSee('Complete ' . $facility->name)
+            ->assertSee('No rating upgrade request found for ' . $s1->name);
+    }
+
+    #[Test]
+    public function a_completed_rating_upgrade_task_replaces_the_missing_request_warning(): void
+    {
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $this->attachVatsimRating($training, VatsimRating::S2, 'S2 TWR');
+
+        $this->completedUpgradeTask($training, $s1);
+
+        $this->actingAs($this->moderatorFor($training))
+            ->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee('Complete ' . $s1->name)
+            ->assertDontSee('No rating upgrade request found');
+    }
+
+    #[Test]
+    public function an_upgrade_task_without_a_chosen_rating_counts_for_the_highest_vatsim_rating(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        // RatingUpgrade falls back to getHighestVatsimRating() when staff picked no rating,
+        // so a null-rating task credits S2, not the S1 part that is completable first.
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $s2 = $this->attachVatsimRating($training, VatsimRating::S2, 'S2 TWR');
+
+        $this->completedUpgradeTask($training, null);
+
+        $moderator = $this->moderatorFor($training);
+        $this->actingAs($moderator)
+            ->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee('No rating upgrade request found for ' . $s1->name);
+
+        // With S1 done, the completable part becomes S2, which the task does credit.
+        $this->assertNull(app(TrainingService::class)->completeRatingPart($training, $s1));
+
+        $this->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee('Complete ' . $s2->name)
+            ->assertDontSee('No rating upgrade request found');
+    }
+
+    #[Test]
+    public function a_completed_part_is_shown_with_its_date_and_the_control_moves_on(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $s2 = $this->attachVatsimRating($training, VatsimRating::S2, 'S2 TWR');
+
+        $this->actingAs($this->moderatorFor($training));
+        $this->assertNull(app(TrainingService::class)->completeRatingPart($training, $s1));
+
+        $completedOn = Carbon::parse($this->partCompletedAt($training, $s1))->toEuropeanDate();
+
+        $this->get(route('training.show', $training))
+            ->assertOk()
+            // The date is asserted with its parentheses so this fails if the per-rating
+            // date span is dropped: a bare date also appears in the activity log.
+            ->assertSee('(' . $completedOn . ')')
+            ->assertSee('Complete ' . $s2->name)
+            ->assertDontSee('Complete ' . $s1->name);
+    }
+
+    #[Test]
+    public function the_control_is_disabled_when_signing_off_the_part_would_finish_the_training(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $s2 = $this->attachVatsimRating($training, VatsimRating::S2, 'S2 TWR');
+        $s3 = $this->attachVatsimRating($training, VatsimRating::S3, 'S3 APP');
+
+        $this->actingAs($this->moderatorFor($training));
+
+        // S2 and S3 outstanding, so signing off S1 leaves the training open.
+        $this->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee('Complete partial training')
+            ->assertDontSee('is the only rating left');
+
+        $this->assertNull(app(TrainingService::class)->completeRatingPart($training, $s1));
+        $this->assertNull(app(TrainingService::class)->completeRatingPart($training->fresh(), $s2));
+
+        // S3 is the only rating left, so the control is disabled and says why.
+        $this->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee('Complete partial training')
+            ->assertSee('disabled title="' . $s3->name . ' is the only rating left', false);
+
+        $this->assertTrue($training->fresh()->status->isInProgress());
+    }
+
+    #[Test]
+    public function a_user_without_training_update_sees_no_complete_control(): void
+    {
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $this->attachVatsimRating($training, VatsimRating::S2, 'S2 TWR');
+
+        // The student can view their own training but cannot complete a part of it.
+        $this->actingAs($training->user)
+            ->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee($s1->name)
+            ->assertDontSee('Complete partial training')
+            ->assertDontSee('Complete ' . $s1->name);
+    }
+
+    #[Test]
+    public function no_complete_control_is_offered_for_a_single_rating_or_closed_training(): void
+    {
+        $single = $this->openTrainingInDivision();
+        $only = $this->attachVatsimRating($single, VatsimRating::S1, 'S1 TWR');
+
+        $this->actingAs($this->moderatorFor($single))
+            ->get(route('training.show', $single))
+            ->assertOk()
+            ->assertDontSee('Complete partial training');
+
+        $closed = $this->openTrainingInDivision();
+        $this->attachVatsimRating($closed, VatsimRating::S1, 'S1 TWR');
+        $this->attachVatsimRating($closed, VatsimRating::S2, 'S2 TWR');
+        $closed->update(['status' => TrainingStatus::CLOSED_BY_STAFF]);
+
+        $this->actingAs($this->moderatorFor($closed))
+            ->get(route('training.show', $closed))
+            ->assertOk()
+            ->assertDontSee('Complete partial training');
+    }
+
+    /**
+     * Attach a facility rating with a known name, for view assertions.
+     */
+    private function attachNamedFacilityRating(Training $training, string $name): Rating
+    {
+        $rating = Rating::factory()->create(['vatsim_rating' => null, 'name' => $name]);
+        $training->ratings()->attach($rating->id);
+
+        return $rating;
+    }
+
+    #[Test]
+    public function the_partial_control_names_every_rating_that_stays_outstanding(): void
+    {
+        $training = $this->openTrainingInDivision();
+        $s3 = $this->attachVatsimRating($training, VatsimRating::S3, 'S3 APP');
+        $this->attachNamedFacilityRating($training, 'T1 ENGM APP');
+        $this->attachNamedFacilityRating($training, 'T2 EKCH APP');
+
+        $this->actingAs($this->moderatorFor($training))
+            ->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee('Complete partial training')
+            ->assertDontSee('Mark training as completed')
+            ->assertSee('Sign off the')
+            ->assertSee('The training stays open for T1 ENGM APP, T2 EKCH APP.')
+            ->assertSee('Complete ' . $s3->name);
+    }
+
+    #[Test]
+    public function a_facility_rating_stamped_by_an_earlier_completion_still_counts_as_outstanding(): void
+    {
+        $training = $this->openTrainingInDivision();
+        $s3 = $this->attachVatsimRating($training, VatsimRating::S3, 'S3 APP');
+        $facility = $this->attachNamedFacilityRating($training, 'T1 ENGM APP');
+
+        // Stands in for a completion that was later reopened: the pivot keeps its stamp.
+        $training->ratings()->updateExistingPivot($facility->id, ['completed_at' => now()]);
+
+        // So the control stays partial rather than offering to finish the training.
+        $this->actingAs($this->moderatorFor($training))
+            ->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee('Complete partial training')
+            ->assertSee('The training stays open for T1 ENGM APP.')
+            ->assertDontSee('This is the last outstanding part');
+    }
+
+    #[Test]
+    public function the_status_dropdown_still_completes_a_training_with_an_outstanding_part(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $s2 = $this->attachVatsimRating($training, VatsimRating::S2, 'S2 TWR');
+        $t1 = $this->attachNamedFacilityRating($training, 'T1 ENGM APP');
+
+        $this->actingAs($this->moderatorFor($training));
+        $this->assertNull(app(TrainingService::class)->completeRatingPart($training, $s1));
+
+        DivisionApi::shouldReceive('assignTierEndorsement')->once()->andReturn(false);
+
+        // Staff side-step the remaining partial upgrade and close the whole training from
+        // the status dropdown. That has to keep working.
+        $this->patch(route('training.update.details', $training), ['status' => TrainingStatus::COMPLETED->value])
+            ->assertRedirect($training->path());
+
+        $closed = $training->fresh();
+        $this->assertSame(TrainingStatus::COMPLETED, $closed->status);
+
+        // The outstanding part and the endorsement rating are both completed by that path.
+        $this->assertNotNull($this->partCompletedAt($training, $s2));
+        $this->assertNotNull($this->partCompletedAt($training, $t1));
+        $this->assertSame(1, Endorsement::where('user_id', $training->user->id)->where('revoked', false)->count());
+
+        Notification::assertSentToTimes($training->user, TrainingClosedNotification::class, 1);
+    }
+
+    #[Test]
+    public function the_auto_close_status_change_is_shown_after_the_part_completed_comment(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        // Freeze time so every activity row shares one created_at, which is what forces
+        // this test to exercise the id tie-break rather than distinct timestamps.
+        $this->freezeTime();
+
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $s2 = $this->attachVatsimRating($training, VatsimRating::S2, 'S2 TWR');
+
+        $this->actingAs($this->moderatorFor($training));
+        $service = app(TrainingService::class);
+        $this->assertNull($service->completeRatingPart($training, $s1));
+        $this->assertNull($service->completeRatingPart($training->fresh(), $s2));
+
+        // Newest first: the status change, then the sign-off that triggered it, then the
+        // earlier part completion. Matched raw, because the rating name is rendered in a
+        // badge rather than inline.
+        $this->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSeeInOrder([
+                'Status changed from',
+                $s2->name . '</span> part completed',
+                $s1->name . '</span> part completed',
+            ], false);
     }
 }


### PR DESCRIPTION
A multi-rating training such as S1 + S2 is examined one rating at a
time, but the application could only close the whole thing at once.
Staff left the training open with no record of the part that was done,
and sync:roster then removed the rating upgrade that had just been
requested, because Core already had the student at S1 while User.rating
was still waiting on the nightly member data refresh. 

Fixes #1431.

An optional completion time now records which part of a training is
done. Staff sign off the lowest outstanding VATSIM part from a control
in the training details card, which stamps that part, marks the student
active for the area, and logs it on the timeline. 

Facility and tier ratings are never signed off on their own, since their
endorsement is granted through the Division API when the training is
completed. Every route ends on the existing closeTraining() path, so a
training is closed and the student emailed exactly once however it got
there.

sync:roster now leaves alone anyone whose rating upgrade was requested
within the last 30 days, taking the completed RatingUpgrade task as the
record of that request. The student still does not appear on Control
Center roster views until VATSIM actually grants the rating. That is
deliberate: they cannot control the position until they hold it.

## Summary by Sourcery

Enable staff to sign off multi-rating VATSIM training progressively while preserving rating-upgrade requests during roster synchronization.

New Features:
- Allow staff to sign off individual VATSIM rating parts of multi-rating trainings while keeping the training open for remaining ratings.
- Record per-rating completion dates and timeline activity for rating sign-offs, with automatic full completion when the final part is completed.

Bug Fixes:
- Prevent roster synchronization from removing members whose completed rating upgrade requests are still awaiting local rating data propagation.
- Preserve per-rating completion records when training ratings are edited and ensure failed endorsement operations remain retryable.

Enhancements:
- Keep facility and tier ratings on the whole-training completion path while activating students and maintaining consistent closure and notification behavior.
- Add training-page controls, activity/report rendering, upgrade-request warnings, and ordering for rating part completion records.

Documentation:
- Document partial rating sign-off workflows, rating completion dates, upgrade-task warnings, and roster-sync protection behavior.

Tests:
- Add coverage for partial and whole-training completion, authorization, activity visibility, endorsement retries, rating edits, UI controls, and roster synchronization grace periods.

Chores:
- Add nullable per-rating completion timestamps to the training-rating relationship.