### PR TITLE
feat(training): mark a whole training as completed through button dropdown

### DIFF
--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -359,30 +359,35 @@ class TrainingController extends Controller
         // the sign-off always agree on what is left.
         $outstandingRatings = $training->outstandingRatings();
 
-        // Signing off a part is offered on multi-rating trainings in progress only: a
+        // The completion menu is offered on multi-rating trainings in progress only: a
         // single-rating training keeps the status -> Completed flow.
-        $multiRatingInProgress = $training->status->isInProgress() && $training->ratings->count() > 1;
+        $showCompletionControl = $training->status->isInProgress() && $training->ratings->count() > 1;
 
         // The next part staff can sign off: the lowest outstanding VATSIM rating, because a
         // student earns S1 before S2. Facility and tier ratings are never signed off on
         // their own, they are granted when the training is completed as a whole.
-        $completablePart = $multiRatingInProgress
+        $completablePart = $showCompletionControl
             ? $outstandingRatings
                 ->whereNotNull('vatsim_rating')
                 ->sortBy(fn (Rating $rating) => $rating->vatsim_rating->value)
                 ->first()
             : null;
 
-        // Only a part that can actually be signed off gets a control. A training whose
-        // outstanding ratings are all facility or tier ones is finished through its status.
-        $showCompletionControl = $completablePart !== null;
-
-        // What stays outstanding once that part is signed off, so the modal can name it.
+        // What stays outstanding once that part is signed off, so the partial modal can
+        // name it.
         $otherOutstandingRatings = $outstandingRatings->filter(fn (Rating $rating) => $rating->id !== $completablePart?->id);
 
-        // With nothing else outstanding, signing off the part would finish the whole
-        // training, which is not a partial completion. The control is shown but disabled.
-        $canCompletePartially = $otherOutstandingRatings->isNotEmpty();
+        // Signing off a part is only a partial completion while something else stays
+        // outstanding. With nothing else left the part is the training, so the menu drops
+        // the entry and leaves only the whole-training one, which does the same thing and
+        // says so. Marking the whole training as completed is always offered: it is how
+        // staff finish a training whose remaining ratings carry endorsements, and the
+        // escape hatch when a part is not worth signing off on its own.
+        $canCompletePartially = $completablePart !== null && $otherOutstandingRatings->isNotEmpty();
+
+        // The endorsements the whole-training entry would grant, which is every outstanding
+        // rating that is not a VATSIM one.
+        $outstandingEndorsementRatings = $outstandingRatings->whereNull('vatsim_rating');
 
         // Whether the rating upgrade for that part was already requested, so the modal can
         // warn when it was not. Mirrors how RatingUpgrade picks its target rating.
@@ -398,7 +403,7 @@ class TrainingController extends Controller
             return $training->getHighestVatsimRating()?->id === $completablePart->id;
         });
 
