### PR TITLE
fix(endorsements): link a solo to the training for its position's area

### DIFF
--- a/app/Http/Controllers/EndorsementController.php
+++ b/app/Http/Controllers/EndorsementController.php
@@ -9,6 +9,7 @@ use App\Models\Area;
 use App\Models\Endorsement;
 use App\Models\Position;
 use App\Models\Rating;
+use App\Models\Training;
 use App\Models\User;
 use App\Notifications\EndorsementCreatedNotification;
 use App\Notifications\EndorsementModifiedNotification;
@@ -217,8 +218,12 @@ class EndorsementController extends Controller
             ' ― User: ' . $endorsement->user_id .
             ' ― Positions: ' . $data['position']);
 
-            // Log this new endorsement to the user's active training
-            TrainingActivityController::create($user->trainings->filter(fn ($training) => $training->status->isOpen())->first()->id, 'ENDORSEMENT', $endorsement->id, null, Auth::user()->id, $endorsement->positions->pluck('callsign')->implode(', '));
+            // Log this new endorsement to the training it was issued for
+            $linkedTraining = $this->trainingForSoloEndorsement($user, $position);
+
+            if ($linkedTraining) {
+                TrainingActivityController::create($linkedTraining->id, 'ENDORSEMENT', $endorsement->id, null, Auth::user()->id, $endorsement->positions->pluck('callsign')->implode(', '));
+            }
 
             $user->notify(new EndorsementCreatedNotification($endorsement));
 
@@ -374,6 +379,30 @@ class EndorsementController extends Controller
         $endorsement->user->notify(new EndorsementModifiedNotification($endorsement));
 
         return redirect()->back()->withSuccess(User::find($endorsement->user_id)->name . "'s " . $endorsement->type . ' endorsement shortened to ' . Carbon::parse($date)->toEuropeanDateTime() . '. E-mail sent to student.');
+    }
+
+    /**
+     * The training a solo endorsement belongs to.
+     *
+     * A solo is issued for a position, and a position belongs to an area, so the
+     * student's open training in that area is the training the endorsement is
+     * part of. Picking the first open training instead, as this used to, put the
+     * entry on an unrelated training whenever a student had more than one open —
+     * a Norwegian training taking the record of a Swedish solo, for instance.
+     *
+     * Falls back to any open training when none covers the position's area, so
+     * the endorsement is still recorded somewhere rather than lost.
+     */
+    private function trainingForSoloEndorsement(User $user, Position $position): ?Training
+    {
+        $openTrainings = $user->trainings
+            ->filter(fn (Training $training): bool => $training->status->isOpen())
+            // Furthest along first: a student with two open trainings in the same
+            // area is most likely being soloed on the one nearest its exam.
+            ->sortByDesc(fn (Training $training): int => $training->status->value);
+
+        return $openTrainings->firstWhere('area_id', $position->area_id)
+            ?? $openTrainings->first();
     }
 
     /**

--- a/tests/Feature/SoloEndorsementTrainingLinkTest.php
+++ b/tests/Feature/SoloEndorsementTrainingLinkTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Helpers\TrainingStatus;
+use App\Models\Area;
+use App\Models\Endorsement;
+use App\Models\Position;
+use App\Models\Training;
+use App\Models\TrainingActivity;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * A solo endorsement is issued for a position, so the activity entry recording
+ * it must land on the training covering that position's area.
+ */
+class SoloEndorsementTrainingLinkTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $student;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->student = User::factory()->create();
+
+        $this->admin = User::factory()->create();
+        $this->admin->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+    }
+
+    private function issueSolo(Position $position): void
+    {
+        $this->actingAs($this->admin)->post(route('endorsements.store'), [
+            'endorsementType' => 'SOLO',
+            'user' => $this->student->id,
+            'position' => $position->callsign,
+            'expires' => Carbon::today()->addDays(20)->format('d/m/Y'),
+        ])->assertSessionHasNoErrors();
+    }
+
+    private function trainingIn(Area $area, TrainingStatus $status): Training
+    {
+        return Training::factory()->create([
+            'user_id' => $this->student->id,
+            'area_id' => $area->id,
+            'status' => $status,
+        ]);
+    }
+
+    #[Test]
+    public function the_endorsement_is_recorded_against_the_training_for_the_positions_area()
+    {
+        $norway = Area::factory()->create(['name' => 'Norway']);
+        $sweden = Area::factory()->create(['name' => 'Sweden']);
+
+        // Created first, so the old "first open training" rule would pick this one.
+        $norwegianTraining = $this->trainingIn($norway, TrainingStatus::ACTIVE_TRAINING);
+        $swedishTraining = $this->trainingIn($sweden, TrainingStatus::AWAITING_EXAM);
+
+        $this->issueSolo(Position::factory()->create(['area_id' => $sweden->id]));
+
+        $activity = TrainingActivity::where('type', 'ENDORSEMENT')->first();
+
+        $this->assertNotNull($activity);
+        $this->assertSame($swedishTraining->id, $activity->training_id);
+        $this->assertNotSame($norwegianTraining->id, $activity->training_id);
+    }
+
+    #[Test]
+    public function a_closed_training_in_the_positions_area_is_not_used()
+    {
+        $area = Area::factory()->create();
+
+        $closed = $this->trainingIn($area, TrainingStatus::COMPLETED);
+        $open = $this->trainingIn($area, TrainingStatus::ACTIVE_TRAINING);
+
+        $this->issueSolo(Position::factory()->create(['area_id' => $area->id]));
+
+        $activity = TrainingActivity::where('type', 'ENDORSEMENT')->first();
+
+        $this->assertSame($open->id, $activity->training_id);
+        $this->assertNotSame($closed->id, $activity->training_id);
+    }
+
+    #[Test]
+    public function the_training_nearest_its_exam_wins_when_several_are_open_in_the_area()
+    {
+        $area = Area::factory()->create();
+
+        $earlier = $this->trainingIn($area, TrainingStatus::PRE_TRAINING);
+        $nearerExam = $this->trainingIn($area, TrainingStatus::AWAITING_EXAM);
+
+        $this->issueSolo(Position::factory()->create(['area_id' => $area->id]));
+
+        $activity = TrainingActivity::where('type', 'ENDORSEMENT')->first();
+
+        $this->assertSame($nearerExam->id, $activity->training_id);
+        $this->assertNotSame($earlier->id, $activity->training_id);
+    }
+
+    #[Test]
+    public function it_falls_back_to_an_open_training_when_none_covers_the_positions_area()
+    {
+        $trainingArea = Area::factory()->create();
+        $otherArea = Area::factory()->create();
+
+        $training = $this->trainingIn($trainingArea, TrainingStatus::ACTIVE_TRAINING);
+
+        $this->issueSolo(Position::factory()->create(['area_id' => $otherArea->id]));
+
+        $activity = TrainingActivity::where('type', 'ENDORSEMENT')->first();
+
+        $this->assertNotNull($activity, 'The endorsement should still be recorded somewhere.');
+        $this->assertSame($training->id, $activity->training_id);
+    }
+
+    #[Test]
+    public function the_endorsement_is_still_created_when_it_cannot_be_linked()
+    {
+        $area = Area::factory()->create();
+        $this->trainingIn($area, TrainingStatus::ACTIVE_TRAINING);
+
+        $this->issueSolo(Position::factory()->create(['area_id' => $area->id]));
+
+        $this->assertSame(1, Endorsement::where('type', 'SOLO')->count());
+    }
+}


