### PR TITLE
feat(endorsements): add solo endorsement day counter

### DIFF
--- a/app/Http/Controllers/GlobalSettingController.php
+++ b/app/Http/Controllers/GlobalSettingController.php
@@ -50,6 +50,7 @@ class GlobalSettingController extends Controller
             'trainingSubDivisions' => 'nullable',
             'trainingInterval' => 'required|integer|min:1',
             'trainingSoloRequirement' => 'required|max:200',
+            'trainingSoloMaxDays' => 'required|integer|min:1',
             'atcActivityQualificationPeriod' => 'required|integer|min:1',
             'atcActivityGracePeriod' => 'required|integer|min:0',
             'atcActivityRequirement' => 'required|integer|min:0',
@@ -93,6 +94,7 @@ class GlobalSettingController extends Controller
         Setting::set('trainingSubDivisions', $trainingSubDivisions);
         Setting::set('trainingInterval', $data['trainingInterval']);
         Setting::set('trainingSoloRequirement', $data['trainingSoloRequirement']);
+        Setting::set('trainingSoloMaxDays', $data['trainingSoloMaxDays']);
         Setting::set('atcActivityQualificationPeriod', $data['atcActivityQualificationPeriod']);
         Setting::set('atcActivityGracePeriod', $data['atcActivityGracePeriod']);
         Setting::set('atcActivityRequirement', $data['atcActivityRequirement']);

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -24,6 +24,7 @@ use App\Notifications\TrainingCreatedNotification;
 use App\Notifications\TrainingMentorNotification;
 use App\Notifications\TrainingPreStatusNotification;
 use App\Services\ActivityLogService;
+use App\Services\SoloEndorsementService;
 use App\Services\TrainingService;
 use App\Tasks\Types\RatingUpgrade;
 use Carbon\Carbon;
@@ -403,7 +404,11 @@ class TrainingController extends Controller
             return $training->getHighestVatsimRating()?->id === $completablePart->id;
         });
 