-        return view('training.show', compact('training', 'reportsAndExams', 'trainingMentors', 'types', 'experiences', 'activities', 'trainingInterests', 'activeTrainingInterest', 'relatedTasks', 'requestTypes', 'requestPopularAssignees', 'showCompletionControl', 'completablePart', 'otherOutstandingRatings', 'canCompletePartially', 'upgradeRequestedForPart'));
+        return view('training.show', compact('training', 'reportsAndExams', 'trainingMentors', 'types', 'experiences', 'activities', 'trainingInterests', 'activeTrainingInterest', 'relatedTasks', 'requestTypes', 'requestPopularAssignees', 'showCompletionControl', 'completablePart', 'outstandingRatings', 'otherOutstandingRatings', 'outstandingEndorsementRatings', 'canCompletePartially', 'upgradeRequestedForPart'));
     }
 
     /**
@@ -686,6 +691,26 @@ class TrainingController extends Controller
         ActivityLogService::warning(LogName::Training, 'Completed the ' . $rating->name . ' part of training ' . $training->id . ' for CID ' . $training->user_id);
 
         return back()->withSuccess('Completed the ' . $rating->name . ' part.');
+    }
+
+    /**
+     * Complete a whole training, for the outstanding ratings that cannot be signed off
+     * part by part.
+     *
+     * @throws AuthorizationException
+     */
+    public function complete(Training $training): RedirectResponse
+    {
+        $this->authorize('update', $training);
+
+        $error = app(TrainingService::class)->completeWholeTraining($training);
+        if ($error !== null) {
+            return back()->withErrors($error);
+        }
+
+        ActivityLogService::warning(LogName::Training, 'Completed training ' . $training->id . ' for CID ' . $training->user_id);
+
+        return back()->withSuccess('Training successfully closed. E-mail confirmation sent to the student.');
     }
 
     /**

--- a/app/Services/TrainingService.php
+++ b/app/Services/TrainingService.php
@@ -125,13 +125,13 @@ class TrainingService
     /**
      * Complete a whole training and close it.
      *
-     * Reached from completeRatingPart() once the last outstanding part is stamped.
-     * closeTraining() grants every rating its endorsement, so a training can end with one
-     * endorsement or several.
+     * This is what finishes a training whose outstanding ratings cannot be signed off part
+     * by part, which is every facility and tier rating. closeTraining() grants each of them
+     * its endorsement, so a training can end with one endorsement or several.
      *
      * Returns an error string for the caller to flash, or null on success.
      */