### PR DESCRIPTION
## Problem

A solo endorsement is issued for a **position**, and a position belongs to an **area**. But the `training_activity` entry recording the endorsement was attached to whichever open training happened to come first in the student's collection:

```php
TrainingActivityController::create($user->trainings->filter(fn ($training) => $training->status->isOpen())->first()->id, 'ENDORSEMENT', ...)
```

For a student with more than one open training, the entry lands on an unrelated one. Found while testing #1334 against seeded data: a student had an open Norwegian training and an open Swedish one, and a solo issued for a Swedish position was recorded against the Norwegian training.

Because the endorsement history on a training page is driven by these entries, the solo never appears on the training it was actually issued for.

`->first()->id` was also dereferenced unconditionally, which is a fatal error when the student has no open training.

## Change

Pick the student's open training in the **position's area**, preferring the one nearest its exam when several qualify, and fall back to any open training so the endorsement is still recorded when no area matches. The lookup is now null-safe.

## Tests

`tests/Feature/SoloEndorsementTrainingLinkTest.php` — 5 tests covering area matching, closed trainings being skipped, the status tie-break, the no-area-match fallback, and the endorsement still being created when it cannot be linked.

Existing endorsement and training suites pass unchanged (67 tests).

## Note

[#1334](https://github.com/Vatsim-Scandinavia/controlcenter/pull/1334) (solo day counter) is stacked on top of this branch — the counter reads these activity entries, so it needs this fix to show on the right training.

## Summary by Sourcery

Associate solo endorsement activity with the most appropriate open training for the endorsed position while preserving endorsement creation when no suitable training is available.

Bug Fixes:
- Link solo endorsement activity to the student’s open training for the endorsed position’s area, avoiding incorrect training history associations.
- Allow endorsements to be created safely when no open training exists.

Enhancements:
- Prefer the open training nearest its exam when multiple trainings cover the same area, with a fallback to any open training when no area match exists.

Tests:
- Add feature coverage for area matching, closed-training exclusion, training-status selection, fallback behavior, and unlinked endorsement creation.