### PR TITLE
fix(ui): unify page filter pills into shared components across pages

### DIFF
--- a/app/Http/Controllers/Admin/PositionController.php
+++ b/app/Http/Controllers/Admin/PositionController.php
@@ -20,8 +20,7 @@ class PositionController extends Controller
 
         $accessibleAreas = $allAreas->filter(fn ($a) => $request->user()->can('viewAny', [Position::class, $a]));
 
-        $currentAreaId = $area ?? $request->input('area');
-        $currentArea = $currentAreaId ? $allAreas->firstWhere('id', $currentAreaId) : null;
+        $currentArea = $area ? $allAreas->firstWhere('id', $area) : null;
 
         $this->authorize('viewAny', [Position::class, $currentArea]);
 

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -105,13 +105,7 @@ class ReportController extends Controller
             : null;
 
         $areas = Area::all();
-        $filterName = 'All Areas';
-        if ($filterArea) {
-            $area = $areas->find($filterArea);
-            if ($area) {
-                $filterName = $area->name;
-            }
-        }
+        $currentArea = $filterArea ? $areas->find($filterArea) : null;
 
         [$newRequests, $completedRequests, $closedRequests, $passedExamRequests, $failedExamRequests, $labels] = $this->getBiAnnualRequestsStats($filterArea, $startDate, $endDate);
         $cardStats = $this->getCardStats($filterArea, $startDate, $endDate);