-    private function completeWholeTraining(Training $training): ?string
+    public function completeWholeTraining(Training $training): ?string
     {
         if (! $training->status->isInProgress()) {
             return 'Only a training in progress can be completed.';

--- a/docs/concepts/training.md
+++ b/docs/concepts/training.md
@@ -58,9 +58,10 @@ See [Roles and Permissions][permissions].
 A training can cover more than one rating, such as S1 + S2.
 Because a student is examined and awarded one rating at a time, you can sign off each rating as the student earns it and leave the training open for the rest.
 
-The **Complete partial training** button appears on the training page when the training is *In Progress* and covers more than one rating.
+The **Complete training** menu appears on the training page when the training is *In Progress* and covers more than one rating.
+It holds **Complete partial training** whenever signing off a rating would still leave something outstanding.
 
-1. Open the training and select **Complete partial training**.
+1. Open the training and select **Complete training**, then **Complete partial training**.
 2. Check the rating shown. Control Center offers the lowest rating still outstanding, because a student earns S1 before S2.
 3. Select **Complete S1**, or whichever rating is named.
 
@@ -70,24 +71,25 @@ Control Center then:
 - Marks the student active for the training's area and starts a fresh [activity grace period][activity]. This follows the same rules as closing a training, so visitors and members outside your division are not affected.
 - Adds an entry to the training timeline naming the rating and you as the author. Unlike a comment, the student sees this one on their own training, and it cannot be edited afterwards.
 
-The training stays *In Progress* for the remaining ratings, and the button offers the next one the next time you open the page.
+The training stays *In Progress* for the remaining ratings, and the menu offers the next one the next time you open the page.
 
 !!! note "Older trainings show no per-rating dates"
     Trainings closed before per-rating sign-off existed show nothing under **Level** but the ratings themselves.
     Only the training's own closing date was recorded then.
 
-### Finish a training
+### Complete a whole training
 
-The control only ever signs off a part while something else stays outstanding.
-When one rating is left, signing it off would finish the whole training, so the control is shown with the part it would sign off but is disabled.
-Close the training by setting its status to *Completed*, which grants any endorsements its ratings carry and emails the student a confirmation.
+**Mark training as completed** is the menu's other entry, and it is always offered.
+Selecting it closes the training, completes every rating still outstanding, grants the endorsements they carry, and emails the student a confirmation.
 
-Facility and tier ratings are never signed off part by part, because their endorsement is granted through the [Division API][vateud] when the training is completed.
-A training with nothing left that can be signed off on its own therefore offers no button.
-Close it by setting the training status to *Completed*.
+Use it when the student has finished everything the training covers, and there is no reason to sign the remaining ratings off one at a time.
+Facility and tier ratings are never signed off part by part, because their endorsement is granted through the [Division API][vateud] when the training is completed as a whole.
+A training whose outstanding ratings are all facility or tier ones therefore offers this entry alone.
 
-A training that covers a single rating has no completion button either.
-Close it the same way, and its rating still gets a completion date under **Level**.
+When one rating is left, signing it off would finish the training anyway, so **Complete partial training** drops out of the menu and this entry names the rating it completes.
+
+A training that covers a single rating has no completion menu.
+Close it by setting the training status to *Completed*, and its rating still gets a completion date under **Level**.
 
 However you get there, a training is closed and the student emailed exactly once.
 
@@ -99,6 +101,7 @@ Every closing status emails the student, but only *Completed* grants the endorse
 ### Rating upgrades and the roster
 
 When you sign off a rating, Control Center warns you if it finds no completed [rating upgrade task][tasks] for it.
+**Mark training as completed** carries a matching warning, naming the VATSIM ratings it signs off with the training rather than part by part.
 The warning is advisory and does not block you:
 
 - Completing the upgrade task first is the normal order, since that is what adds the student to the Division roster.

--- a/resources/views/training/parts/completepartmodal.blade.php
+++ b/resources/views/training/parts/completepartmodal.blade.php
@@ -1,8 +1,8 @@
-<div class="modal fade" id="completeTraining" tabindex="-1" aria-labelledby="completeTrainingLabel" aria-hidden="true">
+<div class="modal fade" id="completePartialTraining" tabindex="-1" aria-labelledby="completePartialTrainingLabel" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h1 class="modal-title fs-5" id="completeTrainingLabel">Complete partial training</h1>
+                <h1 class="modal-title fs-5" id="completePartialTrainingLabel">Complete partial training</h1>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
@@ -15,11 +15,7 @@
                         <i class="fas fa-check"></i> Sign off the <b>{{ $completablePart->name }}</b> part of this training
                     </div>
 
-                    @if($otherOutstandingRatings->isNotEmpty())
-                        <p>The training stays open for {{ $otherOutstandingRatings->pluck('name')->implode(', ') }}.</p>
-                    @else
-                        <p>This is the last outstanding part, so the training is completed and closed.</p>
-                    @endif
+                    <p>The training stays open for {{ $otherOutstandingRatings->pluck('name')->implode(', ') }}.</p>
                     <p>The student is marked active for {{ $training->area->name }}.</p>
 
                     @if(! $upgradeRequestedForPart)

--- a/resources/views/training/parts/completetrainingmodal.blade.php
+++ b/resources/views/training/parts/completetrainingmodal.blade.php
@@ -1,0 +1,44 @@
+<div class="modal fade" id="completeWholeTraining" tabindex="-1" aria-labelledby="completeWholeTrainingLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title fs-5" id="completeWholeTrainingLabel">Mark training as completed</h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+
+                <form action="{{ route('training.action.complete', $training) }}" method="POST">
+
+                    @csrf
+
+                    <div class="alert alert-primary">
+                        @if($outstandingRatings->isEmpty())
+                            <i class="fas fa-check"></i> Complete this training and close it
+                        @elseif($outstandingRatings->count() === 1)
+                            <i class="fas fa-check"></i> <b>Complete the final {{ $outstandingRatings->first()->name }} rating and close this training</b>
+                        @else
+                            <i class="fas fa-check"></i> <b>Complete the outstanding {{ $outstandingRatings->pluck('name')->implode(', ') }} ratings and close this training</b>
+                        @endif
+                    </div>
+
+                    @if($outstandingEndorsementRatings->isNotEmpty())
+                        <p>This grants the {{ $outstandingEndorsementRatings->pluck('name')->implode(', ') }} {{ Str::plural('endorsement', $outstandingEndorsementRatings->count()) }}.</p>
+                    @endif
+                    <p>The student is marked active for {{ $training->area->name }} and emailed a confirmation.</p>
+
+                    @php($outstandingVatsimRatings = $outstandingRatings->whereNotNull('vatsim_rating'))
+
+                    @if($outstandingVatsimRatings->isNotEmpty())
+                        @php($vatsimCount = $outstandingVatsimRatings->count())
+                        <div class="alert alert-warning mb-0">{{ $outstandingVatsimRatings->pluck('name')->implode(', ') }} {{ $vatsimCount === 1 ? 'is' : 'are' }} signed off with the training rather than part by part. Check that the rating {{ Str::plural('upgrade', $vatsimCount) }} {{ $vatsimCount === 1 ? 'has' : 'have' }} been requested.</div>
+                    @endif
+
+                    <div class="modal-footer border-top-0">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-success">Mark as completed</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/training/show.blade.php
+++ b/resources/views/training/show.blade.php
@@ -150,13 +150,21 @@
 
                     @if($showCompletionControl)
                         @can('update', $training)
-                            <button type="button" class="btn btn-outline-success btn-icon" data-bs-toggle="modal" data-bs-target="#completeTraining"
-                                @unless($canCompletePartially)
-                                    disabled title="{{ $completablePart->name }} is the only rating left, so signing it off would finish the whole training. Set the training status to Completed instead."
-                                @endunless
-                            >
-                                <i class="fas fa-check"></i>&nbsp;Complete partial training
-                            </button>
+                            <div class="btn-group" role="group">
+                                <button class="btn btn-outline-success btn-icon dropdown-toggle" type="button" id="completionMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <i class="fas fa-check me-1"></i>Complete training
+                                </button>
+                                <div class="dropdown-menu" aria-labelledby="completionMenuButton">
+                                    @if($canCompletePartially)
+                                        <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#completePartialTraining">
+                                            <i class="fas fa-list-check me-1"></i>Complete partial training
+                                        </button>
+                                    @endif
+                                    <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#completeWholeTraining">
+                                        <i class="fas fa-check me-1"></i>Mark training as completed
+                                    </button>
+                                </div>
+                            </div>
                         @endcan
                     @endif
                 </div>
@@ -624,7 +632,10 @@
 
 @if($showCompletionControl)
     @can('update', $training)
-        @include('training.parts.completepartmodal', ['training' => $training, 'completablePart' => $completablePart, 'otherOutstandingRatings' => $otherOutstandingRatings, 'upgradeRequestedForPart' => $upgradeRequestedForPart])
+        @if($canCompletePartially)
+            @include('training.parts.completepartmodal', ['training' => $training, 'completablePart' => $completablePart, 'otherOutstandingRatings' => $otherOutstandingRatings, 'upgradeRequestedForPart' => $upgradeRequestedForPart])
+        @endif
+        @include('training.parts.completetrainingmodal', ['training' => $training, 'outstandingRatings' => $outstandingRatings, 'outstandingEndorsementRatings' => $outstandingEndorsementRatings])
     @endcan
 @endif
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -122,6 +122,7 @@ Route::middleware(['auth', 'activity', 'suspended'])->group(function () {
         Route::get('/training/{training}/action/close', 'close')->name('training.action.close');
         Route::get('/training/{training}/action/pretraining', 'togglePreTrainingCompleted')->name('training.action.pretraining');
         Route::post('/training/{training}/rating/{rating}/complete', 'completePart')->name('training.action.completepart');
+        Route::post('/training/{training}/complete', 'complete')->name('training.action.complete');
         Route::patch('/training/{training}', 'updateDetails')->name('training.update.details');
         Route::get('/training/{training}', 'show')->name('training.show');
 

--- a/tests/Feature/TrainingsTest.php
+++ b/tests/Feature/TrainingsTest.php
@@ -1305,7 +1305,7 @@ class TrainingsTest extends TestCase
 
         $this->get(route('training.show', $training))
             ->assertOk()
-            ->assertSee('Complete ' . $s2->name)
+            ->assertSee('Complete the final ' . $s2->name . ' rating')
             ->assertDontSee('No rating upgrade request found');
     }
 
@@ -1329,12 +1329,14 @@ class TrainingsTest extends TestCase
             // The date is asserted with its parentheses so this fails if the per-rating
             // date span is dropped: a bare date also appears in the activity log.
             ->assertSee('(' . $completedOn . ')')
-            ->assertSee('Complete ' . $s2->name)
+            // S2 is all that is left, so the menu offers it as the final rating rather
+            // than as a part to sign off.
+            ->assertSee('Complete the final ' . $s2->name . ' rating')
             ->assertDontSee('Complete ' . $s1->name);
     }
 
     #[Test]
-    public function the_control_is_disabled_when_signing_off_the_part_would_finish_the_training(): void
+    public function the_control_offers_to_finish_the_training_when_one_rating_is_left(): void
     {
         Notification::fake();
         Setting::set('atcActivityBasedOnTotalHours', false);
@@ -1355,11 +1357,12 @@ class TrainingsTest extends TestCase
         $this->assertNull(app(TrainingService::class)->completeRatingPart($training, $s1));
         $this->assertNull(app(TrainingService::class)->completeRatingPart($training->fresh(), $s2));
 
-        // S3 is the only rating left, so the control is disabled and says why.
+        // S3 is the only rating left, so the control switches to finishing the training.
         $this->get(route('training.show', $training))
             ->assertOk()
-            ->assertSee('Complete partial training')
-            ->assertSee('disabled title="' . $s3->name . ' is the only rating left', false);
+            ->assertSee('Mark training as completed')
+            ->assertDontSee('Complete partial training')
+            ->assertDontSee('is the only rating left');
 
         $this->assertTrue($training->fresh()->status->isInProgress());
     }
@@ -1425,10 +1428,33 @@ class TrainingsTest extends TestCase
             ->get(route('training.show', $training))
             ->assertOk()
             ->assertSee('Complete partial training')
-            ->assertDontSee('Mark training as completed')
+            // Both menu entries apply here: sign off S3 alone, or finish the training and
+            // grant both endorsements in one go.
+            ->assertSee('Mark training as completed')
             ->assertSee('Sign off the')
             ->assertSee('The training stays open for T1 ENGM APP, T2 EKCH APP.')
             ->assertSee('Complete ' . $s3->name);
+    }
+
+    #[Test]
+    public function the_completion_menu_offers_both_ways_of_finishing_a_training(): void
+    {
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $s2 = $this->attachVatsimRating($training, VatsimRating::S2, 'S2 TWR');
+
+        // Signing off S1 leaves S2 outstanding, so the partial entry is a real choice
+        // alongside finishing the whole training in one go.
+        $this->actingAs($this->moderatorFor($training))
+            ->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee('Complete partial training')
+            ->assertSee('Mark training as completed')
+            // Each entry opens its own modal, posting to its own route.
+            ->assertSee(route('training.action.completepart', ['training' => $training->id, 'rating' => $s1->id]), false)
+            ->assertSee(route('training.action.complete', $training), false)
+            // The whole-training modal warns that both parts are signed off at once.
+            ->assertSee($s1->name . ', ' . $s2->name . ' are signed off with the training');
     }
 
     #[Test]
@@ -1448,6 +1474,172 @@ class TrainingsTest extends TestCase
             ->assertSee('Complete partial training')
             ->assertSee('The training stays open for T1 ENGM APP.')
             ->assertDontSee('This is the last outstanding part');
+    }
+
+    #[Test]
+    public function the_control_says_completed_when_the_last_vatsim_part_finishes_the_training(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $s2 = $this->attachVatsimRating($training, VatsimRating::S2, 'S2 TWR');
+
+        $this->actingAs($this->moderatorFor($training));
+        $this->assertNull(app(TrainingService::class)->completeRatingPart($training, $s1));
+
+        $this->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee('Mark training as completed')
+            ->assertDontSee('Complete partial training')
+            ->assertSee('Complete the final ' . $s2->name . ' rating and close this training')
+            // Singular form of the sign-off warning, which the plural render would spell
+            // "S2 TWR are signed off".
+            ->assertSee($s2->name . ' is signed off with the training');
+    }
+
+    #[Test]
+    public function the_control_completes_the_whole_training_when_only_endorsement_ratings_remain(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $s3 = $this->attachVatsimRating($training, VatsimRating::S3, 'S3 APP');
+        $this->attachNamedFacilityRating($training, 'T1 ENGM APP');
+        $this->attachNamedFacilityRating($training, 'T2 EKCH APP');
+
+        $this->actingAs($this->moderatorFor($training));
+        $this->assertNull(app(TrainingService::class)->completeRatingPart($training, $s3));
+
+        $this->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee('Mark training as completed')
+            ->assertDontSee('Complete partial training')
+            // Every outstanding endorsement is named, and the copy is plural for two of them.
+            ->assertSee('T1 ENGM APP, T2 EKCH APP')
+            ->assertSee('endorsements')
+            ->assertSee(route('training.action.complete', $training), false);
+    }
+
+    #[Test]
+    public function the_endorsement_copy_is_singular_for_a_single_outstanding_endorsement(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $s3 = $this->attachVatsimRating($training, VatsimRating::S3, 'S3 APP');
+        $this->attachNamedFacilityRating($training, 'T1 ENGM APP');
+
+        $this->actingAs($this->moderatorFor($training));
+        $this->assertNull(app(TrainingService::class)->completeRatingPart($training, $s3));
+
+        $this->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee('Mark training as completed')
+            // Pins the singular form directly: a plural render would read "endorsements."
+            // here, which does not contain the substring "endorsement." (note the period
+            // right after the singular word), so this line alone rules out the plural.
+            ->assertSee('This grants the T1 ENGM APP endorsement.');
+    }
+
+    #[Test]
+    public function completing_a_training_from_the_header_grants_every_outstanding_endorsement_and_closes_it(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        $training = $this->openTrainingInDivision();
+        $s3 = $this->attachVatsimRating($training, VatsimRating::S3, 'S3 APP');
+        $t1 = $this->attachNamedFacilityRating($training, 'T1 ENGM APP');
+        $t2 = $this->attachNamedFacilityRating($training, 'T2 EKCH APP');
+
+        $this->actingAs($this->moderatorFor($training));
+        $this->assertNull(app(TrainingService::class)->completeRatingPart($training, $s3));
+
+        // One API call per outstanding endorsement rating.
+        DivisionApi::shouldReceive('assignTierEndorsement')->twice()->andReturn(false);
+
+        $this->from($training->path())
+            ->post(route('training.action.complete', $training))
+            ->assertRedirect($training->path())
+            ->assertSessionHas('success');
+
+        $closed = $training->fresh();
+        $this->assertSame(TrainingStatus::COMPLETED, $closed->status);
+        $this->assertNotNull($closed->closed_at);
+
+        // Both endorsements granted, and every rating is stamped.
+        $this->assertSame(2, Endorsement::where('user_id', $training->user->id)->where('revoked', false)->count());
+        $this->assertNotNull($this->partCompletedAt($training, $t1));
+        $this->assertNotNull($this->partCompletedAt($training, $t2));
+        $this->assertNotNull($this->partCompletedAt($training, $s3));
+
+        Notification::assertSentToTimes($training->user, TrainingClosedNotification::class, 1);
+    }
+
+    #[Test]
+    public function completing_a_whole_training_from_the_menu_stamps_the_outstanding_vatsim_parts(): void
+    {
+        Notification::fake();
+        Setting::set('atcActivityBasedOnTotalHours', false);
+
+        // The menu now offers this while parts are still outstanding, so the whole-training
+        // route has to sweep them up rather than leave them unstamped.
+        $training = $this->openTrainingInDivision();
+        $s1 = $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $s2 = $this->attachVatsimRating($training, VatsimRating::S2, 'S2 TWR');
+
+        $this->actingAs($this->moderatorFor($training))
+            ->from($training->path())
+            ->post(route('training.action.complete', $training))
+            ->assertRedirect($training->path())
+            ->assertSessionHas('success');
+
+        $closed = $training->fresh();
+        $this->assertSame(TrainingStatus::COMPLETED, $closed->status);
+        $this->assertNotNull($closed->closed_at);
+
+        $this->assertNotNull($this->partCompletedAt($training, $s1));
+        $this->assertNotNull($this->partCompletedAt($training, $s2));
+
+        Notification::assertSentToTimes($training->user, TrainingClosedNotification::class, 1);
+    }
+
+    #[Test]
+    public function a_user_without_training_update_cannot_complete_a_whole_training(): void
+    {
+        $training = $this->openTrainingInDivision();
+        $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $this->attachNamedFacilityRating($training, 'T1 ENGM APP');
+
+        $this->actingAs(User::factory()->create())
+            ->post(route('training.action.complete', $training))
+            ->assertStatus(403);
+
+        $this->assertTrue($training->fresh()->status->isInProgress());
+    }
+
+    #[Test]
+    public function completing_an_already_closed_training_from_the_header_is_rejected(): void
+    {
+        Notification::fake();
+
+        $training = $this->openTrainingInDivision();
+        $this->attachVatsimRating($training, VatsimRating::S1, 'S1 TWR');
+        $this->attachNamedFacilityRating($training, 'T1 ENGM APP');
+        $training->update(['status' => TrainingStatus::CLOSED_BY_STAFF]);
+
+        $this->actingAs($this->moderatorFor($training))
+            ->from($training->path())
+            ->post(route('training.action.complete', $training))
+            ->assertRedirect($training->path())
+            ->assertSessionHasErrors();
+
+        $this->assertSame(TrainingStatus::CLOSED_BY_STAFF, $training->fresh()->status);
+        Notification::assertNothingSentTo($training->user);
     }
 
     #[Test]


