### PR TITLE
fix(security): escape flash messages and user-written comments

### DIFF
--- a/resources/views/admin/globalsettings.blade.php
+++ b/resources/views/admin/globalsettings.blade.php
@@ -10,7 +10,7 @@
 
         @if(Session::has('success') OR isset($success))
             <div class="alert alert-success" role="alert">
-                <i class="fas fa-lg fa-check-circle"></i>&nbsp;{!! Session::has('success') ? Session::pull("success") : $error !!}
+                <i class="fas fa-lg fa-check-circle"></i>&nbsp;{{ Session::has('success') ? Session::pull("success") : $error }}
             </div>
         @endif
 

--- a/resources/views/front.blade.php
+++ b/resources/views/front.blade.php
@@ -8,13 +8,13 @@
 
             @if(Session::has('error') OR isset($error))
             <div class="alert alert-danger" role="alert">
-                <i class="fa fa-lg fa-exclamation-circle"></i> {!! Session::has('error') ? Session::pull("error") : $error !!}
+                <i class="fa fa-lg fa-exclamation-circle"></i> {{ Session::has('error') ? Session::pull("error") : $error }}
             </div>
             @endif
 
             @if(Session::has('success') OR isset($success))
             <div class="alert alert-success" role="alert">
-                <i class="fas fa-lg fa-check-circle"></i>&nbsp;{!! Session::has('success') ? Session::pull("success") : $error !!}
+                <i class="fas fa-lg fa-check-circle"></i>&nbsp;{{ Session::has('success') ? Session::pull("success") : $error }}
             </div>
             @endif
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -39,7 +39,7 @@
 
                     @if(Session::has('success') OR isset($success))
                         <div class="alert alert-success" role="alert">
-                            <i class="fas fa-lg fa-check-circle"></i>&nbsp;{!! Session::pull("success") !!}
+                            <i class="fas fa-lg fa-check-circle"></i>&nbsp;{{ Session::pull("success") }}
                         </div>
                     @endif
 

--- a/resources/views/reports/activities.blade.php
+++ b/resources/views/reports/activities.blade.php
@@ -151,7 +151,7 @@
                                                     <span class="badge text-bg-light">{{ $activity->rating->name }}</span> part completed
                                                 @endisset
                                             @elseif($activity->type == "COMMENT")
-                                                {!! nl2br($activity->comment) !!}
+                                                {!! nl2br(e($activity->comment)) !!}
 
                                                 @if($activity->created_at != $activity->updated_at)
                                                     <span class="text-muted">(edited)</span>

--- a/resources/views/training/show.blade.php
+++ b/resources/views/training/show.blade.php
@@ -353,7 +353,7 @@
                                             <span class="badge text-bg-light">{{ $activity->rating->name }}</span> part completed
                                         @endisset
                                     @elseif($activity->type == "COMMENT")
-                                        {!! nl2br($activity->comment) !!}
+                                        {!! nl2br(e($activity->comment)) !!}
 
                                         @if($activity->created_at != $activity->updated_at)
                                             <span class="text-muted">(edited)</span>


### PR DESCRIPTION
Hihi! We run a fork of Control Center for VATSSA. 

After making code changes our own deployment, I used Claude to run a basic security review for the code and it detected these issues. Even though I'm skeptical if anybody would abuse anything like this, I just wanted to report it at least. :) 

The issue is explained below:
### Training comments render as raw HTML

`resources/views/training/show.blade.php` and
`resources/views/reports/activities.blade.php` both do this:

```blade
{!! nl2br($activity->comment) !!}
```

That comment is free text typed by a mentor or a student. Rendering it unescaped
means markup inside a comment runs in the browser of anyone who opens that
training or the activities report afterwards, and staff open both. So a member
who can comment on their own training can reach a session with more access than
their own.

Both are now:

```blade
{!! nl2br(e($activity->comment)) !!}
```

The order is deliberate. Escape first, then convert the newlines. Doing it the
other way round escapes the `<br>` tags that `nl2br()` just added, so you get
visible `&lt;br&gt;` in the comment and the hole is still there.

### Flash messages go through the same kind of sink

`layouts/app.blade.php`, `front.blade.php` and `admin/globalsettings.blade.php`
pull session values with `{!! !!}`:

```blade
{!! Session::pull("success") !!}
```

As far as I can tell nothing exploitable goes through these today. Every caller
I could find passes a fixed string. The issue is the sink itself: the next
person to flash a message containing a member's name, a form value or an API
response opens a hole without touching these lines or having any reason to know
they exist. A flash message never needs to carry markup, so `{{ }}` is the right
rendering here and costs nothing.

### Files

- `resources/views/training/show.blade.php`
- `resources/views/reports/activities.blade.php`
- `resources/views/layouts/app.blade.php`
- `resources/views/front.blade.php`
- `resources/views/admin/globalsettings.blade.php`

### Testing

Full suite on `v7.1.1` with this change: 561 tests, 0 failures, 4 skipped.

## Summary by Sourcery

Escape user-controlled comments and flash messages to prevent cross-site scripting through rendered view content.

Bug Fixes:
- Prevent user-written training comments from being rendered as executable HTML.
- Escape flash-message content before displaying it across application, frontend, and admin settings views.