@@ -120,7 +114,7 @@ class ReportController extends Controller
         $sessionsPerRating = $this->getSessionsPerRatingStats($filterArea, $startDate, $endDate);
 
         return view('reports.trainings', [
-            'filterName' => $filterName,
+            'currentArea' => $currentArea,
             'areas' => $areas,
             'cardStats' => $cardStats,
             'totalRequests' => $totalRequests,
@@ -192,17 +186,11 @@ class ReportController extends Controller
         $entries = $entries->concat($activities)->sortByDesc('activity_date');
 
         $areas = Area::all();
-        $filterName = 'All Areas';
-        if ($filterArea) {
-            $area = $areas->find($filterArea);
-            if ($area) {
-                $filterName = $area->name;
-            }
-        }
+        $currentArea = $filterArea ? $areas->find($filterArea) : null;
 
         return view('reports.activities', [
             'entries' => $entries,
-            'filterName' => $filterName,
+            'currentArea' => $currentArea,
             'areas' => $areas,
         ]);
     }

--- a/resources/views/admin/notificationtemplates.blade.php
+++ b/resources/views/admin/notificationtemplates.blade.php
@@ -2,12 +2,11 @@
 
 @section('title', 'Notification Templates')
 @section('title-flex')
-    <div>
-        <i class="fas fa-filter"></i>&nbsp;Filter:&nbsp;
+    <x-filter.group>
         @foreach($areas as $area)
-            <a class="btn btn-sm {{ $currentArea == $area ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('admin.templates.area', $area->id) }}">{{ $area->name }}</a>
+            <x-filter.item :href="route('admin.templates.area', $area->id)" :active="$currentArea?->is($area)">{{ $area->name }}</x-filter.item>
         @endforeach
-    </div>
+    </x-filter.group>
 @endsection
 
 @section('content')

--- a/resources/views/admin/positions/index.blade.php
+++ b/resources/views/admin/positions/index.blade.php
@@ -4,15 +4,12 @@
 
 @section('title-flex')
     <div class="d-flex align-items-center">
-        <div class="me-3">
-            <i class="fas fa-filter"></i>&nbsp;Filter:&nbsp;
-            <a class="btn btn-sm {{ !isset($currentArea) ? 'btn-primary' : 'btn-outline-primary' }}"
-                href="{{ route('positions.index') }}">All</a>
+        <x-filter.group class="me-3">
+            <x-filter.item :href="route('positions.index')" :active="! $currentArea">All</x-filter.item>
             @foreach ($areas as $area)
-                <a class="btn btn-sm {{ isset($currentArea) && $currentArea->id == $area->id ? 'btn-primary' : 'btn-outline-primary' }}"
-                    href="{{ route('positions.index.area', $area->id) }}">{{ $area->name }}</a>
+                <x-filter.item :href="route('positions.index.area', $area->id)" :active="$currentArea?->is($area)">{{ $area->name }}</x-filter.item>
             @endforeach
-        </div>
+        </x-filter.group>
         @can('createAny', App\Models\Position::class)
             <div>
                 <a href="#" class="btn btn-outline-success" data-bs-toggle="modal" data-bs-target="#create-position-modal">

--- a/resources/views/components/filter/group.blade.php
+++ b/resources/views/components/filter/group.blade.php
@@ -1,0 +1,12 @@
+{{--
+    Segmented filter pills for the page header, as used on Training Statistics.
+
+    Wraps any number of <x-filter.item> children. Permission gating stays in the
+    caller, since every page filters on its own permission and area source.
+--}}
+@props(['label' => 'Filter', 'icon' => 'fa-filter'])
+
+<div {{ $attributes->class(['input-group', 'input-group-sm', 'w-auto', 'align-self-center']) }}>
+    <span class="input-group-text"><i class="fas {{ $icon }} me-1"></i>{{ $label }}</span>
+    {{ $slot }}
+</div>

--- a/resources/views/components/filter/item.blade.php
+++ b/resources/views/components/filter/item.blade.php
@@ -1,0 +1,16 @@
+{{--
+    One pill inside an <x-filter.group>.
+
+    The current query string is carried into $href, so switching filter never
+    silently drops unrelated filter state such as a date range. Params already
+    present in $href win over the carried ones.
+--}}
+@props(['href', 'active' => false])
+
+@php
+    $base = strstr($href, '?', true) ?: $href;
+    parse_str((string) parse_url($href, PHP_URL_QUERY), $ownParams);
+    $query = array_merge(request()->query(), $ownParams);
+@endphp
+
+<a {{ $attributes->class(['btn', 'btn-sm', $active ? 'btn-primary' : 'btn-outline-primary']) }} href="{{ $base.($query === [] ? '' : '?'.http_build_query($query)) }}">{{ $slot }}</a>

--- a/resources/views/reports/activities.blade.php
+++ b/resources/views/reports/activities.blade.php
@@ -2,17 +2,16 @@
 
 @section('title', 'Training Activities')
 @section('title-flex')
-    <div>
-        <i class="fas fa-filter text-secondary"></i>&nbsp;Filter&nbsp;
+    <x-filter.group>
         @if(\Auth::user()->accessibleAreasForPermission('training.activities.view')->isGlobal)
-            <a class="btn btn-sm {{ $filterName == "All Areas" ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('reports.activities') }}">All Areas</a>
+            <x-filter.item :href="route('reports.activities')" :active="! $currentArea">All Areas</x-filter.item>
         @endif
         @foreach($areas as $area)
             @can('training.activities.view', $area)
-                <a class="btn btn-sm {{ $filterName == $area->name ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('reports.activities.area', $area->id) }}">{{ $area->name }}</a>
+                <x-filter.item :href="route('reports.activities.area', $area->id)" :active="$currentArea?->is($area)">{{ $area->name }}</x-filter.item>
             @endcan
         @endforeach
-    </div>
+    </x-filter.group>
 @endsection
 
 @section('header')

--- a/resources/views/reports/trainings.blade.php
+++ b/resources/views/reports/trainings.blade.php
@@ -17,17 +17,16 @@
             </div>
         </form>
 
-        <div class="input-group input-group-sm w-auto">
-            <span class="input-group-text"><i class="fas fa-filter me-1"></i>Filter</span>
+        <x-filter.group>
             @if(\Auth::user()->accessibleAreasForPermission('training.statistics.view')->isGlobal)
-                <a class="btn btn-sm {{ $filterName == "All Areas" ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('reports.trainings', ['start_date' => request('start_date'), 'end_date' => request('end_date')]) }}">All Areas</a>
+                <x-filter.item :href="route('reports.trainings')" :active="! $currentArea">All Areas</x-filter.item>
             @endif
             @foreach($areas as $area)
                 @can('training.statistics.view', $area)
-                    <a class="btn btn-sm {{ $filterName == $area->name ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('reports.training.area', ['id' => $area->id, 'start_date' => request('start_date'), 'end_date' => request('end_date')]) }}">{{ $area->name }}</a>
+                    <x-filter.item :href="route('reports.training.area', $area->id)" :active="$currentArea?->is($area)">{{ $area->name }}</x-filter.item>
                 @endcan
             @endforeach
-        </div>
+        </x-filter.group>
     </div>
 @endsection
 @section('content')

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -2,12 +2,11 @@
 
 @section('title', 'Tasks')
 @section('title-flex')
-    <div>
-        <i class="fas fa-filter"></i>&nbsp;Filter:&nbsp;
-        <a class="btn btn-sm {{ ($activeFilter != 'sent' && $activeFilter != 'archived') ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('tasks') }}">Open</a>
-        <a class="btn btn-sm {{ ($activeFilter == 'sent') ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('tasks.filtered', 'sent') }}">Sent</a>
-        <a class="btn btn-sm {{ ($activeFilter == 'archived') ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ route('tasks.filtered', 'archived') }}">Archived</a>
-    </div>
+    <x-filter.group>
+        <x-filter.item :href="route('tasks')" :active="$activeFilter !== 'sent' && $activeFilter !== 'archived'">Open</x-filter.item>
+        <x-filter.item :href="route('tasks.filtered', 'sent')" :active="$activeFilter === 'sent'">Sent</x-filter.item>
+        <x-filter.item :href="route('tasks.filtered', 'archived')" :active="$activeFilter === 'archived'">Archived</x-filter.item>
+    </x-filter.group>
 @endsection
 
 @section('content')

--- a/tests/Feature/FilterComponentTest.php
+++ b/tests/Feature/FilterComponentTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Blade;
+use Tests\TestCase;
+
+class FilterComponentTest extends TestCase
+{
+    public function test_only_the_active_pill_is_solid(): void
+    {
+        $html = Blade::render(
+            '<x-filter.group>'
+            . '<x-filter.item href="/reports/trainings" :active="true">All Areas</x-filter.item>'
+            . '<x-filter.item href="/reports/training/1">Oslo</x-filter.item>'
+            . '</x-filter.group>'
+        );
+
+        $this->assertStringContainsString('class="input-group input-group-sm w-auto align-self-center"', $html);
+        $this->assertStringContainsString('btn btn-sm btn-primary" href="/reports/trainings"', $html);
+        $this->assertStringContainsString('btn btn-sm btn-outline-primary" href="/reports/training/1"', $html);
+    }
+
+    public function test_pills_carry_the_current_query_string(): void
+    {
+        $this->app->instance('request', Request::create('/reports/training/1?start_date=2026-01-01'));
+
+        $html = Blade::render('<x-filter.item href="/reports/trainings">All Areas</x-filter.item>');
+
+        $this->assertStringContainsString('href="/reports/trainings?start_date=2026-01-01"', $html);
+    }
+}


### PR DESCRIPTION
Every page-level Filter toggle now renders through the x-filter.group
and x-filter.item components, adopting the Training Statistics
input-group chrome instead of five hand-rolled variants.

The item component carries the current query string into each pill href,
so switching area no longer drops the date range on Training Statistics.

Controllers now pass a nullable Area rather than a name, improving
matching when necessary.

Also drops the dead area query-string fallback in PositionController,
which nothing linked to.

## Summary by Sourcery

Unify page-level filters with shared components while preserving query state and simplifying area selection handling.

Bug Fixes:
- Preserve existing query parameters when switching page-level filters, preventing date ranges and other filter state from being lost.

Enhancements:
- Standardize page-level filter pills across positions, notification templates, reports, and tasks with shared filter components and consistent styling.
- Represent selected areas as nullable Area models for clearer and more reliable filter matching.
- Remove the unused area query-string fallback from the positions controller.

Tests:
- Add feature coverage for shared filter styling, active-state rendering, and query-string preservation.