### PR DESCRIPTION
Signing off one rating part at a time cannot finish every training. A
training whose outstanding ratings are all facility or tier ones has no
part that can be signed off on its own, since those endorsements are
granted through the Division API when the training is completed. 

Such a training could only be closed by setting its status, which reads
as an administrative edit rather than the completion it "is". Sort of.

The completion control is now offered on any multi-rating training in
progress, and says what pressing it will do. While a signable part is
left and other ratings stay outstanding, it signs off that part. When
pressing it would finish the training it reads Mark training as
completed instead: signing off the last outstanding part closes the
training on the way through, and a training with nothing signable on its
own posts to a new complete route that completes it as a whole.

Both paths end on the existing closeTraining() call, which grants the
endorsements the remaining ratings carry, so a training is closed and
the student emailed exactly once however it got there.

## Summary by Sourcery

Provide a unified completion workflow for multi-rating trainings that supports both partial sign-offs and completing the entire training.

New Features:
- Add a completion menu that lets staff either sign off the next rating part or mark an entire multi-rating training as completed.
- Add whole-training completion that stamps outstanding ratings, grants applicable endorsements, closes the training, and sends the existing confirmation email.

Enhancements:
- Allow trainings with only facility or tier ratings outstanding to be completed through the training page instead of administrative status editing.
- Clarify completion prompts and warnings for final ratings, outstanding endorsements, and VATSIM rating upgrades.

Documentation:
- Update training documentation to describe the completion menu and whole-training completion behavior.

Tests:
- Add coverage for partial and whole-training completion choices, endorsement handling, authorization, invalid closed-training attempts, and notification behavior.