-        return view('training.show', compact('training', 'reportsAndExams', 'trainingMentors', 'types', 'experiences', 'activities', 'trainingInterests', 'activeTrainingInterest', 'relatedTasks', 'requestTypes', 'requestPopularAssignees', 'showCompletionControl', 'completablePart', 'outstandingRatings', 'otherOutstandingRatings', 'outstandingEndorsementRatings', 'canCompletePartially', 'upgradeRequestedForPart'));
+        // How much of the solo day allowance this training has used, or null when
+        // no solo endorsement was ever issued on it.
+        $soloEndorsementSummary = app(SoloEndorsementService::class)->summaryFor($training);
+
+        return view('training.show', compact('training', 'reportsAndExams', 'trainingMentors', 'types', 'experiences', 'activities', 'trainingInterests', 'activeTrainingInterest', 'relatedTasks', 'requestTypes', 'requestPopularAssignees', 'showCompletionControl', 'completablePart', 'outstandingRatings', 'otherOutstandingRatings', 'outstandingEndorsementRatings', 'canCompletePartially', 'upgradeRequestedForPart', 'soloEndorsementSummary'));
     }
 
     /**

--- a/app/Services/SoloEndorsementService.php
+++ b/app/Services/SoloEndorsementService.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Services;
+
+use anlutro\LaravelSettings\Facade as Setting;
+use App\Models\Endorsement;
+use App\Models\Training;
+use Illuminate\Support\Collection;
+
+/**
+ * Totals up the solo endorsement days granted on a training, so staff can see
+ * how much of the allowance is left before issuing another one.
+ */
+class SoloEndorsementService
+{
+    /**
+     * Fallback allowance for installations whose setting has not been seeded.
+     */
+    private const DEFAULT_MAX_DAYS = 60;
+
+    /**
+     * The solo endorsements recorded against a training and how much of the day
+     * allowance they consume, or null when the training has none.
+     *
+     * @return array{endorsements: Collection<int, array{endorsement: Endorsement, days: int}>, used: int, left: int, total: int, percentage_used: int, collapsed: bool}|null
+     */
+    public function summaryFor(Training $training): ?array
+    {
+        $endorsements = $this->endorsementsFor($training)
+            ->map(fn (Endorsement $endorsement): array => [
+                'endorsement' => $endorsement,
+                'days' => $this->daysGranted($endorsement),
+            ]);
+
+        if ($endorsements->isEmpty()) {
+            return null;
+        }
+
+        $total = $this->maxDays();
+        // Every day granted counts, revoked ones included: the allowance is about
+        // how much solo time has been issued, not how much was flown.
+        $used = (int) $endorsements->sum('days');
+        $percentageUsed = (int) min(100, round(($used / $total) * 100));
+
+        return [
+            'endorsements' => $endorsements,
+            'used' => $used,
+            'left' => max($total - $used, 0),
+            'total' => $total,
+            'percentage_used' => $percentageUsed,
+            // Nothing left to act on once the allowance is spent or the training
+            // is over, so the breakdown starts folded away.
+            'collapsed' => $used >= $total || $training->status->isClosed(),
+        ];
+    }
+
+    /**
+     * Solo endorsements recorded against this training through its activity log.
+     *
+     * Endorsements carry no training reference of their own, so the ENDORSEMENT
+     * activity written when one is issued is the only link between the two.
+     *
+     * @return Collection<int, Endorsement>
+     */
+    public function endorsementsFor(Training $training): Collection
+    {
+        $endorsementIds = $training->activities
+            ->where('type', 'ENDORSEMENT')
+            ->pluck('new_data')
+            ->filter()
+            ->unique();
+
+        if ($endorsementIds->isEmpty()) {
+            return collect();
+        }
+
+        return Endorsement::where('type', 'SOLO')
+            ->where('user_id', $training->user_id)
+            ->whereIn('id', $endorsementIds)
+            ->orderByDesc('valid_from')
+            ->get();
+    }
+
+    /**
+     * Whole days an endorsement grants. An endorsement with no end date grants
+     * nothing countable, and a backwards range counts as zero rather than
+     * crediting days back to the student.
+     *
+     * Rounded up, because a part day is a day the student was on solo: an
+     * endorsement issued at 14:00 and expiring at 12:00 twenty days later spans
+     * 19.9 days, and counting that as 19 would quietly hand back a day of the
+     * allowance on every endorsement.
+     */
+    public function daysGranted(Endorsement $endorsement): int
+    {
+        if (! $endorsement->valid_from || ! $endorsement->valid_to) {
+            return 0;
+        }
+
+        return (int) max(0, ceil($endorsement->valid_from->diffInDays($endorsement->valid_to)));
+    }
+
+    /**
+     * The configured day allowance, floored at one day so the percentage
+     * calculation can never divide by zero.
+     */
+    public function maxDays(): int
+    {
+        return max(1, (int) Setting::get('trainingSoloMaxDays', self::DEFAULT_MAX_DAYS));
+    }
+}

--- a/database/migrations/2026_08_31_130000_add_solo_max_days_setting.php
+++ b/database/migrations/2026_08_31_130000_add_solo_max_days_setting.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * The number of solo days a student may be granted across one training.
+     * 60 matches the two 30-day endorsements a solo is normally issued as, and
+     * stays adjustable per installation from the global settings page.
+     */
+    private const DEFAULT_MAX_DAYS = '60';
+
+    public function up(): void
+    {
+        $table = Config::get('settings.table');
+
+        if (DB::table($table)->where('key', 'trainingSoloMaxDays')->exists()) {
+            return;
+        }
+
+        DB::table($table)->insert([
+            ['key' => 'trainingSoloMaxDays', 'value' => self::DEFAULT_MAX_DAYS],
+        ]);
+    }
+
+    public function down(): void
+    {
+        DB::table(Config::get('settings.table'))->where('key', 'trainingSoloMaxDays')->delete();
+    }
+};

--- a/resources/sass/_global.scss
+++ b/resources/sass/_global.scss
@@ -384,3 +384,31 @@ table{
     margin-bottom: 3px;
     vertical-align: middle;
 }
+
+.solo-endorsements {
+    > summary {
+        cursor: pointer;
+        list-style: none;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+
+        &::-webkit-details-marker {
+            display: none;
+        }
+
+        &::after {
+            content: "\f078";
+            font-family: "Font Awesome 7 Free";
+            font-weight: 900;
+            font-size: 0.8em;
+            color: var(--bs-secondary-color);
+            transition: transform 0.2s ease-in-out;
+        }
+    }
+
+    &[open] > summary::after {
+        transform: rotate(180deg);
+    }
+}

