### PR TITLE
fix(api): document the real /positions response schema

### DIFF
--- a/app/Http/Controllers/API/PositionController.php
+++ b/app/Http/Controllers/API/PositionController.php
@@ -4,12 +4,21 @@ namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
 use App\Models\Position;
+use Dedoc\Scramble\Attributes\Response;
 
 class PositionController extends Controller
 {
     /**
-     * Display all positions
+     * List positions.
+     *
+     * Returns every position, reduced to the fields a booking client needs to render
+     * and match a callsign.
      */
+    #[Response(
+        status: 200,
+        description: 'All positions, wrapped in a `data` array. The query selects three columns only, so the response carries no `id`, `fir`, `rating`, `area_id` or `required_facility_rating_id`.',
+        type: 'array{data: array<int, array{callsign: string, frequency: string|null, name: string}>}',
+    )]
     public function index()
     {
         $positions = Position::select(['callsign', 'name', 'frequency'])->get();

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Services\PermissionMatrix;
+use App\Support\OpenApi\RemovesUnreferencedSchemas;
 use App\Support\OpenApi\SortsDocumentAlphabetically;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\ServerVariable;
@@ -43,7 +44,10 @@ class AppServiceProvider extends ServiceProvider
         // Sort the generated document alphabetically so the exported `docs/api-v1.json` is
         // byte-identical regardless of the database engine it is generated against. See
         // SortsDocumentAlphabetically for the full rationale.
-        Scramble::configure()->withDocumentTransformers(SortsDocumentAlphabetically::class);
-        Scramble::configure('internal')->withDocumentTransformers(SortsDocumentAlphabetically::class);
+        // Prune first so the sort only ever runs over schemas that survive, then sort, keeping the
+        // exported document byte-identical across engines. See RemovesUnreferencedSchemas for why
+        // orphaned schemas appear at all.
+        Scramble::configure()->withDocumentTransformers([RemovesUnreferencedSchemas::class, SortsDocumentAlphabetically::class]);
+        Scramble::configure('internal')->withDocumentTransformers([RemovesUnreferencedSchemas::class, SortsDocumentAlphabetically::class]);
     }
 }

--- a/app/Support/OpenApi/RemovesUnreferencedSchemas.php
+++ b/app/Support/OpenApi/RemovesUnreferencedSchemas.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Support\OpenApi;
+
+use Dedoc\Scramble\Contracts\DocumentTransformer;
+use Dedoc\Scramble\OpenApiContext;
+use Dedoc\Scramble\Support\Generator\OpenApi;
+
+/**
+ * Drops component schemas that nothing in the document references.
+ *
+ * Scramble registers a model schema whenever it analyses a query on that model, even when an
+ * explicit `#[Response]` attribute overrides the inferred response type. `PositionController::index`
+ * runs `Position::select([...])->get()` but documents a narrower three-column shape, so the
+ * `Position` schema (and the `VatsimRating` enum it references) would otherwise linger in
+ * `components.schemas` unreferenced. The docs renderer lists component schemas
+ * (`scramble.renderers.elements.hideSchemas` is `false`), so an orphan advertises an object shape
+ * no endpoint actually returns.
+ *
+ * Reachability is computed over the serialised document, which is the exact set of bytes exported
+ * to `docs/api-v1.json`, and closed transitively so a schema referenced only by another orphan is
+ * dropped too while one referenced from anywhere outside `components.schemas` is kept.
+ */
+class RemovesUnreferencedSchemas implements DocumentTransformer
+{
+    public function handle(OpenApi $document, OpenApiContext $context): void
+    {
+        $serialized = $document->toArray();
+        $schemas = $serialized['components']['schemas'] ?? [];
+
+        if ($schemas === []) {
+            return;
+        }
+
+        // Everything except the schema definitions themselves: paths, component responses,
+        // security schemes. A reference from here is what makes a schema genuinely used.
+        $documentWithoutSchemaDefinitions = $serialized;
+        unset($documentWithoutSchemaDefinitions['components']['schemas']);
+
+        $reachable = $this->referencedSchemaNames($documentWithoutSchemaDefinitions);
+
+        // Close over schema-to-schema references until the set stops growing, so a chain such as
+        // Booking -> Position -> VatsimRating is kept or dropped as a whole.
+        do {
+            $before = count($reachable);
+
+            foreach ($reachable as $name) {
+                if (! isset($schemas[$name])) {
+                    continue;
+                }
+
+                $reachable = array_values(array_unique(array_merge(
+                    $reachable,
+                    $this->referencedSchemaNames($schemas[$name]),
+                )));
+            }
+        } while (count($reachable) > $before);
+
+        foreach (array_keys($document->components->schemas) as $fullName) {
+            if (! in_array($document->components->uniqueSchemaName($fullName), $reachable, true)) {
+                $document->components->removeSchema($fullName);
+            }
+        }
+    }
+
+    /**
+     * Collect the component schema names every `$ref` in the given node points at.
+     *
+     * @param  array<array-key, mixed>  $node
+     * @return array<int, string>
+     */
+    private function referencedSchemaNames(array $node): array
+    {
+        $names = [];
+
+        array_walk_recursive($node, function ($value, $key) use (&$names): void {
+            if ($key === '$ref' && is_string($value) && str_starts_with($value, '#/components/schemas/')) {
+                $names[] = basename($value);
+            }
+        });
+
+        return array_values(array_unique($names));
+    }
+}