--- a/resources/views/admin/globalsettings.blade.php
+++ b/resources/views/admin/globalsettings.blade.php
@@ -128,6 +128,15 @@
                                 <span class="text-danger">{{ $errors->first('trainingSoloRequirement') }}</span>
                             @enderror
 
+                            <div class="mb-4">
+                                <label class="form-label" for="trainingSoloMaxDays">Solo Endorsement Day Limit</label>
+                                <input type="number" min="1" class="form-control @error('trainingSoloMaxDays') is-invalid @enderror" id="trainingSoloMaxDays" name="trainingSoloMaxDays" required value="{{ Setting::get("trainingSoloMaxDays") }}">
+                                <small class="form-text">Total solo days a student may be granted on one training, shown as a counter on the training page.</small>
+                            </div>
+                            @error('trainingSoloMaxDays')
+                                <span class="text-danger">{{ $errors->first('trainingSoloMaxDays') }}</span>
+                            @enderror
+
                         </div>
                     </div>
                 </div>

--- a/resources/views/training/show.blade.php
+++ b/resources/views/training/show.blade.php
@@ -391,6 +391,68 @@
             </div>
         </div>
 
+        @if($soloEndorsementSummary)
+            <div class="card shadow mb-4">
+                <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
+                    <h6 class="m-0 fw-bold text-white">
+                        Solo Endorsements
+                    </h6>
+                </div>
+                <div class="card-body">
+                    {{-- A native details element, so the breakdown needs no collapse
+                         script and stays keyboard accessible on its own. --}}
+                    <details class="solo-endorsements" @if(! $soloEndorsementSummary['collapsed']) open @endif>
+                        <summary>
+                            Solo days remaining:
+                            <span class="{{ $soloEndorsementSummary['left'] === 0 ? 'text-danger' : 'text-success' }}">{{ $soloEndorsementSummary['left'] }}</span>
+                            of {{ $soloEndorsementSummary['total'] }}
+                        </summary>
+
+                        <div class="mt-3">
+                            <div class="text-muted mb-2">
+                                Days granted: {{ $soloEndorsementSummary['used'] }}
+                            </div>
+                            <div class="progress mb-3" role="progressbar" aria-label="Solo days used" aria-valuemin="0" aria-valuemax="{{ $soloEndorsementSummary['total'] }}" aria-valuenow="{{ $soloEndorsementSummary['used'] }}">
+                                <div class="progress-bar {{ $soloEndorsementSummary['percentage_used'] >= 100 ? 'bg-danger' : 'bg-primary' }}" style="width: {{ $soloEndorsementSummary['percentage_used'] }}%;"></div>
+                            </div>
+                            <small class="text-muted d-block mb-3">{{ $soloEndorsementSummary['percentage_used'] }}% of the allowable {{ $soloEndorsementSummary['total'] }} days used.</small>
+
+                            <div class="table-responsive">
+                                <table class="table table-sm table-leftpadded mb-0">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th>Granted</th>
+                                            <th>Expires</th>
+                                            <th>Days Granted</th>
+                                            <th>Status</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach($soloEndorsementSummary['endorsements'] as ['endorsement' => $soloEndorsement, 'days' => $soloDays])
+                                            <tr>
+                                                <td>{{ $soloEndorsement->valid_from?->toEuropeanDateTime() ?? '—' }}</td>
+                                                <td>{{ $soloEndorsement->valid_to?->toEuropeanDateTime() ?? '—' }}</td>
+                                                <td>{{ $soloEndorsement->valid_to ? $soloDays : '—' }}</td>
+                                                <td>
+                                                    @if($soloEndorsement->revoked)
+                                                        <span class="badge bg-danger">Revoked</span>
+                                                    @elseif($soloEndorsement->expired || $soloEndorsement->valid_to?->isPast())
+                                                        <span class="badge bg-warning text-dark">Expired</span>
+                                                    @else
+                                                        <span class="badge bg-success">Active</span>
+                                                    @endif
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </details>
+                </div>
+            </div>
+        @endif
+
         <div class="card shadow mb-4">
             <div class="card-header bg-primary py-3 d-flex flex-row align-items-center justify-content-between">
                 <h6 class="m-0 fw-bold text-white">

--- a/tests/Feature/SoloEndorsementCounterTest.php
+++ b/tests/Feature/SoloEndorsementCounterTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Tests\Feature;
+
+use anlutro\LaravelSettings\Facade as Setting;
+use App\Helpers\TrainingStatus;
+use App\Models\Endorsement;
+use App\Models\Training;
+use App\Models\TrainingActivity;
+use App\Models\User;
+use App\Services\SoloEndorsementService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SoloEndorsementCounterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Training $training;
+
+    private SoloEndorsementService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->training = Training::factory()->create([
+            'user_id' => User::factory()->create()->id,
+            'status' => TrainingStatus::ACTIVE_TRAINING,
+        ]);
+
+        $this->service = app(SoloEndorsementService::class);
+    }
+
+    /**
+     * Issue a solo endorsement and record it against the training the way
+     * EndorsementController does.
+     */
+    private function grantSolo(?Carbon $from, ?Carbon $to, bool $linked = true, array $attributes = []): Endorsement
+    {
+        $endorsement = Endorsement::factory()->create([
+            'user_id' => $this->training->user_id,
+            'type' => 'SOLO',
+            'valid_from' => $from,
+            'valid_to' => $to,
+            ...$attributes,
+        ]);
+
+        if ($linked) {
+            $activity = new TrainingActivity();
+            $activity->training_id = $this->training->id;
+            $activity->type = 'ENDORSEMENT';
+            $activity->new_data = $endorsement->id;
+            $activity->save();
+        }
+
+        return $endorsement;
+    }
+
+    private function moderator(): User
+    {
+        $moderator = User::factory()->create();
+        $moderator->roleAssignments()->create(['role' => 'moderator', 'area_id' => $this->training->area->id]);
+
+        return $moderator;
+    }
+
+    #[Test]
+    public function a_training_without_solo_endorsements_has_no_summary()
+    {
+        $this->assertNull($this->service->summaryFor($this->training));
+    }
+
+    #[Test]
+    public function it_totals_the_days_granted_across_linked_endorsements()
+    {
+        $this->grantSolo(Carbon::parse('2026-01-01 12:00'), Carbon::parse('2026-01-31 12:00'));
+        $this->grantSolo(Carbon::parse('2026-02-01 12:00'), Carbon::parse('2026-02-21 12:00'));
+
+        $summary = $this->service->summaryFor($this->training->refresh());
+
+        $this->assertSame(50, $summary['used']);
+        $this->assertSame(10, $summary['left']);
+        $this->assertSame(60, $summary['total']);
+        $this->assertSame(83, $summary['percentage_used']);
+        $this->assertCount(2, $summary['endorsements']);
+    }
+
+    #[Test]
+    public function it_ignores_solo_endorsements_not_recorded_against_the_training()
+    {
+        $this->grantSolo(Carbon::parse('2026-01-01 12:00'), Carbon::parse('2026-01-11 12:00'));
+        // Issued on a different training, so it must not count here.
+        $this->grantSolo(Carbon::parse('2026-03-01 12:00'), Carbon::parse('2026-03-31 12:00'), linked: false);
+
+        $summary = $this->service->summaryFor($this->training->refresh());
+
+        $this->assertSame(10, $summary['used']);
+        $this->assertCount(1, $summary['endorsements']);
+    }
+
+    #[Test]
+    public function an_endorsement_without_an_end_date_grants_no_countable_days()
+    {
+        $this->grantSolo(Carbon::parse('2026-01-01 12:00'), null);
+
+        $summary = $this->service->summaryFor($this->training->refresh());
+
+        $this->assertSame(0, $summary['used']);
+        $this->assertSame(60, $summary['left']);
+    }
+
+    #[Test]
+    public function the_allowance_comes_from_the_global_setting()
+    {
+        Setting::set('trainingSoloMaxDays', 30);
+        Setting::save();
+
+        $this->grantSolo(Carbon::parse('2026-01-01 12:00'), Carbon::parse('2026-01-11 12:00'));
+
+        $summary = $this->service->summaryFor($this->training->refresh());
+
+        $this->assertSame(30, $summary['total']);
+        $this->assertSame(20, $summary['left']);
+    }
+
+    #[Test]
+    public function overspending_the_allowance_clamps_at_zero_left_and_full_percentage()
+    {
+        Setting::set('trainingSoloMaxDays', 10);
+        Setting::save();
+
+        $this->grantSolo(Carbon::parse('2026-01-01 12:00'), Carbon::parse('2026-02-10 12:00'));
+
+        $summary = $this->service->summaryFor($this->training->refresh());
+
+        $this->assertSame(40, $summary['used']);
+        $this->assertSame(0, $summary['left']);
+        $this->assertSame(100, $summary['percentage_used']);
+        $this->assertTrue($summary['collapsed']);
+    }
+
+    #[Test]
+    public function revoked_endorsements_still_count_towards_the_days_issued()
+    {
+        $this->grantSolo(Carbon::parse('2026-01-01 12:00'), Carbon::parse('2026-01-21 12:00'), attributes: ['revoked' => true]);
+
+        $summary = $this->service->summaryFor($this->training->refresh());
+
+        $this->assertSame(20, $summary['used']);
+    }
+
+    #[Test]
+    public function the_counter_is_shown_on_the_training_page()
+    {
+        $this->grantSolo(Carbon::parse('2026-01-01 12:00'), Carbon::parse('2026-01-21 12:00'));
+
+        $this->actingAs($this->moderator())
+            ->get(route('training.show', $this->training))
+            ->assertOk()
+            ->assertSee('Solo Endorsements')
+            ->assertSee('Solo days remaining:');
+    }
+
+    #[Test]
+    public function the_counter_is_hidden_when_no_solo_was_issued()
+    {
+        $this->actingAs($this->moderator())
+            ->get(route('training.show', $this->training))
+            ->assertOk()
+            ->assertDontSee('Solo days remaining:');
+    }
+}