--- a/docs/api-v1.json
+++ b/docs/api-v1.json
@@ -453,13 +453,14 @@
         "/positions": {
             "get": {
                 "operationId": "v1.positions.index",
-                "summary": "Display all positions",
+                "description": "Returns every position, reduced to the fields a booking client needs to render\nand match a callsign.",
+                "summary": "List positions",
                 "tags": [
                     "Position"
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "All positions, wrapped in a `data` array. The query selects three columns only, so the response carries no `id`, `fir`, `rating`, `area_id` or `required_facility_rating_id`.",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -468,7 +469,26 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/components/schemas/Position"
+                                                "type": "object",
+                                                "properties": {
+                                                    "callsign": {
+                                                        "type": "string"
+                                                    },
+                                                    "frequency": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "callsign",
+                                                    "frequency",
+                                                    "name"
+                                                ]
                                             }
                                         }
                                     },
@@ -694,74 +714,6 @@
                     "vatsim_booking"
                 ],
                 "title": "Booking"
-            },
-            "Position": {
-                "type": "object",
-                "properties": {
-                    "area_id": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ]
-                    },
-                    "callsign": {
-                        "type": "string"
-                    },
-                    "fir": {
-                        "type": "string"
-                    },
-                    "frequency": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "id": {
-                        "type": "integer"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "rating": {
-                        "$ref": "#/components/schemas/VatsimRating"
-                    },
-                    "required_facility_rating_id": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ]
-                    }
-                },
-                "required": [
-                    "area_id",
-                    "callsign",
-                    "fir",
-                    "frequency",
-                    "id",
-                    "name",
-                    "rating",
-                    "required_facility_rating_id"
-                ],
-                "title": "Position"
-            },
-            "VatsimRating": {
-                "type": "integer",
-                "description": "The VATSIM ATC ratings. The case name is the short code (e.g. `OBS`, `S3`) and the backing value is the numeric VATSIM rating id. Note that `C2` (6) and `I2` (9) exist in VATSIM but are unused here.\n| |\n|---|\n| `-1` <br/> Inactive. |\n| `0` <br/> Suspended. |\n| `1` <br/> Pilot/Observer. |\n| `2` <br/> Tower Trainee. |\n| `3` <br/> Tower Controller. |\n| `4` <br/> TMA Controller. |\n| `5` <br/> Enroute Controller. |\n| `7` <br/> Senior Controller. |\n| `8` <br/> Instructor. |\n| `10` <br/> Senior Instructor. |\n| `11` <br/> Supervisor. |\n| `12` <br/> Administrator. |",
-                "enum": [
-                    -1,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    7,
-                    8,
-                    10,
-                    11,
-                    12
-                ],
-                "title": "VatsimRating"
             }
         },
         "responses": {

--- a/tests/Feature/Api/V1/OpenApiDocumentTest.php
+++ b/tests/Feature/Api/V1/OpenApiDocumentTest.php
@@ -76,6 +76,68 @@ class OpenApiDocumentTest extends TestCase
         $this->assertSchemaOrdering($document['components']['schemas'] ?? [], 'components.schemas');
     }
 