--- a/tests/Feature/SoloEndorsementLinkingTest.php
+++ b/tests/Feature/SoloEndorsementLinkingTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Helpers\TrainingStatus;
+use App\Models\Area;
+use App\Models\Endorsement;
+use App\Models\Position;
+use App\Models\Training;
+use App\Models\User;
+use App\Services\SoloEndorsementService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * End-to-end cover for the counter: issuing a solo through the endorsement form
+ * must make the counter appear on the training it was issued for, and only that
+ * one, for a student with several open trainings.
+ */
+class SoloEndorsementLinkingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function the_counter_appears_on_the_training_the_solo_was_issued_for()
+    {
+        $student = User::factory()->create();
+
+        $norway = Area::factory()->create(['name' => 'Norway']);
+        $sweden = Area::factory()->create(['name' => 'Sweden']);
+
+        $norwegianTraining = Training::factory()->create([
+            'user_id' => $student->id,
+            'area_id' => $norway->id,
+            'status' => TrainingStatus::ACTIVE_TRAINING,
+        ]);
+
+        $swedishTraining = Training::factory()->create([
+            'user_id' => $student->id,
+            'area_id' => $sweden->id,
+            'status' => TrainingStatus::AWAITING_EXAM,
+        ]);
+
+        $admin = User::factory()->create();
+        $admin->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        $this->actingAs($admin)->post(route('endorsements.store'), [
+            'endorsementType' => 'SOLO',
+            'user' => $student->id,
+            'position' => Position::factory()->create(['area_id' => $sweden->id])->callsign,
+            'expires' => Carbon::today()->addDays(20)->format('d/m/Y'),
+        ])->assertSessionHasNoErrors();
+
+        $this->assertSame(1, Endorsement::where('type', 'SOLO')->count());
+
+        $service = app(SoloEndorsementService::class);
+
+        $summary = $service->summaryFor($swedishTraining->refresh());
+        $this->assertNotNull($summary, 'The counter should show on the training the solo was issued for.');
+        $this->assertSame(20, $summary['used']);
+
+        $this->assertNull(
+            $service->summaryFor($norwegianTraining->refresh()),
+            'The counter must not show on an unrelated training in another area.'
+        );
+    }
+
+    #[Test]
+    public function the_counter_renders_on_that_trainings_page()
+    {
+        $student = User::factory()->create();
+        $area = Area::factory()->create();
+
+        $training = Training::factory()->create([
+            'user_id' => $student->id,
+            'area_id' => $area->id,
+            'status' => TrainingStatus::ACTIVE_TRAINING,
+        ]);
+
+        $admin = User::factory()->create();
+        $admin->roleAssignments()->create(['role' => 'admin', 'area_id' => null]);
+
+        $this->actingAs($admin)->post(route('endorsements.store'), [
+            'endorsementType' => 'SOLO',
+            'user' => $student->id,
+            'position' => Position::factory()->create(['area_id' => $area->id])->callsign,
+            'expires' => Carbon::today()->addDays(20)->format('d/m/Y'),
+        ])->assertSessionHasNoErrors();
+
+        $this->actingAs($admin)
+            ->get(route('training.show', $training))
+            ->assertOk()
+            ->assertSee('Solo Endorsements')
+            ->assertSee('Solo days remaining:');
+    }
+}


### PR DESCRIPTION
Supersedes [#1334](https://github.com/Vatsim-Scandinavia/controlcenter/pull/1334). Closes #1283.

> **Stacked on [#1653](https://github.com/Vatsim-Scandinavia/controlcenter/pull/1653)** — base is `fix/solo-endorsement-training-link`, not `main`. The counter reads `ENDORSEMENT` activity entries, so without that fix it renders on the wrong training. Review #1653 first; this PR's diff will collapse to just the counter once that merges.

## What it does

Shows how many of the allowed solo days a training has used, so staff can see what is left before issuing another endorsement. Rendered as a collapsible card on the training page with a progress bar and a per-endorsement breakdown.

## Why it is a rework rather than a rebase

`feat/solo-counter` branched from v6.4.0 and was **344 commits** behind. Of its 6 commits, 5 were dev-container/Sail work that `main` has since gained on its own (`laravel/sail`, `docker-compose.dev.yaml`, `docker/8.4`), so only the one feature commit was worth carrying. It also predates `TrainingService`, the `TrainingStatus` enum cast, `LogName`, and the matrix-driven permissions.

## Changes from the original implementation

- **`SoloEndorsementService`** — the ~50 lines of counting logic moved out of `TrainingController::show()`, which now calls it in two lines, matching how the controller already resolves `TrainingService`.
- **Configurable allowance** — new `trainingSoloMaxDays` setting (seed migration, validation, admin settings field) replacing the hardcoded `SOLO_ENDORSEMENT_MAX_DAYS = 60`. This is the half of #1283 the original left open: *"it should also be possible to set a custom maximum days allowed"*.
- **Activity-linked only** — dropped the date heuristic that counted any solo issued after the training was created, which could attribute another training's endorsement.
- **Native `<details>`** instead of Bootstrap collapse — removes ~40 lines of toggle JS and, more importantly, the two exclusion guards the original had to patch into the *shared* collapse handler in `show.blade.php`.

## Bugs fixed along the way

- `$training->status < 0` no longer works — `status` is cast to the `TrainingStatus` enum on current `main`. Uses `->isClosed()`.
- `reduce(function (int $carry, ...))` accumulating `diffInDays()`, which returns a **float** in Carbon 3. Passing that back into an `int` parameter is deprecated in PHP 8.4+ and breaks on 8.5.
- Day counts round **up**. `valid_from` is `now()` while `valid_to` is set to 12:00, so a 20-day solo issued in the afternoon spans 19.9 days; truncating handed a day of the allowance back on every endorsement.
- `optional()` → nullsafe, and negative ranges clamp to zero.

## Tests

The original had none.

- `SoloEndorsementCounterTest.php` — 9 tests: totals, the setting, no end date, over-spend clamping, revoked endorsements counting as issued, unlinked endorsements ignored, and the card showing/hiding on the page.
- `SoloEndorsementLinkingTest.php` — 2 end-to-end tests issuing a solo through the real endorsement form and asserting the counter lands on the right training.

Related existing suites pass unchanged.

## Summary by Sourcery

Add a configurable, training-specific solo endorsement day counter with progress tracking and endorsement details.

New Features:
- Add a training-page counter showing solo endorsement days used, remaining, and a per-endorsement breakdown.
- Allow administrators to configure the maximum solo endorsement days through global settings.

Bug Fixes:
- Associate counted endorsements with the specific training through endorsement activity records, avoiding attribution to unrelated trainings.
- Correct day calculations for partial days, missing or reversed date ranges, enum-based training statuses, and allowance overages.

Enhancements:
- Extract solo endorsement allowance calculations into a dedicated service and use an accessible native collapsible details component for the breakdown.

Tests:
- Add feature coverage for allowance totals, configurable limits, edge cases, page visibility, and end-to-end training linkage.

<img width="690" height="326" alt="image" src="https://github.com/user-attachments/assets/51d59076-ff44-49ad-92e5-6fb3257189d5" />
<img width="690" height="326" alt="image" src="https://github.com/user-attachments/assets/3730870d-bc41-4b15-810a-40a942ef7f65" />