+    public function test_every_reference_resolves_to_a_defined_component_schema(): void
+    {
+        $document = app(Generator::class)();
+        $schemas = $document['components']['schemas'] ?? [];
+
+        foreach ($this->referencedSchemaNames($document) as $name) {
+            $this->assertArrayHasKey($name, $schemas, "Reference to undefined component schema {$name}.");
+        }
+    }
+
+    public function test_no_component_schema_is_left_unreferenced(): void
+    {
+        $document = app(Generator::class)();
+        $schemas = $document['components']['schemas'] ?? [];
+        $this->assertNotEmpty($schemas);
+
+        // Scramble registers a model schema whenever it analyses a query on that model, even when
+        // an explicit #[Response] attribute documents a narrower shape, so orphans appear without
+        // RemovesUnreferencedSchemas. The docs renderer lists component schemas, so an orphan would
+        // advertise an object shape no endpoint returns.
+        $withoutDefinitions = $document;
+        unset($withoutDefinitions['components']['schemas']);
+
+        $reachable = $this->referencedSchemaNames($withoutDefinitions);
+
+        do {
+            $before = count($reachable);
+
+            foreach ($reachable as $name) {
+                if (isset($schemas[$name])) {
+                    $reachable = array_values(array_unique(array_merge(
+                        $reachable,
+                        $this->referencedSchemaNames($schemas[$name]),
+                    )));
+                }
+            }
+        } while (count($reachable) > $before);
+
+        $orphans = array_values(array_diff(array_keys($schemas), $reachable));
+
+        $this->assertSame([], $orphans, 'Unreferenced component schemas: ' . implode(', ', $orphans));
+    }
+
+    /**
+     * Collect the component schema names every `$ref` in the given node points at.
+     *
+     * @param  array<array-key, mixed>  $node
+     * @return array<int, string>
+     */
+    private function referencedSchemaNames(array $node): array
+    {
+        $names = [];
+
+        array_walk_recursive($node, function ($value, $key) use (&$names): void {
+            if ($key === '$ref' && is_string($value) && str_starts_with($value, '#/components/schemas/')) {
+                $names[] = basename($value);
+            }
+        });
+
+        return array_values(array_unique($names));
+    }
+
     /**
      * Recursively assert that every object node exposes its `properties` keys and `required`
      * entries in alphabetical order.

--- a/tests/Feature/Api/V1/PositionsEndpointTest.php
+++ b/tests/Feature/Api/V1/PositionsEndpointTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature\Api\V1;
+
+use Dedoc\Scramble\Generator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PositionsEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * The documented 200 response for `/positions` must describe exactly the fields the
+     * endpoint actually returns. Scramble cannot infer the column list from
+     * `Position::select([...])->get()`, so without an explicit response annotation it
+     * documents every column of the `Position` model instead of the three selected ones.
+     */
+    public function test_documented_response_matches_the_actual_payload(): void
+    {
+        $data = $this->getJson('/api/v1/positions')->assertOk()->json('data');
+
+        $this->assertNotEmpty($data, 'The seeded positions must be present, otherwise this assertion passes vacuously.');
+
+        $actualFields = array_keys($data[0]);
+        sort($actualFields);
+
+        $documentedFields = $this->documentedPositionFields();
+        sort($documentedFields);
+
+        $this->assertSame($documentedFields, $actualFields);
+    }
+
+    public function test_documented_response_lists_only_the_selected_columns(): void
+    {
+        $documentedFields = $this->documentedPositionFields();
+        sort($documentedFields);
+
+        $this->assertSame(['callsign', 'frequency', 'name'], $documentedFields);
+    }
+
+    public function test_endpoint_returns_only_the_selected_columns(): void
+    {
+        $data = $this->getJson('/api/v1/positions')->assertOk()->json('data');
+
+        $this->assertNotEmpty($data);
+
+        foreach ($data as $position) {
+            $fields = array_keys($position);
+            sort($fields);
+            $this->assertSame(['callsign', 'frequency', 'name'], $fields);
+        }
+    }
+
+    public function test_legacy_unversioned_endpoint_returns_the_same_payload(): void
+    {
+        $legacy = $this->getJson('/api/positions')->assertOk()->json('data');
+        $versioned = $this->getJson('/api/v1/positions')->assertOk()->json('data');
+
+        $this->assertSame($versioned, $legacy);
+    }
+
+    /**
+     * Resolve the property names of the documented `/positions` 200 response item schema,
+     * following a `$ref` into `components.schemas` when Scramble emits one.
+     *
+     * @return array<int, string>
+     */
+    private function documentedPositionFields(): array
+    {
+        $document = app(Generator::class)();
+
+        $schema = $document['paths']['/positions']['get']['responses'][200]['content']['application/json']['schema'];
+
+        $items = $this->resolveRef($document, $schema)['properties']['data']['items'];
+
+        return array_keys($this->resolveRef($document, $items)['properties']);
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $document
+     * @param  array<array-key, mixed>  $schema
+     * @return array<array-key, mixed>
+     */
+    private function resolveRef(array $document, array $schema): array
+    {
+        if (! isset($schema['$ref'])) {
+            return $schema;
+        }
+
+        $name = basename($schema['$ref']);
+
+        return $document['components']['schemas'][$name];
+    }
+}


### PR DESCRIPTION
After introducing the API spec, the spec included all the fields of
Position, even though we only return a limited list of fields.

The fix annotates the method with an explicit `#[Response]` shape,
matching the approach used elsewhere. The response payload is unchanged,
so existing consumers of both `/api/positions` and `/api/v1/positions`
are unaffected.

Introduces a transformer to Scramble which properly removes old schemas
that are no longer valid.

## Summary by Sourcery

Align the generated positions API documentation with the existing response payload and eliminate stale OpenAPI schemas.

Bug Fixes:
- Document the `/positions` API response as the three-field payload actually returned to clients, avoiding exposure of unrelated `Position` model fields.

Enhancements:
- Remove unreferenced OpenAPI component schemas from generated documents while preserving transitively referenced schemas.

Documentation:
- Update the generated API specification to reflect the accurate positions response schema.

Tests:
- Add coverage for response-field accuracy, parity between versioned and legacy positions endpoints, and complete OpenAPI schema references without orphaned components.